### PR TITLE
fix: support legacy PBS qstat formats

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -19,16 +19,28 @@ import qtop_py.fileutils as fileutils
 import itertools
 
 
+PBS_REQUEST_STATES = {
+    "RUNNING": "R",
+    "WAITING": "W",
+    "QUEUED": "Q",
+    "HELD": "H",
+    "EXITING": "E",
+    "FINISHED": "F",
+    "SUSPENDED": "S",
+    "TRANSITING": "T",
+}
+
+
 class PBSStatExtractor(StatExtractor):
     def __init__(self, config, options):
         StatExtractor.__init__(self, config, options)
         self.user_q_search = (
             r"^(?P<host_name>(?P<job_id>[0-9\[\]-]+)\.(?P<domain>[\w*-]+))\s+"
-            r"(?P<name>[\w%.=+/{}*-]+)\s+"
-            r"(?P<user>[A-Za-z0-9.*]+)\s+"
+            r"(?P<name>\S+)\s+"
+            r"(?P<user>[A-Za-z0-9.*-]+)\s+"
             r"(?P<time>\d+:\d*:?\d*\*?|0)\s+"
             r"(?P<state>[BCEFHMQRSTUWX])\s+"
-            r"(?P<queue_name>\w+)"
+            r"(?P<queue_name>[\w.-]+)"
         )
 
         self.user_q_search_prior = (
@@ -37,12 +49,21 @@ class PBSStatExtractor(StatExtractor):
             r"(?:[0-9]\.[0-9]+)\s+"
             r"(?:[\w.-]+)\s+"
             r"(?P<user>[\w.-]+)\s+"
-            r"(?P<state>[a-z])\s+"
-            r"(?:\d{2}/\d{2}/\d{2}|0)\s+"
-            r"(?:\d+:\d+:\d*|0)\s+"
-            r"(?P<queue_name>\w+@[\w.-]+)\s+"
-            r"(?:\d+)\s+"
-            r"(?:\w*)"
+            r"(?P<state>[A-Za-z]+)\s+"
+            r"(?:\d{2}/\d{2}/\d{4}|0)\s+"
+            r"(?:\d+:\d+:\d+|0)\s+"
+            r"(?P<queue_name>[\w.-]+@[\w.-]+)\s+"
+            r"(?:\d+)"
+            r"\s*"
+            r"(?:\w*)?"
+        )
+
+        self.user_q_search_request = (
+            r"^\s*\d+:\s+"
+            r"(?P<name>\S+)\s+"
+            r"(?P<job_id>\d+)\s+"
+            r"(?P<user>[\w.-]+)\s+"
+            r"(?P<state>[A-Z]+)"
         )
 
     def extract_qstat(self, orig_file):
@@ -80,28 +101,51 @@ class PBSStatExtractor(StatExtractor):
     def _extract_qstat_regex(self, qstat_file):
         all_qstat_values = list()
         with open(qstat_file, "r") as fin:
-            _ = fin.readline()  # header
-            fin.readline()  # horizontal row
-            line = fin.readline()  # first line
-            re_match_positions = ("job_id", "user", "state", "queue_name")  # was: (1, 5, 7, 8), (1, 4, 5, 8)
-            try:  # first qstat line determines which format qstat follows.
-                re_search = self.user_q_search
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                # unused: _job_nr, _ce_name, _name, _time_use = m.group(2), m.group(3), m.group(4), m.group(6)
-            except AttributeError:  # this means 'prior' exists in qstat, it's another format
-                re_search = self.user_q_search_prior
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                # unused:  _prior, _name, _submit, _start_at, _queue_domain, _slots, _ja_taskID =
-                # m.group(2), m.group(3), m.group(6), m.group(7), m.group(9), m.group(10), m.group(11)
-            finally:
-                all_qstat_values.append(qstat_values)
-
-            # hence the rest of the lines should follow either try's or except's same format
             for line in fin:
-                qstat_values = self._process_qstat_line(re_search, line, re_match_positions)
-                all_qstat_values.append(qstat_values)
+                qstat_values = self._process_qstat_text_line(line)
+
+                if qstat_values:
+                    all_qstat_values.append(qstat_values)
 
         return all_qstat_values
+
+    def _process_qstat_text_line(self, line):
+        line = line.strip()
+
+        if not line or line.startswith("-") or line.startswith(("Job id", "job-ID")):
+            return None
+
+        if " type=BATCH;" in line or "REQUEST NAME" in line or re.search(r"^\d+\s+run;\s+\d+\s+wait;", line):
+            return None
+
+        if " " not in line:
+            return None
+
+        for re_search in (self.user_q_search, self.user_q_search_prior):
+            try:
+                return self._process_qstat_line(re_search, line, ("job_id", "user", "state", "queue_name"))
+            except AttributeError:
+                pass
+
+        return self._process_qstat_request_line(line)
+
+    def _process_qstat_request_line(self, line):
+        match = re.search(self.user_q_search_request, line)
+
+        if match is None:
+            logging.warning("Line: %s not properly parsed by regex expression. Skipping." % line.strip())
+            return None
+
+        job_id = match.group("job_id")
+        user = self.anonymize(match.group("user"), "users")
+        state = PBS_REQUEST_STATES.get(match.group("state"), match.group("state")[0])
+
+        return {
+            "JobId": job_id,
+            "UnixAccount": user,
+            "S": state,
+            "Queue": "",
+        }
 
     def _extract_qstat_json(self, qstat_file):
         all_qstat_values = list()

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -10,6 +10,7 @@
 
 from qtop_py.plugins import pbs
 import pytest
+from types import SimpleNamespace
 
 
 @pytest.mark.parametrize('core_selections, result',
@@ -38,3 +39,84 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+@pytest.fixture
+def qstat_extractor():
+    return pbs.PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+
+
+def test_extract_qstat_regex_accepts_job_names_with_colons(tmp_path, qstat_extractor):
+    qstat_file = tmp_path / "qstat.txt"
+    qstat_file.write_text(
+        "\n".join(
+            [
+                "Job id                    Name             User            Time Use S Queue",
+                "------------------------- ---------------- --------------- -------- - -----",
+                "11894868.pbs-goegrid       ML:DROP:ANGLE    marcel.langenbe 08:24:54 R shorttime",
+            ]
+        )
+    )
+
+    assert qstat_extractor._extract_qstat_regex(str(qstat_file)) == [
+        {
+            "JobId": "11894868",
+            "UnixAccount": "marcel.langenbe",
+            "S": "R",
+            "Queue": "shorttime",
+        }
+    ]
+
+
+def test_extract_qstat_regex_accepts_prior_table_format(tmp_path, qstat_extractor):
+    qstat_file = tmp_path / "qstat.txt"
+    qstat_file.write_text(
+        "\n".join(
+            [
+                "job-ID  prior   name       user         state submit/start at     queue                          slots ja-task-ID",
+                "-----------------------------------------------------------------------------------------------------------------",
+                "7214025 0.50103 cccreamcel dteam018     r     08/10/2012 01:46:35 medium@ccwsge0454.in2p3.fr         1",
+            ]
+        )
+    )
+
+    assert qstat_extractor._extract_qstat_regex(str(qstat_file)) == [
+        {
+            "JobId": "7214025",
+            "UnixAccount": "dteam018",
+            "S": "r",
+            "Queue": "medium@ccwsge0454.in2p3.fr",
+        }
+    ]
+
+
+def test_extract_qstat_regex_accepts_request_name_sections(tmp_path, qstat_extractor):
+    qstat_file = tmp_path / "qstat.txt"
+    qstat_file.write_text(
+        "\n".join(
+            [
+                "cert;  type=BATCH;  [ENABLED];  pri=90",
+                "1 run;   0 wait;",
+                "",
+                "        REQUEST NAME        REQUEST ID          USER   STATE",
+                "   1:   cream_878672            238085     dteam031  RUNNING",
+                "short;  type=BATCH;  [ENABLED];  pri=40",
+                "   2:   cr001_215824            625164     dteam032  WAITING",
+            ]
+        )
+    )
+
+    assert qstat_extractor._extract_qstat_regex(str(qstat_file)) == [
+        {
+            "JobId": "238085",
+            "UnixAccount": "dteam031",
+            "S": "R",
+            "Queue": "",
+        },
+        {
+            "JobId": "625164",
+            "UnixAccount": "dteam032",
+            "S": "W",
+            "Queue": "",
+        },
+    ]


### PR DESCRIPTION
## Summary

This updates the PBS qstat text parser to handle legacy PBS-style formats seen in historical qtop sample results.

The parser now:

- handles job names that contain colons and queue names with dots or hyphens
- accepts prior-table qstat rows using four-digit years and longer state names
- skips queue metadata/header lines while parsing request-name sections
- maps request states like RUNNING and WAITING to qtop state letters
- keeps existing behavior for current qstat text and JSON paths

## Validation

- `PYTHONPATH=. pytest -q` -> 87 passed
- External sample check against `/tmp/qtop-test-repo/qtop5/results`: 447 samples parsed successfully after this patch
- Before the patch, the same sample sweep had 73 failures in legacy PBS qstat parsing

AI assistance was used to inspect the legacy qstat fixtures, implement the parser changes, and run regression validation.