### PR TITLE
docs: triage stale qtop pull requests

### DIFF
--- a/docs/pr-wrapup-2026-05.md
+++ b/docs/pr-wrapup-2026-05.md
@@ -1,0 +1,18 @@
+# PR wrap-up notes, 2026-05
+
+Candidate clean-up paths for issue #357:
+
+- #345: rebase to `develop` or close after confirming whether the small SGE
+  finally/test fix is already covered.
+- #334: keep closed; the redundant-import cleanup was superseded by later
+  maintenance work.
+- #342: keep closed unless the minerador generic API task can be mapped to a
+  concrete qtop issue.
+- #341: keep closed for the same minerador/generic API reason as #342.
+- #306: extract the SGE multi-slot behavior into a fresh `develop` PR if still
+  useful; the original branch target is stale.
+- #241: close unless Python 2.6 compatibility is explicitly revived; the
+  backport branch is too old for direct merge.
+
+Suggested order: decide #345 first, keep #334/#342/#341 closed, then make a
+maintainer call on whether #306 or #241 still represent active roadmap work.


### PR DESCRIPTION
## Summary
- add concise wrap-up notes for six stale or superseded pull requests
- propose which PRs should stay closed, be rebased, or be extracted into fresh work
- keep the change documentation-only and below the challenge line limit

## Verification
- git diff --check
- line count: 18 lines

/claim #357