### PR TITLE
Removing `scheduler_factory`

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["oar", "pbs", "sge", "demo"]

--- a/plugins/demo.py
+++ b/plugins/demo.py
@@ -1,0 +1,62 @@
+from serialiser import *
+
+
+class DemoBatchSystem(GenericBatchSystem):
+
+    @staticmethod
+    def get_mnemonic():
+        return "demo"
+
+    def __init__(self, scheduler_output_filenames, config):
+        self.scheduler_output_filenames = scheduler_output_filenames
+        self.config = config
+
+    def get_worker_nodes(self):
+
+        worker_nodes = [
+            {
+                "domainname": "dn1.foo.com",
+                "state": "-", # This - here is way to cryptic :)
+                "gpus": "", # This isn't used anywhere
+                "np": 24,
+                "core_job_map": {
+                    "11": "j2",
+                    "12": "j2"
+                }
+            },
+            {
+                "domainname": "dn2.bar.com",
+                "state": "-",
+                "gpus": "",
+                "np": 8,
+                "core_job_map": {0: "j2", 1: "j2"}
+            },
+            {
+                "domainname": "dn3.baz.com",
+                "state": "-",
+                "gpus": "",
+                "np": 16,
+                "core_job_map": {2: "j2", 4: "j2"}
+            }
+        ]
+
+        return worker_nodes
+
+    def get_jobs_info(self):
+        job_ids = "j1 j2 j3 j4 j5".split()
+        job_states = "Q R C E W".split() # Can't see how those are represented in the screen
+        usernames = "bill john".split()
+        queue_names = "Urgent Foobar".split() # Those names don't seem to be used
+        return job_ids, usernames, job_states, queue_names
+
+    def get_queues_info(self):
+        total_running_jobs = 1
+        total_queued_jobs = 4
+
+        qstatq_list = [
+            #                     V- Why these should be strings (colorize)?
+            {'run': 1, 'queued': '3', 'queue_name': 'Urgent', 'state': 'Q', 'lm': 0},
+            {'run': 0, 'queued': '2', 'queue_name': 'Foobar', 'state': 'W', 'lm': 0}
+        ]
+
+        return total_running_jobs, total_queued_jobs, qstatq_list

--- a/plugins/oar.py
+++ b/plugins/oar.py
@@ -34,6 +34,11 @@ class OarStatExtractor(StatExtractor):
 
 
 class OARBatchSystem(GenericBatchSystem):
+
+    @staticmethod
+    def get_mnemonic():
+        return "oar"
+
     def __init__(self, scheduler_output_filenames, config):
         self.oarnodes_s_file = scheduler_output_filenames.get('oarnodes_s_file')
         self.oarnodes_y_file = scheduler_output_filenames.get('oarnodes_y_file')

--- a/plugins/pbs.py
+++ b/plugins/pbs.py
@@ -116,6 +116,11 @@ class PBSStatExtractor(StatExtractor):
 
 
 class PBSBatchSystem(GenericBatchSystem):
+
+    @staticmethod
+    def get_mnemonic():
+        return "pbs"
+
     def __init__(self, scheduler_output_filenames, config):
         self.pbsnodes_file = scheduler_output_filenames.get('pbsnodes_file')
         self.qstat_file = scheduler_output_filenames.get('qstat_file')

--- a/plugins/sge.py
+++ b/plugins/sge.py
@@ -76,6 +76,11 @@ class SGEStatExtractor(StatExtractor):
 
 
 class SGEBatchSystem(GenericBatchSystem):
+
+    @staticmethod
+    def get_mnemonic():
+        return "sge"
+
     def __init__(self, scheduler_output_filenames, config):
         self.sge_file_stat = scheduler_output_filenames.get('sge_file_stat')
         self.config = config

--- a/qtop.py
+++ b/qtop.py
@@ -26,13 +26,14 @@ import termios
 import contextlib
 import glob
 import tempfile
+import sys
+from common_module import *
+from plugins import *
 from math import ceil
-from plugins.pbs import *
-from plugins.oar import *
-from plugins.sge import *
 from colormap import color_of_account, code_of_color
 from yaml_parser import read_yaml_natively, fix_config_list, convert_dash_key_in_dict
 from ui.viewport import Viewport
+from serialiser import GenericBatchSystem
 
 
 @contextlib.contextmanager
@@ -1242,15 +1243,6 @@ def decide_batch_system(cmdline_switch, env_var, config_file_batch_option):
         return scheduler
 
 
-def scheduler_factory(scheduler, scheduler_output_filenames, config):
-    if scheduler == "pbs":
-        return PBSBatchSystem(scheduler_output_filenames, config)
-    elif scheduler == "oar":
-        return OARBatchSystem(scheduler_output_filenames, config)
-    elif scheduler == "sge":
-        return SGEBatchSystem(scheduler_output_filenames, config)
-
-
 class Document(namedtuple('Document', ['wns_occupancy', 'cluster'])):
 
     def save(self, filename):
@@ -1747,7 +1739,31 @@ def get_qnames_per_worker_node(worker_nodes):
     return worker_nodes
 
 
+def discover_batch_systems():
+    batch_systems = set()
+
+    # Find all the classes that extend GenericBatchSystem
+    to_scan = [GenericBatchSystem]
+    while to_scan:
+        parent = to_scan.pop()
+        for child in parent.__subclasses__():
+            if child not in batch_systems:
+                batch_systems.add(child)
+                to_scan.append(child)
+
+    # Extract those class's mnemonics
+    available_batch_systems = {}
+    for batch_system in batch_systems:
+        mnemonic = batch_system.get_mnemonic()
+        assert mnemonic
+        assert mnemonic not in available_batch_systems, "Duplicate for mnemonic: '%s'" % mnemonic
+        available_batch_systems[mnemonic] = batch_system
+
+    return available_batch_systems
+
+
 if __name__ == '__main__':
+    available_batch_systems = discover_batch_systems()
 
     stdout = sys.stdout  # keep a copy of the initial value of sys.stdout
 
@@ -1778,7 +1794,7 @@ if __name__ == '__main__':
                 init_sample_file(options)
 
                 ###### Gather data ###############
-                scheduling_system = scheduler_factory(scheduler, scheduler_output_filenames, config)
+                scheduling_system = available_batch_systems[scheduler](scheduler_output_filenames, config)
                 worker_nodes = scheduling_system.get_worker_nodes()
                 job_ids, user_names, job_states, job_queues = scheduling_system.get_jobs_info()
                 total_running_jobs, total_queued_jobs, qstatq_lod = scheduling_system.get_queues_info()

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -22,6 +22,8 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file_stat: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  demo:
+
 
 # Utilises lxml module. Needs to be installed in your system.
 # Might result in segmentation fault in some systems.
@@ -64,6 +66,18 @@ state_abbreviations:
     s: suspended_of_user
     S: suspended_by_the_queue
     shite: testing_of_user
+  pbs:
+    Q: queued_of_user
+    R: running_of_user
+    C: cancelled_of_user
+    E: exiting_of_user
+    W: waiting_of_user
+  demo:
+    Q: queued_of_user
+    R: running_of_user
+    C: cancelled_of_user
+    E: exiting_of_user
+    W: waiting_of_user
 
 # original OAR abbreviations:
 # state_abbreviations = {
@@ -201,12 +215,12 @@ workernodes_matrix:
      yaml_key: state
      label: Node state
      max_len: 5
-     systems: [sge, oar, pbs]
+     systems: [sge, oar, pbs, demo]
  - queue name:
      yaml_key: qname
      label: queue name
      max_len: 13
-     systems: [sge, oar, pbs]
+     systems: [sge, oar, pbs, demo]
  - core user map:
      options1: {}
      options2: {}

--- a/serialiser.py
+++ b/serialiser.py
@@ -85,3 +85,7 @@ class GenericBatchSystem(object):
 
     def get_jobs_info(self, qstats):
         raise NotImplementedError
+
+    @staticmethod
+    def get_mnemonic():
+        raise NotImplementedError


### PR DESCRIPTION
Replacing `scheduler_factory` with a module discovery mechanism. Still not crazy modular but way more extensible.