### PR TITLE
ERq state needed to be added in qtopconf.yaml

### DIFF
--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -79,8 +79,9 @@ state_abbreviations:
     s: suspended_of_user
     S: suspended_by_the_queue
     shite: testing_of_user
-    Rs: suspended_of_user
+    ERq: ERq_of_user
     Rq: queued_of_user
+    Rs: suspended_of_user
     Rt: transferring_of_user
     Rr: running_of_user    
   demo:


### PR DESCRIPTION
This is probably the first bug hit after more than a month of usage; probably a good sign overall;
it does indicate though that the current approach of listing individual states for SGE is less than desired, because the total list of possible states is a combinatorial space! t.b.c.