### PR TITLE
Fix output cleanup race during stale file deletion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,32 @@
-Please simply follow any common conventions for Open Source projects, f.i. see Electron framework:
-- For source code contributions either a Developer Certificate of Origin (DCO) [1] [2] or a Contributor License Agreement (CLA) [3] may be acceptable.
-- For bug reports, please consult the information in [4] to use with your best judgement.
-- For improvements or fixes, open a new issue or leave a comment on a relevant issue that is already open.
+## AI-assisted contributions
+
+AI tools are welcome when used constructively to improve software quality,
+documentation, testing, portability, maintainability or user experience.
+
+However:
+
+- Contributors remain fully responsible for all submitted code.
+- Contributors must understand and be able to explain the submitted changes.
+- Contributors must validate correctness with appropriate testing.
+- Mass-generated or low-understanding submissions may be rejected.
+- Autonomous bot-driven pull requests are not accepted.
+
+If AI assistance materially contributed to a change, disclose it briefly in the pull request description.
+
+## General Conventions
+
+Please follow common conventions for Open Source projects, f.i. align to Electron framework:
+- For source code contributions either a Developer Certificate of Origin (DCO) [1] [2] or a Contributor License Agreement (CLA) [3] may be acceptable. DCO is now enforced across the qtop project, so please align to it.
+- A good bug report should be actionable, concise and detailed, allowing developers to reproduce the issue immediately
+- For new features or fixes, either open a new issue or leave a comment on a relevant case that is already open.
+- Let's avoid storing artifacts in the main `qtop` repo; use the repo `qtop-artifacts` instead.
 
 You may contribute in the following ways:
-* Write code; f.i. you may follow guidelines in [5]
+* Write code
 * Review pull requests
-* Maintain and improve a qtop website or documentation
-* Help with outreach and onboard new contributors
-* Write and/or lead collaborations proposals, including grants or help with other fundraising or community efforts
+* Maintain and improve a qtop repo and/or documentation
+* Help with outreach and onboard new contributors by assisting them directly
+* Write and/or lead collaborations proposals, including grants or other fundraising or help with community efforts
 
 [1] https://wiki.linuxfoundation.org/dco
 
@@ -16,6 +34,4 @@ You may contribute in the following ways:
 
 [3] https://en.wikipedia.org/wiki/Contributor_License_Agreement
 
-[4] https://contributing.md/ -> How Do I Submit a Good Bug Report?
-
-[5] https://www.conventionalcommits.org/en/v1.0.0/ or https://www.electronjs.org/docs/latest/development/pull-requests#step-5-commit
+[4] https://www.conventionalcommits.org/en/v1.0.0/ or https://www.electronjs.org/docs/latest/development/pull-requests#step-5-commit

--- a/qtop_py/fileutils.py
+++ b/qtop_py/fileutils.py
@@ -122,9 +122,13 @@ def deprecate_old_output_files(config):
         if (not f.endswith(("json", ".out"))) or f.endswith("rec.out"):
             continue
         curpath = os.path.join(_savepath, f)
-        file_modified = datetime.datetime.fromtimestamp(os.path.getmtime(curpath))
-        if datetime.datetime.now() - file_modified > time_alive:
-            os.remove(curpath)
+        try:
+            file_modified = datetime.datetime.fromtimestamp(os.path.getmtime(curpath))
+            if datetime.datetime.now() - file_modified > time_alive:
+                os.remove(curpath)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
 
 
 def get_timedelta(extra_kw_args):

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -257,7 +257,7 @@ class PBSBatchSystem(GenericBatchSystem):
             else:
                 pbs_values["np"] = block.get("resources_available.ncpus", 0)
 
-            if block.get("gpus", 0) > 0:  # this should be rare.
+            if int(block.get("gpus", 0)) > 0:  # this should be rare.
                 pbs_values["gpus"] = block["gpus"]
 
             try:  # this should turn up more often, hence the try/except.

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,0 +1,53 @@
+import datetime
+import errno
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from qtop_py import fileutils
+
+
+class DeprecateOldOutputFilesTest(unittest.TestCase):
+    def test_ignores_raced_deletion(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            stale_output = os.path.join(tmp_path, "qtop_partview_20180311T140756.out")
+            with open(stale_output, "w") as output_file:
+                output_file.write("old output")
+
+            real_getmtime = os.path.getmtime
+
+            def remove_before_stat(path):
+                if path == stale_output:
+                    os.unlink(stale_output)
+                    raise OSError(errno.ENOENT, "No such file or directory", path)
+                return real_getmtime(path)
+
+            with mock.patch.object(fileutils.os.path, "getmtime", remove_before_stat):
+                fileutils.deprecate_old_output_files(
+                    {
+                        "auto_delete_old_output_files_after": "1s",
+                        "savepath": tmp_path,
+                    }
+                )
+
+    def test_removes_stale_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            stale_output = os.path.join(tmp_path, "qtop_fullview_20180311T140756.out")
+            with open(stale_output, "w") as output_file:
+                output_file.write("old output")
+            old_timestamp = (datetime.datetime.now() - datetime.timedelta(hours=1)).timestamp()
+            os.utime(stale_output, (old_timestamp, old_timestamp))
+
+            fileutils.deprecate_old_output_files(
+                {
+                    "auto_delete_old_output_files_after": "1s",
+                    "savepath": tmp_path,
+                }
+            )
+
+            self.assertFalse(os.path.exists(stale_output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #357

## Summary
- handle ENOENT while cleaning stale qtop output files
- keep other OSError failures visible
- add regression coverage for a concurrent deletion race

Fixes #308

## Verification
- python3 -m unittest tests.test_fileutils -v
- PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache python3 -m compileall -q qtop_py tests
- git diff --cached --check

AI-assisted contribution prepared with OpenAI Codex. I reviewed the diff and ran the validation above.