### PR TITLE
Challenge #4: add PR wrap-up guidance for maintainers

### DIFF
--- a/docs/plans/2026-05-17-issue-357-plan.md
+++ b/docs/plans/2026-05-17-issue-357-plan.md
@@ -1,0 +1,12 @@
+# Issue 357 Plan
+Created: 2026-05-17
+
+Scope:
+- Produce a concise meta-cleanup artifact to help maintainers close/supersede stale or overlapping PRs.
+- Keep patch documentation-only and small.
+
+Implementation units:
+- docs/pr-meta-wrapup-357.md
+
+Validation:
+- git diff --check

--- a/docs/pr-meta-wrapup-357.md
+++ b/docs/pr-meta-wrapup-357.md
@@ -1,0 +1,16 @@
+# Challenge #4 Meta Wrap-up
+
+This note proposes a low-friction declutter path for five active PRs, based on overlap and base-branch alignment.
+
+## Suggested Actions
+
+- `#381` (base: `main`, issue `#357`): supersede with a `develop`-targeted follow-up or retarget if content is still needed.
+- `#365` (docs triage): keep as reference-only and close after extracting any maintainers-only checklist items.
+- `#368` (output cleanup race, base: `main`): retarget to `develop` if still relevant to current challenge flow.
+- `#360` (slurm support): compare against newer slurm submissions and keep a single canonical implementation branch.
+- `#359` (issue `#355` maintenance pack): close in favor of one accepted `#355` branch to reduce duplicate review load.
+
+## Reviewer Shortcut
+
+- Prioritize one branch per challenge (`#355`, `#356`, `#357`) on `develop`.
+- Mark all other overlapping branches as superseded once one branch is accepted per challenge.


### PR DESCRIPTION
Adds a compact maintainer-facing meta-wrapup note for challenge #357 to help declutter overlapping PRs.

What it does:
- Identifies 5 concrete active PRs with overlap/base-branch cleanup suggestions.
- Provides a reviewer shortcut to converge on one accepted branch per challenge.
- Keeps the patch docs-only and intentionally small.

Validation:
- git diff --check (clean)

/claim #357
