### PR TITLE
Add PBS sample failure gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
+PBS_MAX_FAILURES ?=
+PBS_SAMPLE_TIMEOUT ?= 8
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
+PBS_MAX_FAILURES_ARG = $(if $(PBS_MAX_FAILURES),--max-failures $(PBS_MAX_FAILURES),)
 
 test:
 	$(PYTHON) -m pytest
 
 test-pbs-samples:
-	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR) --timeout $(PBS_SAMPLE_TIMEOUT) $(PBS_MAX_FAILURES_ARG)

--- a/docs/pbs-sample-regressions.md
+++ b/docs/pbs-sample-regressions.md
@@ -35,6 +35,7 @@ This PR adds a lightweight path toward `make test` integration:
 ```bash
 make test
 make test-pbs-samples PBS_SAMPLES_DIR=../qtop-test-repo/qtop5/results PBS_SAMPLE_LIMIT=100
+make test-pbs-samples PBS_SAMPLES_DIR=../qtop-test-repo/qtop5/results PBS_SAMPLE_LIMIT=10 PBS_MAX_FAILURES=50 PBS_SAMPLE_TIMEOUT=20
 ```
 
 The proposed regression flow is:
@@ -50,8 +51,11 @@ The proposed regression flow is:
 python3 -m pytest tests/test_pbs_sample_regressions.py -q
 python3 tools/validate_pbs_samples.py ../qtop-test-repo/qtop5/results --limit 10 --output /tmp/qtop-pbs-golden-10
 python3 tools/validate_pbs_samples.py ../qtop-test-repo/qtop5/results --limit 100 --output /tmp/qtop-pbs-rendered-100
+python3 tools/validate_pbs_samples.py ../qtop-test-repo/qtop5/results --limit 10 --max-failures 50 --timeout 20 --output /tmp/qtop-pbs-failure-count-10
 ```
 
-Observed local golden-output check after this patch: `validated=10 output=/tmp/qtop-pbs-golden-10`.
+Observed local golden-output check after this patch: `rendered=10 passed=10 failed=0 scanned=10 output=/tmp/qtop-pbs-golden-10`.
 
-Observed local sample sweep after this patch: `validated=100 output=/tmp/qtop-pbs-rendered-100`.
+Observed local sample sweep after this patch: `rendered=100 passed=100 failed=0 scanned=100 output=/tmp/qtop-pbs-rendered-100`.
+
+Observed local full-corpus failure-count check after this patch: `rendered=10 passed=447 failed=0 scanned=447 output=/tmp/qtop-pbs-failure-count-10`.

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -31,7 +31,7 @@ GOLDEN_PBS_SAMPLES = (
 def render_sample(sample_dir, output_dir, save_output=True, timeout=8):
     proc = subprocess.Popen(
         ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
-        text=True,
+        universal_newlines=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -3,10 +3,13 @@
 
 Usage:
     python tools/validate_pbs_samples.py /path/to/qtop-test-repo/qtop5/results --limit 100 --output /tmp/qtop-pbs-rendered
+    python tools/validate_pbs_samples.py /path/to/qtop-test-repo/qtop5/results --limit 10 --max-failures 50 --timeout 20
 """
 
 import argparse
 import json
+import os
+import signal
 import subprocess
 from pathlib import Path
 
@@ -25,22 +28,33 @@ GOLDEN_PBS_SAMPLES = (
 )
 
 
-def render_sample(sample_dir, output_dir):
-    proc = subprocess.run(
+def render_sample(sample_dir, output_dir, save_output=True, timeout=8):
+    proc = subprocess.Popen(
         ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
         text=True,
-        capture_output=True,
-        timeout=8,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
     )
-    if proc.returncode != 0 or not proc.stdout.strip():
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.communicate()
+        return None
+    if proc.returncode != 0 or not stdout.strip():
         return None
 
-    output_file = output_dir / f"{sample_dir.name}.ans"
-    output_file.write_text(proc.stdout)
+    output_file = output_dir / f"{sample_dir.name}.ans" if save_output else None
+    if output_file is not None:
+        output_file.write_text(stdout)
     return {
         "sample": sample_dir.name,
-        "output": output_file.name,
-        "stderr_tail": proc.stderr.splitlines()[-5:],
+        "output": output_file.name if output_file is not None else None,
+        "stderr_tail": stderr.splitlines()[-5:],
     }
 
 
@@ -54,11 +68,26 @@ def main() -> int:
         action="store_true",
         help="Do not force the curated 10-sample golden set into the rendered output.",
     )
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        default=None,
+        help="Scan the full sample collection and fail if more than this many samples do not render.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=8,
+        help="Per-sample qtop timeout in seconds.",
+    )
     args = parser.parse_args()
 
     sample_dirs = sorted(path for path in args.samples_dir.iterdir() if path.is_dir())
     args.output.mkdir(parents=True, exist_ok=True)
     manifest = []
+    failures = []
+    passed = 0
+    scanned = 0
     seen = set()
 
     if not args.skip_golden_samples:
@@ -66,28 +95,53 @@ def main() -> int:
             sample_dir = args.samples_dir / sample
             if not sample_dir.is_dir():
                 raise FileNotFoundError(f"golden PBS sample not found: {sample_dir}")
-            entry = render_sample(sample_dir, args.output)
+            entry = render_sample(sample_dir, args.output, timeout=args.timeout)
             if entry is None:
                 raise RuntimeError(f"golden PBS sample failed to render: {sample_dir}")
+            passed += 1
             entry["golden"] = True
             manifest.append(entry)
             seen.add(sample_dir.name)
 
     for sample_dir in sample_dirs:
-        if len(manifest) >= args.limit:
+        if args.max_failures is None and len(manifest) >= args.limit:
             break
         if sample_dir.name in seen:
             continue
-        entry = render_sample(sample_dir, args.output)
+        scanned += 1
+        entry = render_sample(
+            sample_dir,
+            args.output,
+            save_output=len(manifest) < args.limit,
+            timeout=args.timeout,
+        )
         if entry is None:
+            failures.append(sample_dir.name)
             continue
-        manifest.append(entry)
-        if len(manifest) >= args.limit:
+        passed += 1
+        if entry["output"] is not None:
+            manifest.append(entry)
+        if args.max_failures is None and len(manifest) >= args.limit:
             break
 
+    summary = {
+        "rendered": len(manifest),
+        "passed": passed,
+        "failed": len(failures),
+        "scanned": len(seen) + scanned,
+    }
     (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    print(f"validated={len(manifest)} output={args.output}")
-    return 0 if len(manifest) >= args.limit else 1
+    (args.output / "failures.json").write_text(json.dumps(failures, indent=2))
+    (args.output / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(
+        f"rendered={summary['rendered']} passed={summary['passed']} "
+        f"failed={summary['failed']} scanned={summary['scanned']} output={args.output}"
+    )
+    if len(manifest) < args.limit:
+        return 1
+    if args.max_failures is not None and len(failures) > args.max_failures:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
/claim #355

Addresses #355

## Summary

- add a `--max-failures` gate to the PBS sample validation helper
- make `tools/validate_pbs_samples.py` scan the full archived PBS sample collection when that gate is enabled, instead of only collecting the first `--limit` successful renders
- add configurable per-sample timeout handling so a hung PBS sample counts as a failed sample instead of crashing the helper
- write `summary.json` and `failures.json` alongside `manifest.json`
- wire `PBS_MAX_FAILURES` and `PBS_SAMPLE_TIMEOUT` into `make test-pbs-samples`
- document the command that proves the challenge's "no more than 50 cluster samples fail" criterion
- keep the new helper path compatible with Python 3.6 by using `universal_newlines=True` instead of the Python 3.7+ `text=True` subprocess alias

This is intentionally scoped to the PBS sample-failure evidence gap discussed in #359. It does not overlap the existing maintenance-tooling/eval/MANIFEST PRs.

Current context: the maintainer noted on #359 that the "no more than 50 cluster samples fail" challenge item had not been processed. This PR targets that exact proof gap by adding a reusable failure-budget gate and full-corpus scanned/passed/failed summary, instead of changing the maintenance checklist files.


## Maintainer follow-up status

- Python 3.6 compatibility was rechecked with `vermin --target=3.6`, `ast.parse(..., feature_version=(3, 6))`, and `py_compile`; the PR uses `universal_newlines=True` rather than the Python 3.7+ `text=True` alias.
- The requested AlmaLinux validation was run in a GitHub Actions proof branch using `almalinux:8.10` with Python 3.6.8 against sample `gef_xwILYNMpoabX4PDGYXIZAA`; the posted result was `rendered=1 passed=1 failed=0 scanned=1` with artifact `pr376-almalinux-sample-346-rendered`.
- Proof-of-humanity coordination is being handled through the maintainer-requested email path for subject `PR376`.

## Validation

```sh
python3 -m pytest -q
# 90 passed, 7 warnings

python3 -m compileall -q tools tests qtop_py
# passed; existing tests/test_yaml_parser.py invalid-escape SyntaxWarning remains

python3 -m py_compile tools/validate_pbs_samples.py tests/test_pbs_sample_regressions.py qtop_py/plugins/pbs.py qtop_py/qtop.py
# passed

git diff --check
# passed

python3 - <<'PY'
import ast
from pathlib import Path
for path in [Path('tools/validate_pbs_samples.py'), Path('tests/test_pbs_sample_regressions.py')]:
    ast.parse(path.read_text(), filename=str(path), feature_version=(3, 6))
print('python3.6 syntax parse passed for changed Python files')
PY
# python3.6 syntax parse passed for changed Python files

vermin --target=3.6 tools/validate_pbs_samples.py tests/test_pbs_sample_regressions.py
# Minimum required versions: 3.6

python3 tools/validate_pbs_samples.py /tmp/qtop-test-repo/qtop5/results --limit 10 --max-failures 50 --timeout 8 --output /tmp/qtop-pbs-rendered-pr376-full
# rendered=10 passed=447 failed=0 scanned=447 output=/tmp/qtop-pbs-rendered-pr376-full

make test-pbs-samples PBS_SAMPLES_DIR=/tmp/qtop-test-repo-codex/qtop5/results PBS_SAMPLE_LIMIT=10 PBS_MAX_FAILURES=50 PBS_OUTPUT_DIR=/tmp/qtop-pbs-20260515-1840-make
# rendered=10 passed=447 failed=0 scanned=447 output=/tmp/qtop-pbs-20260515-1840-make
```

I also ran direct full-corpus render sweeps against `fgeorgatos/qtop-test-repo/qtop5/results`: all 447 archived PBS sample directories rendered successfully with zero command failures.

## Notes

- This preserves the existing default helper behavior when `--max-failures` is not set.
- `--limit` still controls how many rendered `.ans` outputs are saved to the manifest.
- `--max-failures` controls whether the full corpus is scanned and whether the command fails when the configured failure budget is exceeded.
- `summary.json` records the rendered-output count, passed count, failed count, and scanned count for review.
- qtop screenshot for the follow-up request: https://gist.github.com/newmattock/06262a0b89f94a8dd5ff7dd3a3818349

AI-assisted contribution prepared with OpenAI Codex (GPT-5). I reviewed the diff and ran the validation above.
