### PR TITLE
20260522: fix source-file -s handling and missing coreline config

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -769,7 +769,7 @@ def get_output_size(max_line_len, output_fp, max_height=0):
 
 
 def update_config_with_cmdline_vars(args, config):
-    config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
+    config["rem_empty_corelines"] = int(config.get("rem_empty_corelines", 0))
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
         val = eval(val) if ("True" in val or "False" in val) else val
@@ -795,6 +795,8 @@ def attempt_faster_xml_parsing(config):
 
 def init_dirs(args, _savepath):
     args.SOURCEDIR = realpath(args.SOURCEDIR) if args.SOURCEDIR else None
+    if args.SOURCEDIR and os.path.isfile(args.SOURCEDIR):
+        args.SOURCEDIR = os.path.dirname(args.SOURCEDIR)
     logging.debug("User-defined source directory: %s" % args.SOURCEDIR)
     args.workdir = args.SOURCEDIR or _savepath
     logging.debug("Working directory is now: %s" % args.workdir)

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -61,6 +61,28 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert not sentinel.exists()
 
 
+def test_update_config_defaults_missing_rem_empty_corelines():
+    from qtop_py.qtop import update_config_with_cmdline_vars
+
+    class Args(object):
+        OPTION = []
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    assert update_config_with_cmdline_vars(Args(), {})["rem_empty_corelines"] == 0
+
+
+def test_update_config_applies_rem_empty_corelines_increment_with_default():
+    from qtop_py.qtop import update_config_with_cmdline_vars
+
+    class Args(object):
+        OPTION = []
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 2
+
+    assert update_config_with_cmdline_vars(Args(), {})["rem_empty_corelines"] == 2
+
+
 @pytest.mark.parametrize(
     "domain_name, match",
     (
@@ -236,3 +258,25 @@ def test_get_date_obj_from_str(s, now, day_meant):
     at 22:10 at night, the user inputs again 21:00 (the same day is implied)
     """
     assert get_date_obj_from_str(s, now).day == day_meant
+
+
+def test_init_dirs_accepts_source_file_path(tmp_path, monkeypatch):
+    import os
+    from qtop_py.qtop import init_dirs
+
+    source_file = tmp_path / "qstat.F.xml.stdout"
+    source_file.write_text("<job_info />")
+    savepath = tmp_path / "save"
+    savepath.mkdir()
+
+    class Args(object):
+        SOURCEDIR = str(source_file)
+
+    chdir_calls = []
+    monkeypatch.setattr(os, "chdir", chdir_calls.append)
+
+    args = init_dirs(Args(), str(savepath))
+
+    assert args.SOURCEDIR == str(tmp_path)
+    assert args.workdir == str(tmp_path)
+    assert chdir_calls == [str(tmp_path)]


### PR DESCRIPTION
## Summary
- Rebased this Challenge #5 PR onto the latest `develop` branch.
- Normalizes `-s/--SetSourceDir` when it points to an existing scheduler output file, using the parent directory before `init_dirs()` calls `chdir`.
- Defaults missing `rem_empty_corelines` config values to `0` before applying CLI overrides.
- Adds regression tests for both legacy issue paths.

## Issues addressed
- Fixes #291
- Fixes #290
- Related to #358

/claim #358

## Validation
- `PYTHONPATH=. uvx --with pytest pytest tests/test_qtop.py -q` -> 37 passed
- `python3 -m py_compile qtop_py/qtop.py tests/test_qtop.py`
- `git diff --check`

## Challenge alignment
- Target branch is `develop`.
- Patch remains a brief code-focused pack under 100 LOC.
- RHEL8/Python 3.6 compatibility was considered: this patch avoids newer syntax.
- Exact AI tool used: OpenAI Codex based on GPT-5. I used it to inspect code paths, prepare the focused patch, and run validation; I reviewed the final diff and test results.

## Screenshots
No UI output was changed. These fixes are CLI/config regression paths covered by tests.