### PR TITLE
20260522: (human) (uni) fix viewport horizontal scroll indexes

### DIFF
--- a/qtop_py/ui/viewport.py
+++ b/qtop_py/ui/viewport.py
@@ -113,14 +113,14 @@ class Viewport(BaseViewport):
     def scroll_right(self):
         if self.h_start + self.h_term_size >= self.max_width:
             return False
-        self.h_start += self.h_term_size / 2
+        self.h_start += self.h_term_size // 2
         return True
 
     def scroll_far_right(self):
         self.h_start = self.get_right_limit()
 
     def scroll_left(self):
-        self.h_start -= self.h_term_size / 2
+        self.h_start -= self.h_term_size // 2
 
     def scroll_far_left(self):
         self.h_start = 0

--- a/tests/ui/test_viewport.py
+++ b/tests/ui/test_viewport.py
@@ -39,6 +39,8 @@ def test_after_scroll_right_UNUSED():  # FIXME: cleanup as such
     assert 176 / 2 + 176 == viewport.h_stop  # (not scroll endelessly to the right)
     assert 0 == viewport.v_start
     assert 53 == viewport.v_stop
+    assert isinstance(viewport.h_start, int)
+    assert isinstance(viewport.h_stop, int)
 
 
 def test_after_scroll_down():


### PR DESCRIPTION
## Summary
- rebased on latest develop and realigned this PR with the updated Challenge #358 request for a very small code-backed win
- replace the earlier documentation-only triage note with a focused viewport fix related to older scrolling issue #121
- keep horizontal scroll offsets as integers by using integer division, so rendering slices never receive float indexes after left/right scrolling
- add a regression guard that h_start and h_stop stay integer values after horizontal scroll

## Verification
- git diff --check passed locally
- line count: 4 additions / 2 deletions across 2 files
- Python/RHEL8 note: integer division is compatible with Python 3.6
- Could not run pytest or ruff locally because this Windows PATH currently has no python, py, or uv executable available

## AI assistance
- Assisted with OpenAI Codex (GPT-5), with manual review of the final diff and challenge requirements.

/claim #358