### PR TITLE
Fix PBS gpus field type comparison error (issue #337)

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -257,7 +257,7 @@ class PBSBatchSystem(GenericBatchSystem):
             else:
                 pbs_values["np"] = block.get("resources_available.ncpus", 0)
 
-            if block.get("gpus", 0) > 0:  # this should be rare.
+            if int(block.get("gpus", 0)) > 0:  # this should be rare.
                 pbs_values["gpus"] = block["gpus"]
 
             try:  # this should turn up more often, hence the try/except.


### PR DESCRIPTION
Fixes #337
Running PBS on a cluster where gpus is returned as a string by the scheduler causes a TypeError crash in pbs.py line 260:
TypeError: '>' not supported between instances of 'str' and 'int'
Fix:
diff- if block.get("gpus", 0) > 0:
+ if int(block.get("gpus", 0)) > 0:
Verification: Tested against PBS sample data (829 nodes) and OAR sample data (183 nodes) using qtop v0.9.20241013. Both schedulers run successfully after the fix.
This bug is present in the most recent version (v0.9.20241013).
/claim #337