### PR TITLE
Challenge #2: safer YAML scalar handling and manifest cleanup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,10 @@
 include CHANGELOG.rst
-include CONTRIBUTING.rst
+include CONTRIBUTING.md
 include helpfile.txt
 include Makefile
 include MANIFEST.in
 include LICENSE
 include qtopconf.yaml
-include qtop.py
 include qtop
 include qtop_py/cli.py
 include qtop_py/colormap.py
@@ -42,9 +41,13 @@ include qtop_py/web/index.html
 include qtop_py/web.py
 include qtop_py/yaml_parser.py
 include qtop_py/qtop.sh
-include README.rst
+include README.md
 include ROADMAP.rst
-include setup.py
+recursive-include tests *.py
+recursive-include qtop_py/contrib *
+recursive-include qtop_py/inputs *
+recursive-include qtop_py/plugins *.py
+recursive-include qtop_py/ui *.py
 include tests/plugins/__init__.py
 include tests/plugins/test_pbs.py
 include tests/test_qtop.py

--- a/docs/plans/2026-05-17-issue-355-plan.md
+++ b/docs/plans/2026-05-17-issue-355-plan.md
@@ -1,0 +1,15 @@
+# Issue 355 Plan
+Created: 2026-05-17
+
+Scope:
+- Prepare qtop codebase for developer testing by removing risky parsing behavior and tightening package manifest handling.
+- Keep change set small and focused.
+
+Implementation units:
+- qtop_py/yaml_parser.py: remove risky parse path for scalar coercion.
+- MANIFEST.in: prune stale patterns and use tighter include rules.
+- tests/test_yaml_parser.py: add regression coverage for parser coercion behavior.
+
+Validation:
+- python -m pytest tests/test_yaml_parser.py -q
+- python -m pytest -q

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -8,6 +8,7 @@
 ## SPDX-License-Identifier: MIT
 ##
 
+import ast
 import os
 import logging
 
@@ -244,9 +245,11 @@ def process_line(list_line, fin, get_lines, parent_container):
             container = "" if container in ("''", '""') else container
             if len(container) == 1 and isinstance(container, list) and isinstance(container[0], str):
                 try:
-                    container = list(eval(container[0]))
-                except NameError:
-                    pass
+                    parsed_container = ast.literal_eval(container[0])
+                except (ValueError, SyntaxError):
+                    parsed_container = None
+                if isinstance(parsed_container, (list, tuple)):
+                    container = list(parsed_container)
             return {"-": [{key.rstrip(":"): container}]}, container  # list
 
         elif container.endswith("|"):

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -258,6 +258,19 @@ def test_process_code(fin, code):
     assert process_code(fin) == code
 
 
+@pytest.mark.parametrize(
+    "line, expected",
+    (
+        ([0, "-", "key: [1, 2, 3]"], {"-": [{"key": ["1", "2", "3"]}]}),
+        ([0, "-", "key: [alpha, beta]"], {"-": [{"key": ["alpha", "beta"]}]}),
+        ([0, "-", "key: [abc-def]"], {"-": [{"key": ["abc-def"]}]}),
+    ),
+)
+def test_process_line_bracket_values(line, expected):
+    parsed, _ = process_line(line, [], iter(()), {})
+    assert parsed == expected
+
+
 # @pytest.mark.current
 @pytest.mark.parametrize(
     "dict_a, dict_b",


### PR DESCRIPTION
Implements a focused, non-overlapping maintenance slice for #355.

Changes:
- Replaced dynamic eval path in qtop_py/yaml_parser.py with ast.literal_eval plus strict type guard.
- Added parser regression tests for bracketed scalar/list inputs in tests/test_yaml_parser.py.
- Updated MANIFEST.in to match current markdown docs and recursive package/test includes.

Validation:
- .venv/bin/python -m pytest tests/test_yaml_parser.py -q (25 passed)
- .venv/bin/python -m pytest -q (87 passed)

/claim #355
