### PR TITLE
hRq state of sge

### DIFF
--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -70,6 +70,7 @@ state_abbreviations:
     R: restarting_of_user
     Eqw: Eqw_of_user
     hqw: hold_of_user
+    hRq: hRq_of_user
     t: transferring_of_user
     T: threshold_reached
     ht: ht_of_user


### PR DESCRIPTION
In an ideal world, we should not need to add a config line for each job state re-combination of SGE!