### PR TITLE
Add Slurm scheduler support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-pbs-samples
+.PHONY: test test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -10,3 +10,6 @@ test:
 
 test-pbs-samples:
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+
+test-slurm-samples:
+	$(PYTHON) -m pytest tests/plugins/test_slurm.py

--- a/qtop_py/plugins/__init__.py
+++ b/qtop_py/plugins/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["oar", "pbs", "sge", "demo"]
+__all__ = ["oar", "pbs", "sge", "demo", "slurm"]

--- a/qtop_py/plugins/slurm.py
+++ b/qtop_py/plugins/slurm.py
@@ -1,0 +1,242 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 qtop contributors
+##
+## SPDX-License-Identifier: MIT
+##
+
+import logging
+import re
+from collections import OrderedDict
+
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
+import qtop_py.fileutils as fileutils
+
+
+class SlurmStatExtractor(StatExtractor):
+    def extract_squeue(self, orig_file):
+        """
+        Parse output from:
+        squeue -h -o %i|%u|%t|%P|%N
+        """
+        try:
+            fileutils.check_empty_file(orig_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % orig_file)
+            return []
+
+        jobs = []
+        with open(orig_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    job_id, user, state, partition, nodes = line.split("|", 4)
+                except ValueError:
+                    logging.warning("Line: %s not properly parsed as Slurm squeue output." % line)
+                    continue
+
+                jobs.append(
+                    {
+                        "JobId": job_id,
+                        "UnixAccount": self.anonymize(user, "users"),
+                        "S": state,
+                        "Queue": self.anonymize(partition, "qs"),
+                        "Nodes": nodes,
+                    }
+                )
+        return jobs
+
+    def extract_sinfo(self, orig_file):
+        """
+        Parse output from:
+        sinfo -N -h -o %N|%P|%t|%c
+        """
+        try:
+            fileutils.check_empty_file(orig_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % orig_file)
+            return []
+
+        nodes = []
+        with open(orig_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    node_name, partition, state, cpus = line.split("|", 3)
+                except ValueError:
+                    logging.warning("Line: %s not properly parsed as Slurm sinfo output." % line)
+                    continue
+
+                nodes.append(
+                    {
+                        "domainname": self.anonymize(node_name, "wns"),
+                        "raw_domainname": node_name,
+                        "qname": [self.anonymize(partition.rstrip("*"), "qs")],
+                        "state": self._map_node_state(state),
+                        "np": cpus,
+                    }
+                )
+        return nodes
+
+    @staticmethod
+    def _map_node_state(state):
+        state = state.lower().strip("*+#~")
+        if state in ("idle", "planned"):
+            return "-"
+        if state in ("alloc", "allocated"):
+            return "a"
+        if state == "mix":
+            return "%"
+        if state in ("down", "drain", "drng", "fail", "failing", "maint"):
+            return "d"
+        if state in ("comp", "completing"):
+            return "c"
+        if state in ("resv", "reserved"):
+            return "r"
+        return state[:1] or "?"
+
+
+class SlurmBatchSystem(GenericBatchSystem):
+    @staticmethod
+    def get_mnemonic():
+        return "slurm"
+
+    def __init__(self, scheduler_output_filenames, config, options):
+        self.squeue_file = scheduler_output_filenames.get("squeue_file")
+        self.sinfo_file = scheduler_output_filenames.get("sinfo_file")
+        self.config = config
+        self.options = options
+        self.slurm_stat_maker = SlurmStatExtractor(self.config, self.options)
+
+    def get_jobs_info(self):
+        job_ids, usernames, job_states, queue_names = [], [], [], []
+        for job in self._get_jobs():
+            job_ids.append(job["JobId"])
+            usernames.append(job["UnixAccount"])
+            job_states.append(job["S"])
+            queue_names.append(job["Queue"])
+
+        logging.debug(
+            "job_ids, usernames, job_states, queue_names lengths: "
+            "%(job_ids)s, %(usernames)s, %(job_states)s, %(queue_names)s"
+            % {"job_ids": len(job_ids), "usernames": len(usernames), "job_states": len(job_states), "queue_names": len(queue_names)}
+        )
+        return job_ids, usernames, job_states, queue_names
+
+    def get_queues_info(self):
+        queue_counts = OrderedDict()
+        total_running_jobs = 0
+        total_queued_jobs = 0
+
+        for node in self.slurm_stat_maker.extract_sinfo(self.sinfo_file):
+            queue_counts.setdefault(node["qname"][0], {"run": 0, "queued": 0, "lm": "--", "state": "E"})
+
+        for job in self._get_jobs():
+            queue = job["Queue"]
+            queue_counts.setdefault(queue, {"run": 0, "queued": 0, "lm": "--", "state": "E"})
+            if job["S"] == "R":
+                queue_counts[queue]["run"] += 1
+                total_running_jobs += 1
+            elif job["S"] == "PD":
+                queue_counts[queue]["queued"] += 1
+                total_queued_jobs += 1
+
+        qstatq_lod = []
+        for queue_name, values in queue_counts.items():
+            qstatq_lod.append(
+                {
+                    "queue_name": queue_name,
+                    "run": str(values["run"]),
+                    "queued": str(values["queued"]),
+                    "lm": values["lm"],
+                    "state": values["state"],
+                }
+            )
+
+        return total_running_jobs, total_queued_jobs, qstatq_lod
+
+    def get_worker_nodes(self, job_ids, job_queues, options):
+        jobs = self._get_jobs()
+        node_jobs = self._map_jobs_to_nodes(jobs)
+        worker_nodes_by_name = OrderedDict()
+
+        for node in self.slurm_stat_maker.extract_sinfo(self.sinfo_file):
+            raw_name = node.pop("raw_domainname")
+            worker_node = worker_nodes_by_name.setdefault(
+                raw_name,
+                {
+                    "domainname": node["domainname"],
+                    "np": node["np"],
+                    "state": node["state"],
+                    "qname": [],
+                    "core_job_map": {},
+                },
+            )
+            if node["qname"][0] not in worker_node["qname"]:
+                worker_node["qname"].append(node["qname"][0])
+            if worker_node["state"] == "-" and node["state"] != "-":
+                worker_node["state"] = node["state"]
+
+        for raw_name, worker_node in worker_nodes_by_name.items():
+            worker_node["core_job_map"] = dict((idx, job_id) for idx, job_id in enumerate(node_jobs.get(raw_name, [])))
+            worker_node["np"] = str(max(int(worker_node["np"]), len(worker_node["core_job_map"])))
+
+        worker_nodes = list(worker_nodes_by_name.values())
+        logging.info("worker_nodes contains %s entries" % len(worker_nodes))
+        return worker_nodes
+
+    def _get_jobs(self):
+        if not hasattr(self, "_jobs"):
+            self._jobs = self.slurm_stat_maker.extract_squeue(self.squeue_file)
+        return self._jobs
+
+    @classmethod
+    def _map_jobs_to_nodes(cls, jobs):
+        node_jobs = {}
+        for job in jobs:
+            if job["S"] != "R":
+                continue
+            for node in cls._expand_nodelist(job["Nodes"]):
+                node_jobs.setdefault(node, []).append(job["JobId"])
+        return node_jobs
+
+    @classmethod
+    def _expand_nodelist(cls, nodelist):
+        if not nodelist or nodelist.startswith("("):
+            return []
+        expanded = [nodelist]
+        while True:
+            bracketed = None
+            for item in expanded:
+                if "[" in item:
+                    bracketed = item
+                    break
+            if bracketed is None:
+                return expanded
+
+            expanded.remove(bracketed)
+            expanded.extend(cls._expand_first_range(bracketed))
+
+    @staticmethod
+    def _expand_first_range(value):
+        match = re.search(r"(\[[^\]]+\])", value)
+        if not match:
+            return [value]
+        prefix = value[: match.start()]
+        suffix = value[match.end() :]
+        choices = []
+        for part in match.group(1).strip("[]").split(","):
+            if "-" not in part:
+                choices.append(part)
+                continue
+            start, end = part.split("-", 1)
+            width = len(start)
+            choices.extend(str(i).zfill(width) for i in range(int(start), int(end) + 1))
+        return [prefix + choice + suffix for choice in choices]

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -6,7 +6,7 @@
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
 
-## scheduler possible values (currently supported): pbs, oar, sge
+## scheduler possible values (currently supported): pbs, oar, sge, slurm
 ## auto will try to detect available batch commands in the current system
 scheduler: auto
 
@@ -28,6 +28,9 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  slurm:
+    squeue_file: %(savepath)s/squeue%(pid)s.txt, squeue -h -o %%i|%%u|%%t|%%P|%%N
+    sinfo_file: %(savepath)s/sinfo%(pid)s.txt, sinfo -N -h -o %%N|%%P|%%t|%%c
   demo:
     demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
 
@@ -36,6 +39,7 @@ signature_commands:
   pbs: pbsnodes
   oar: oarnodes
   sge: qacct
+  slurm: sinfo
   demo: echo
 
 ## Utilises lxml module. Needs to be installed in your system.
@@ -97,6 +101,19 @@ state_abbreviations:
     Rq: queued_of_user
     Rt: transferring_of_user
     Rr: running_of_user    
+  slurm:
+    R: running_of_user
+    PD: queued_of_user
+    CA: cancelled_of_user
+    CD: finished_of_user
+    CG: exiting_of_user
+    CF: configuring_of_user
+    F: failed_of_user
+    NF: failed_node_of_user
+    TO: timeout_of_user
+    PR: preempted_of_user
+    S: suspended_of_user
+    ST: stopped_of_user
   demo:
     Q: queued_of_user
     R: running_of_user
@@ -270,12 +287,12 @@ workernodes_matrix:
      yaml_key: state
      label: Node state
      max_len: 5
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - queue name:
      yaml_key: qname
      label: queue name
      max_len: 13
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - core_user_map:
      options1: {}
      options2: {}

--- a/tests/plugins/slurm_samples/basic/sinfo.txt
+++ b/tests/plugins/slurm_samples/basic/sinfo.txt
@@ -1,0 +1,3 @@
+node001|compute*|idle|4
+node002|compute*|alloc|4
+node003|long|idle|8

--- a/tests/plugins/slurm_samples/basic/squeue.txt
+++ b/tests/plugins/slurm_samples/basic/squeue.txt
@@ -1,0 +1,3 @@
+101|alice|R|compute|node001
+102|bob|R|compute|node002
+103|carol|PD|long|(Priority)

--- a/tests/plugins/slurm_samples/mixed/sinfo.txt
+++ b/tests/plugins/slurm_samples/mixed/sinfo.txt
@@ -1,0 +1,2 @@
+gpu001|gpu*|mix|8
+gpu002|gpu*|down|8

--- a/tests/plugins/slurm_samples/mixed/squeue.txt
+++ b/tests/plugins/slurm_samples/mixed/squeue.txt
@@ -1,0 +1,3 @@
+201|alice|R|gpu|gpu001
+202|dave|R|gpu|gpu001
+203|erin|CG|gpu|gpu002

--- a/tests/plugins/slurm_samples/multi_partition/sinfo.txt
+++ b/tests/plugins/slurm_samples/multi_partition/sinfo.txt
@@ -1,0 +1,3 @@
+shared001|compute*|alloc|16
+shared001|debug|alloc|16
+shared002|compute*|idle|16

--- a/tests/plugins/slurm_samples/multi_partition/squeue.txt
+++ b/tests/plugins/slurm_samples/multi_partition/squeue.txt
@@ -1,0 +1,2 @@
+301|frank|R|debug|shared001
+302|grace|PD|compute|(Resources)

--- a/tests/plugins/test_slurm.py
+++ b/tests/plugins/test_slurm.py
@@ -1,0 +1,89 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## SPDX-License-Identifier: MIT
+##
+
+import os
+
+import pytest
+
+from qtop_py.plugins.slurm import SlurmBatchSystem
+
+
+class Options(object):
+    ANONYMIZE = False
+
+
+def scheduler_files(sample_name):
+    sample_dir = os.path.join(os.path.dirname(__file__), "slurm_samples", sample_name)
+    return {
+        "squeue_file": os.path.join(sample_dir, "squeue.txt"),
+        "sinfo_file": os.path.join(sample_dir, "sinfo.txt"),
+    }
+
+
+@pytest.mark.parametrize(
+    "sample_name, expected_jobs, expected_queues, expected_nodes",
+    (
+        (
+            "basic",
+            (["101", "102", "103"], ["alice", "bob", "carol"], ["R", "R", "PD"], ["compute", "compute", "long"]),
+            (2, 1, {"compute": ("2", "0"), "long": ("0", "1")}),
+            {
+                "node001": ("-", ["compute"], {0: "101"}),
+                "node002": ("a", ["compute"], {0: "102"}),
+                "node003": ("-", ["long"], {}),
+            },
+        ),
+        (
+            "mixed",
+            (["201", "202", "203"], ["alice", "dave", "erin"], ["R", "R", "CG"], ["gpu", "gpu", "gpu"]),
+            (2, 0, {"gpu": ("2", "0")}),
+            {
+                "gpu001": ("%", ["gpu"], {0: "201", 1: "202"}),
+                "gpu002": ("d", ["gpu"], {}),
+            },
+        ),
+        (
+            "multi_partition",
+            (["301", "302"], ["frank", "grace"], ["R", "PD"], ["debug", "compute"]),
+            (1, 1, {"debug": ("1", "0"), "compute": ("0", "1")}),
+            {
+                "shared001": ("a", ["compute", "debug"], {0: "301"}),
+                "shared002": ("-", ["compute"], {}),
+            },
+        ),
+    ),
+)
+def test_slurm_command_traces(sample_name, expected_jobs, expected_queues, expected_nodes):
+    slurm = SlurmBatchSystem(scheduler_files(sample_name), {}, Options())
+
+    assert slurm.get_jobs_info() == expected_jobs
+
+    total_running, total_queued, queues = slurm.get_queues_info()
+    assert (total_running, total_queued) == expected_queues[:2]
+    queue_counts = dict((queue["queue_name"], (queue["run"], queue["queued"])) for queue in queues)
+    assert queue_counts == expected_queues[2]
+
+    worker_nodes = dict((node["domainname"], node) for node in slurm.get_worker_nodes(expected_jobs[0], expected_jobs[3], Options()))
+    assert set(worker_nodes) == set(expected_nodes)
+    for node_name, expected in expected_nodes.items():
+        expected_state, expected_qnames, expected_core_map = expected
+        assert worker_nodes[node_name]["state"] == expected_state
+        assert worker_nodes[node_name]["qname"] == expected_qnames
+        assert worker_nodes[node_name]["core_job_map"] == expected_core_map
+
+
+@pytest.mark.parametrize(
+    "nodelist, expected",
+    (
+        ("node001", ["node001"]),
+        ("node[001-003]", ["node001", "node002", "node003"]),
+        ("gpu[01-02,04]", ["gpu01", "gpu02", "gpu04"]),
+        ("rack[01-02]node[001-002]", ["rack01node001", "rack01node002", "rack02node001", "rack02node002"]),
+        ("(Priority)", []),
+    ),
+)
+def test_expand_nodelist(nodelist, expected):
+    assert SlurmBatchSystem._expand_nodelist(nodelist) == expected


### PR DESCRIPTION
## Summary
- add a Slurm scheduler plugin using deterministic `squeue` and `sinfo` command traces
- register Slurm in qtop config, plugin imports, state abbreviations, and worker-node matrix sections
- add three Slurm trace fixtures plus a Makefile target for CI-focused plugin verification

## Verification
- `python -m pytest tests\plugins\test_slurm.py -q`
- `python -m pytest tests\plugins\test_slurm.py tests\plugins\test_pbs.py -q`
- `wsl bash -lc "cd /mnt/c/Users/digal/qtop && /tmp/qtop-slurm-venv/bin/python -m pytest -q"`
- `wsl bash -lc "cd /mnt/c/Users/digal/qtop && make test-slurm-samples PYTHON=/tmp/qtop-slurm-venv/bin/python"`
- `wsl bash -lc "cd /mnt/c/Users/digal/qtop && python3 -m qtop_py.qtop -b slurm -s tests/plugins/slurm_samples/basic -O"`
- `wsl bash -lc "cd /mnt/c/Users/digal/qtop && python3 -m qtop_py.qtop -b slurm -s tests/plugins/slurm_samples/mixed -O"`
- `wsl bash -lc "cd /mnt/c/Users/digal/qtop && python3 -m qtop_py.qtop -b slurm -s tests/plugins/slurm_samples/multi_partition -O"`
- `python -m compileall -q qtop_py tests`

Claims #356
