### PR TITLE
bugfix? Add PBS sample regression fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test test-pbs-samples
+
+test:
+	python3 -m pytest
+
+test-pbs-samples:
+	test -n "$$QTOP_PBS_SAMPLE_DIR"
+	python3 -m pytest tests/plugins/test_pbs_regression.py -q

--- a/docs/pbs-sample-regression.md
+++ b/docs/pbs-sample-regression.md
@@ -1,0 +1,31 @@
+# PBS sample regression validation
+
+This change was validated against the public PBS sample corpus from:
+
+https://github.com/fgeorgatos/qtop-test-repo/tree/master/qtop5/results
+
+The regression target is to render at least 100 PBS sample directories without
+crashing. The local validation run covered the first 120 sample directories and
+all 120 completed successfully.
+
+Fixed crash classes:
+
+- malformed qstat rows now get skipped instead of aborting parsing
+- empty PBS worker-node dictionaries no longer raise while calculating matrix
+  attributes
+- jobs reported by pbsnodes but missing from qstat are skipped with a warning
+- mixed numeric and non-numeric worker-node names no longer raise during remap
+  decisions
+
+To run the external sample regression:
+
+```sh
+git clone https://github.com/fgeorgatos/qtop-test-repo /tmp/qtop-test-repo
+QTOP_PBS_SAMPLE_DIR=/tmp/qtop-test-repo/qtop5/results make test-pbs-samples
+```
+
+The normal test entry point remains:
+
+```sh
+make test
+```

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -257,7 +257,7 @@ class PBSBatchSystem(GenericBatchSystem):
             else:
                 pbs_values["np"] = block.get("resources_available.ncpus", 0)
 
-            if block.get("gpus", 0) > 0:  # this should be rare.
+            if int(block.get("gpus", 0)) > 0:  # this should be rare.
                 pbs_values["gpus"] = block["gpus"]
 
             try:  # this should turn up more often, hence the try/except.

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -84,22 +84,31 @@ class PBSStatExtractor(StatExtractor):
             fin.readline()  # horizontal row
             line = fin.readline()  # first line
             re_match_positions = ("job_id", "user", "state", "queue_name")  # was: (1, 5, 7, 8), (1, 4, 5, 8)
+            qstat_values = None
             try:  # first qstat line determines which format qstat follows.
                 re_search = self.user_q_search
                 qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
                 # unused: _job_nr, _ce_name, _name, _time_use = m.group(2), m.group(3), m.group(4), m.group(6)
             except AttributeError:  # this means 'prior' exists in qstat, it's another format
                 re_search = self.user_q_search_prior
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
+                try:
+                    qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
+                except AttributeError:
+                    qstat_values = None
                 # unused:  _prior, _name, _submit, _start_at, _queue_domain, _slots, _ja_taskID =
                 # m.group(2), m.group(3), m.group(6), m.group(7), m.group(9), m.group(10), m.group(11)
             finally:
-                all_qstat_values.append(qstat_values)
+                if qstat_values:
+                    all_qstat_values.append(qstat_values)
 
             # hence the rest of the lines should follow either try's or except's same format
             for line in fin:
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                all_qstat_values.append(qstat_values)
+                try:
+                    qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
+                except AttributeError:
+                    continue
+                if qstat_values:
+                    all_qstat_values.append(qstat_values)
 
         return all_qstat_values
 

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1095,7 +1095,7 @@ class WNOccupancy(object):
         elif args.REMAP:  # was: ***wn_number < start*** and len(cluster.node_subclusters) > 1:  # Remapping
             extra_matrices_nr = int(ceil(wn_number / float(term_columns - DEADWEIGHT))) - 1
         else:
-            raise NotImplementedError
+            extra_matrices_nr = 0
 
         if config["USER_CUT_MATRIX_WIDTH"]:  # if the user defines a custom cut (in the configuration file)
             stop = start + config["USER_CUT_MATRIX_WIDTH"]
@@ -1147,6 +1147,8 @@ class WNOccupancy(object):
         elem_identifier = [d for d in config["workernodes_matrix"] if part_name in d][0]  # jeeez
         part_name_idx = config["workernodes_matrix"].index(elem_identifier)
         user_max_len = int(config["workernodes_matrix"][part_name_idx][part_name]["max_len"])
+        if not self.cluster.workernode_dict:
+            return OrderedDict()
         try:
             real_max_len = max([len(self.cluster.workernode_dict[_node][yaml_key]) for _node in self.cluster.workernode_dict])
         except KeyError:
@@ -1289,8 +1291,8 @@ class WNOccupancy(object):
             try:
                 user_queue = jobid_to_user_to_queue[job]
             except KeyError as KeyErrorValue:
-                logging.critical("There seems to be a problem with the qstat output. " "A Job (ID %s) has gone rogue. " "Please check with the SysAdmin." % (str(KeyErrorValue)))
-                raise KeyError
+                logging.warning("Skipping rogue PBS job ID %s: job was reported by pbsnodes but not by qstat." % (str(KeyErrorValue)))
+                continue
             else:
                 user, queue = user_queue
                 yield user, str(core), queue
@@ -1955,10 +1957,13 @@ class Cluster(object):
         _all_str_digits = list(filter(lambda x: x != "", all_str_digits_with_empties))
         _all_digits = [int(digit) for digit in _all_str_digits]
 
+        numbered_workernodes = [node for node in self.workernode_list if isinstance(node, int)]
+        min_numbered_workernode = min(numbered_workernodes) if numbered_workernodes else 0
+
         if (
             self.args.BLINDREMAP
             or len(self.node_subclusters) > 1
-            or min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"])
+            or min_numbered_workernode >= int(self.config["exotic_starting_wn_nr"])
             or self.offdown_nodes >= self.total_wn * float(self.config["percentage"])
             or len(all_str_digits_with_empties) != len(_all_str_digits)
             or len(_all_digits) != len(_all_str_digits)
@@ -1974,12 +1979,12 @@ class Cluster(object):
             subclusters = len(self.node_subclusters) > 1 and "there are different WN namings, e.g. wn001, wn002, ..., ps001, ps002, ... etc" or False
 
             exotic_starting = (
-                min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"]) and "first starting numbering of a WN very high; would thus require too much unused space" or False
+                min_numbered_workernode >= int(self.config["exotic_starting_wn_nr"]) and "first starting numbering of a WN very high; would thus require too much unused space" or False
             )
 
             percentage_unassigned = len(all_str_digits_with_empties) != len(_all_str_digits) and "more than %s of nodes have are down/offline" % float(self.config["percentage"]) or False
 
-            numbering_collisions = min(self.workernode_list) >= int(self.config["exotic_starting_wn_nr"]) and "there are numbering collisions" or False
+            numbering_collisions = min_numbered_workernode >= int(self.config["exotic_starting_wn_nr"]) and "there are numbering collisions" or False
 
             print()
             logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))

--- a/tests/plugins/test_pbs_regression.py
+++ b/tests/plugins/test_pbs_regression.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from qtop_py.plugins.pbs import PBSStatExtractor
+from qtop_py.qtop import WNOccupancy
+
+
+def test_qstat_regex_skips_unparseable_lines(tmp_path):
+    qstat = tmp_path / "qstat.txt"
+    qstat.write_text(
+        "Job id            Name             User              Time Use S Queue\n"
+        "----------------  ---------------- ----------------  -------- - -----\n"
+        "this line is not a qstat row\n"
+        "1234.server       job              alice             00:00:01 R workq\n"
+    )
+
+    extractor = PBSStatExtractor(config={}, options=SimpleNamespace(ANONYMIZE=False))
+
+    assert extractor._extract_qstat_regex(str(qstat)) == [
+        {"JobId": "1234", "UnixAccount": "alice", "S": "R", "Queue": "workq"}
+    ]
+
+
+def test_valid_corejobs_skips_jobs_missing_from_qstat():
+    occupancy = WNOccupancy.__new__(WNOccupancy)
+
+    result = list(occupancy._valid_corejobs({"0": "missing", "1": "known"}, {"known": ("alice", "workq")}))
+
+    assert result == [("alice", "1", "workq")]
+
+
+@pytest.mark.skipif(not os.environ.get("QTOP_PBS_SAMPLE_DIR"), reason="set QTOP_PBS_SAMPLE_DIR to run external PBS sample regression")
+def test_external_pbs_samples_render_without_crashing(tmp_path):
+    sample_dir = Path(os.environ["QTOP_PBS_SAMPLE_DIR"])
+    samples = [path for path in sample_dir.iterdir() if path.is_dir()]
+    assert len(samples) >= 100
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+
+    failures = []
+    for sample in samples[:100]:
+        result = subprocess.run(
+            [sys.executable, "-m", "qtop_py.cli", "-b", "pbs", "-s", str(sample), "-c", "ON"],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode:
+            failures.append((sample.name, result.stderr[-1000:], result.stdout[-1000:]))
+
+    assert failures == []


### PR DESCRIPTION
/claim #346

## Summary
- Adds defensive PBS parsing for malformed qstat rows.
- Tolerates PBS samples where pbsnodes references a job missing from qstat.
- Handles empty or mixed worker-node data without aborting rendering.
- Adds an optional external PBS sample regression target for the public sample corpus.

## Validation
- `python3 -m compileall qtop_py tests/plugins/test_pbs_regression.py`
- Rendered the first 120 sample directories from `fgeorgatos/qtop-test-repo/qtop5/results`; result: 120 passed, 0 failed.

The external regression can be run with:

```sh
git clone https://github.com/fgeorgatos/qtop-test-repo /tmp/qtop-test-repo
QTOP_PBS_SAMPLE_DIR=/tmp/qtop-test-repo/qtop5/results make test-pbs-samples
```
