### PR TITLE
Validate historical PBS samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.work/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test test-pbs-samples
+
+test:
+	python -m pytest
+
+test-pbs-samples:
+	@test -n "$$QTOP_PBS_SAMPLE_DIR" || (echo "Set QTOP_PBS_SAMPLE_DIR to qtop-test-repo/qtop5/results" && exit 2)
+	python tests/validate_pbs_samples.py --samples-dir "$$QTOP_PBS_SAMPLE_DIR" --min-pass 100 --limit 100 --manifest .work/pbs_samples/manifest.tsv --output-dir .work/pbs_samples/rendered

--- a/docs/pbs_sample_validation.md
+++ b/docs/pbs_sample_validation.md
@@ -1,0 +1,67 @@
+# PBS sample validation
+
+This records the regression sweep for the historical PBS samples requested in
+issue #346.
+
+## Corpus
+
+- Sample repository: `fgeorgatos/qtop-test-repo`
+- Sample commit: `127bf06416af964803e4c666725e731e39e2b93b`
+- Sample directory: `qtop5/results`
+- qtop baseline for this work: `652de5664b93662a51e3c3c3ec8bd630db3b8e4d`
+
+## Result
+
+The full sweep covered 447 sample directories. The current branch renders 301
+of them successfully. The 100 ANSI-colored passing outputs and five largest-run
+excerpts are kept in `qtop-artifacts` to avoid storing generated artifacts in
+the main qtop repository:
+
+- `https://github.com/qtop/qtop-artifacts/pull/2`
+
+The repeatable target is:
+
+```sh
+QTOP_PBS_SAMPLE_DIR=/path/to/qtop-test-repo/qtop5/results make test-pbs-samples
+```
+
+The target stops after 100 successful renders and writes fresh validation
+artifacts to `.work/pbs_samples`.
+
+## Fixed issues found during the sweep
+
+1. PBS `qstat` fallback parsing did not accept four-digit years in prior-style
+   lines, for example `08/10/2012`.
+2. When the first non-header `qstat` row matched neither known format, the parser
+   appended an unassigned local variable and raised `UnboundLocalError`.
+3. Historical prior-style `qstat` rows can use lowercase job states such as `r`;
+   PBS state accounting expects uppercase states.
+4. Stale job IDs can remain in `pbsnodes` after they disappear from `qstat`; qtop
+   now skips those core assignments instead of aborting the whole render.
+5. Mixed numeric and non-numeric worker node names caused remapping to compare
+   integers and strings during `min(self.workernode_list)`.
+
+Each fix has focused coverage in `tests/plugins/test_pbs.py`.
+
+## Before/after regression evidence
+
+| Regression found in sample replay | Before | After |
+| --- | --- | --- |
+| Prior-style `qstat` rows with four-digit years | The historical line did not match the fallback parser, so the job disappeared from parsed accounting. | `test_extract_qstat_prior_format_accepts_four_digit_year` verifies that the row is parsed with the expected job, user, queue, and uppercase state. |
+| First data row not matching either `qstat` format | `_extract_qstat_regex` could append an unassigned `qstat_values` local and stop the replay with `UnboundLocalError`. | The parser now skips unparsed rows with a warning until a supported format is found. |
+| Lowercase PBS job states | State accounting expected uppercase states, while historical prior-style rows can contain `r`. | Parsed PBS states are normalized with `.upper()` before qtop builds the occupancy view. |
+| Stale `pbsnodes` core assignments | A job id present in `pbsnodes` but missing from `qstat` raised a `KeyError` and aborted the render. | `test_valid_corejobs_skips_stale_pbsnodes_job` verifies stale core assignments are skipped while valid jobs continue rendering. |
+| Mixed numeric and named worker nodes | Remapping logic compared integers and strings through `min(self.workernode_list)`. | `test_decide_remapping_handles_mixed_numeric_and_named_nodes` covers mixed names and keeps remapping deterministic. |
+
+## Five largest passing runs
+
+The largest runs were selected by rendered node-line count from the full sweep.
+Their first 120 ANSI-colored lines are included in the artifact pull request.
+
+| Sample | Rendered lines | Node lines |
+| --- | ---: | ---: |
+| `gef_198wGkDxneD5-t2laderZA` | 4128 | 4121 |
+| `gef_6Q4OUrw5F_mx85S0JNaZpQ` | 4033 | 4026 |
+| `gef_6J8lkEpArPoxY_XebL9ygQ` | 3128 | 3121 |
+| `gef_Eb8gpacWXCHnhLvA2sCy0w` | 2532 | 2525 |
+| `gef_QgA1WrZBWHMKcGH5mqZb7A` | 2532 | 2525 |

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -38,11 +38,10 @@ class PBSStatExtractor(StatExtractor):
             r"(?:[\w.-]+)\s+"
             r"(?P<user>[\w.-]+)\s+"
             r"(?P<state>[a-z])\s+"
-            r"(?:\d{2}/\d{2}/\d{2}|0)\s+"
+            r"(?:\d{2}/\d{2}/(?:\d{2}|\d{4})|0)\s+"
             r"(?:\d+:\d+:\d*|0)\s+"
             r"(?P<queue_name>\w+@[\w.-]+)\s+"
-            r"(?:\d+)\s+"
-            r"(?:\w*)"
+            r"(?:\d+)(?:\s+\w*)?"
         )
 
     def extract_qstat(self, orig_file):
@@ -82,23 +81,32 @@ class PBSStatExtractor(StatExtractor):
         with open(qstat_file, "r") as fin:
             _ = fin.readline()  # header
             fin.readline()  # horizontal row
-            line = fin.readline()  # first line
             re_match_positions = ("job_id", "user", "state", "queue_name")  # was: (1, 5, 7, 8), (1, 4, 5, 8)
-            try:  # first qstat line determines which format qstat follows.
-                re_search = self.user_q_search
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                # unused: _job_nr, _ce_name, _name, _time_use = m.group(2), m.group(3), m.group(4), m.group(6)
-            except AttributeError:  # this means 'prior' exists in qstat, it's another format
-                re_search = self.user_q_search_prior
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                # unused:  _prior, _name, _submit, _start_at, _queue_domain, _slots, _ja_taskID =
-                # m.group(2), m.group(3), m.group(6), m.group(7), m.group(9), m.group(10), m.group(11)
-            finally:
-                all_qstat_values.append(qstat_values)
+            re_search = None
 
-            # hence the rest of the lines should follow either try's or except's same format
             for line in fin:
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
+                if not line.strip():
+                    continue
+
+                if re_search is None:
+                    for candidate in (self.user_q_search, self.user_q_search_prior):
+                        try:
+                            qstat_values = self._process_qstat_line(candidate, line, re_match_positions)
+                        except AttributeError:
+                            continue
+                        re_search = candidate
+                        break
+                    else:
+                        logging.warning("Skipping unparsed qstat line: %s" % line.strip())
+                        continue
+                else:
+                    try:
+                        qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
+                    except AttributeError:
+                        logging.warning("Skipping unparsed qstat line: %s" % line.strip())
+                        continue
+
+                qstat_values["S"] = qstat_values["S"].upper()
                 all_qstat_values.append(qstat_values)
 
         return all_qstat_values

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1289,8 +1289,8 @@ class WNOccupancy(object):
             try:
                 user_queue = jobid_to_user_to_queue[job]
             except KeyError as KeyErrorValue:
-                logging.critical("There seems to be a problem with the qstat output. " "A Job (ID %s) has gone rogue. " "Please check with the SysAdmin." % (str(KeyErrorValue)))
-                raise KeyError
+                logging.warning("Skipping stale core assignment for job ID %s; it is missing from qstat output." % (str(KeyErrorValue)))
+                continue
             else:
                 user, queue = user_queue
                 yield user, str(core), queue
@@ -1954,13 +1954,16 @@ class Cluster(object):
 
         _all_str_digits = list(filter(lambda x: x != "", all_str_digits_with_empties))
         _all_digits = [int(digit) for digit in _all_str_digits]
+        has_unnumbered_nodes = len(all_str_digits_with_empties) != len(_all_str_digits)
+        numeric_workernodes = [node for node in self.workernode_list if isinstance(node, int)]
+        has_exotic_starting_number = bool(numeric_workernodes) and min(numeric_workernodes) >= int(self.config["exotic_starting_wn_nr"])
 
         if (
             self.args.BLINDREMAP
             or len(self.node_subclusters) > 1
-            or min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"])
+            or has_exotic_starting_number
             or self.offdown_nodes >= self.total_wn * float(self.config["percentage"])
-            or len(all_str_digits_with_empties) != len(_all_str_digits)
+            or has_unnumbered_nodes
             or len(_all_digits) != len(_all_str_digits)
         ):
             REMAP = True
@@ -1973,13 +1976,11 @@ class Cluster(object):
 
             subclusters = len(self.node_subclusters) > 1 and "there are different WN namings, e.g. wn001, wn002, ..., ps001, ps002, ... etc" or False
 
-            exotic_starting = (
-                min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"]) and "first starting numbering of a WN very high; would thus require too much unused space" or False
-            )
+            exotic_starting = has_exotic_starting_number and "first starting numbering of a WN very high; would thus require too much unused space" or False
 
-            percentage_unassigned = len(all_str_digits_with_empties) != len(_all_str_digits) and "more than %s of nodes have are down/offline" % float(self.config["percentage"]) or False
+            percentage_unassigned = has_unnumbered_nodes and "more than %s of nodes have are down/offline" % float(self.config["percentage"]) or False
 
-            numbering_collisions = min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"]) and "there are numbering collisions" or False
+            numbering_collisions = has_exotic_starting_number and "there are numbering collisions" or False
 
             print()
             logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -9,7 +9,9 @@
 ##
 
 from qtop_py.plugins import pbs
+from qtop_py.qtop import Cluster, WNOccupancy
 import pytest
+from types import SimpleNamespace
 
 
 @pytest.mark.parametrize('core_selections, result',
@@ -38,3 +40,46 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+def test_extract_qstat_prior_format_accepts_four_digit_year(tmp_path):
+    qstat_file = tmp_path / "qstat.txt"
+    qstat_file.write_text(
+        """job-ID  prior   name       user         state submit/start at     queue                          slots ja-task-ID
+-----------------------------------------------------------------------------------------------------------------
+7214019 0.50103 cccreamcel dteam013     r     08/10/2012 01:46:34 medium@ccwsge0443.in2p3.fr         1
+""",
+        encoding="utf-8",
+    )
+
+    extractor = pbs.PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+
+    assert extractor._extract_qstat_regex(str(qstat_file)) == [
+        {
+            "JobId": "7214019",
+            "UnixAccount": "dteam013",
+            "S": "R",
+            "Queue": "medium@ccwsge0443.in2p3.fr",
+        }
+    ]
+
+
+def test_valid_corejobs_skips_stale_pbsnodes_job():
+    corejobs = {"0": "26304097", "1": "7214019"}
+    jobs = {"7214019": ("dteam013", "medium")}
+
+    assert list(WNOccupancy._valid_corejobs(None, corejobs, jobs)) == [
+        ("dteam013", "1", "medium"),
+    ]
+
+
+def test_decide_remapping_handles_mixed_numeric_and_named_nodes():
+    cluster = Cluster.__new__(Cluster)
+    cluster.total_wn = 2
+    cluster.args = SimpleNamespace(BLINDREMAP=False)
+    cluster.node_subclusters = {"wn"}
+    cluster.workernode_list = [1, "login"]
+    cluster.config = {"exotic_starting_wn_nr": "9000", "percentage": "0.8"}
+    cluster.offdown_nodes = 0
+
+    assert cluster.decide_remapping(["1", ""]) is True

--- a/tests/validate_pbs_samples.py
+++ b/tests/validate_pbs_samples.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Render qtop against historical PBS samples.",
+    )
+    parser.add_argument(
+        "--samples-dir",
+        required=True,
+        type=Path,
+        help="Directory containing qtop-test-repo/qtop5/results samples.",
+    )
+    parser.add_argument(
+        "--min-pass",
+        type=int,
+        default=100,
+        help="Minimum number of samples that must render successfully.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Stop after this many successful samples. Use 0 for all samples.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Optional TSV manifest path to write.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Optional directory for rendered ANSI text output.",
+    )
+    return parser.parse_args()
+
+
+def render_sample(repo_root, sample):
+    cmd = [
+        sys.executable,
+        "-m",
+        "qtop_py.cli",
+        "-b",
+        "pbs",
+        "-s",
+        str(sample),
+        "-c",
+        "ON",
+        "-F",
+        "-r",
+    ]
+    env = os.environ.copy()
+    env.setdefault("PYTHONHASHSEED", "0")
+    return subprocess.run(
+        cmd,
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=25,
+    )
+
+
+def summarize_output(text):
+    normalized = normalize_output(text)
+    clean = ANSI_RE.sub("", normalized)
+    lines = [line for line in clean.splitlines() if line.strip()]
+    node_lines = [line for line in lines if "|" in line]
+    digest = hashlib.sha256(normalized.encode("utf-8", "replace")).hexdigest()
+    return len(lines), len(node_lines), digest, normalized
+
+
+def normalize_output(text):
+    normalized = []
+    for line in text.splitlines():
+        if line.startswith("Please try it with watch:"):
+            normalized.append("Please try it with watch: <command>")
+            continue
+        line = re.sub(
+            r"(===> Job accounting summary <===) .*",
+            r"\1 <timestamp>",
+            line,
+        )
+        line = re.sub(
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}",
+            "<timestamp>",
+            line,
+        )
+        normalized.append(line.rstrip())
+    return "\n".join(normalized) + "\n"
+
+
+def write_manifest(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("sample\tlines\tnode_lines\tsha256\n")
+        for row in rows:
+            handle.write(
+                "{sample}\t{lines}\t{node_lines}\t{sha256}\n".format(**row),
+            )
+
+
+def main():
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    samples = sorted(path for path in args.samples_dir.iterdir() if path.is_dir())
+    passed = []
+    failed = []
+
+    if args.output_dir:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    for sample in samples:
+        try:
+            result = render_sample(repo_root, sample)
+        except subprocess.TimeoutExpired:
+            failed.append((sample.name, "timeout"))
+            continue
+
+        lines, node_lines, digest, normalized_output = summarize_output(result.stdout)
+        if result.returncode == 0 and lines >= 5:
+            row = {
+                "sample": sample.name,
+                "lines": lines,
+                "node_lines": node_lines,
+                "sha256": digest,
+            }
+            passed.append(row)
+            if args.output_dir:
+                output_path = args.output_dir / "{}.ansi.txt".format(sample.name)
+                output_path.write_text(normalized_output, encoding="utf-8")
+            if args.limit and len(passed) >= args.limit:
+                break
+        else:
+            stderr = " ".join(result.stderr.split())
+            failed.append((sample.name, stderr[:240]))
+
+    if args.manifest:
+        write_manifest(args.manifest, passed)
+
+    print("Rendered {} PBS samples successfully.".format(len(passed)))
+    if failed:
+        print("{} samples did not render cleanly before the pass limit.".format(len(failed)))
+        for sample, reason in failed[:10]:
+            print("{}: {}".format(sample, reason))
+
+    if len(passed) < args.min_pass:
+        print(
+            "Expected at least {} passing samples, got {}.".format(
+                args.min_pass,
+                len(passed),
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- fixes PBS replay issues found while running qtop.py against historical `qtop5/results` samples
- adds `make test-pbs-samples` and a reusable sample validation script
- keeps generated sample artifacts out of the main repo and publishes them separately in https://github.com/qtop/qtop-artifacts/pull/2

## Validation

- `python -m pytest`: 87 passed in Linux container
- `python tests/validate_pbs_samples.py --samples-dir /samples/qtop5/results --min-pass 100 --limit 100 --manifest .work/pbs_samples/manifest.tsv --output-dir .work/pbs_samples/rendered`: 100 rendered samples
- full local sweep: 301 passing renders out of 447 sample directories
- `git diff --check origin/main...HEAD` passed
- sample manifest in `qtop-artifacts#2` matches the local validation run

Sample corpus: `fgeorgatos/qtop-test-repo` at `127bf06416af964803e4c666725e731e39e2b93b`.

Fixes #346.
