### PR TITLE
Add Slurm plugin (#356)

### DIFF
--- a/qtop_py/contrib/sinfo.txt
+++ b/qtop_py/contrib/sinfo.txt
@@ -1,0 +1,9 @@
+wn001|alloc|short|4/0/0/4
+wn002|alloc|short|4/0/0/4
+wn003|mix*|short|2/2/0/4
+wn004|idle|short|0/4/0/4
+wn005|alloc|short|2/2/0/4
+wn010|mix|gpu|24/8/0/32
+wn011|alloc|gpu|16/16/0/32
+wn012|down*|gpu|0/0/32/32
+wn020|idle~|long|0/8/0/8

--- a/qtop_py/contrib/squeue.txt
+++ b/qtop_py/contrib/squeue.txt
@@ -1,0 +1,7 @@
+1001|short|alice|RUNNING|4|wn[001-002]
+1002|short|bob|RUNNING|2|wn003
+1003|long|carol|PENDING|8|(Resources)
+1004|short|alice|PENDING|1|(Priority)
+1005|gpu|dan|RUNNING|16|wn[010-011]
+1006|short|eve|COMPLETING|2|wn005
+1007|gpu|frank|RUNNING|8|wn010

--- a/qtop_py/plugins/slurm.py
+++ b/qtop_py/plugins/slurm.py
@@ -1,0 +1,247 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+##
+## SPDX-License-Identifier: MIT
+##
+"""
+Slurm support for qtop.
+
+Reads two scheduler-output files captured by the qtop runner:
+
+  squeue_file -- output of ``squeue -h -o '%i|%P|%u|%T|%C|%R'``
+  sinfo_file  -- output of ``sinfo -h -N -o '%N|%T|%P|%C'``
+
+The pipe separator avoids whitespace-in-fields ambiguity (job names, reasons,
+node-state qualifiers like ``mix*`` etc.) without locking us into a specific
+table-formatting width.
+
+Implementation notes
+--------------------
+
+This plugin is intentionally minimal: it follows the same StatExtractor /
+GenericBatchSystem pattern used by ``oar.py``, parses text-mode Slurm output
+(no JSON dependency on the Slurm side, since ``--json`` is optional on
+older clusters), and expands Slurm's compact node-list notation
+(``wn[001-003,005]``) into individual node names so the rest of qtop can
+treat each worker node uniformly.
+"""
+
+import logging
+import re
+
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
+
+#: Slurm job-state letters as they appear in ``squeue -h -t all``. We keep
+#: the full long form to avoid colliding with qtop's per-scheduler state map.
+SLURM_RUNNING_STATES = frozenset({"RUNNING", "COMPLETING"})
+SLURM_QUEUED_STATES = frozenset({"PENDING", "CONFIGURING"})
+
+#: Used when squeue puts a reason in the NODELIST column for pending jobs.
+_REASON_PREFIX = "("
+
+
+def expand_nodelist(nodelist):
+    """Expand Slurm's compact host-range notation into a flat list of names.
+
+    Examples::
+
+        >>> expand_nodelist("wn001")
+        ['wn001']
+        >>> expand_nodelist("wn[001-003]")
+        ['wn001', 'wn002', 'wn003']
+        >>> expand_nodelist("wn[001,003-004]")
+        ['wn001', 'wn003', 'wn004']
+        >>> expand_nodelist("(Priority)")
+        []
+        >>> expand_nodelist("")
+        []
+
+    Width-preserving: ``001`` stays zero-padded to 3 digits.
+    """
+    if not nodelist or nodelist.startswith(_REASON_PREFIX):
+        return []
+
+    m = re.match(r"^([A-Za-z][\w.-]*)\[([^\]]+)\]$", nodelist)
+    if not m:
+        # No bracket form. Either a single node or a comma-separated bare list.
+        return [n.strip() for n in nodelist.split(",") if n.strip()]
+
+    prefix = m.group(1)
+    body = m.group(2)
+    nodes = []
+    for chunk in body.split(","):
+        chunk = chunk.strip()
+        if "-" in chunk:
+            lo_s, hi_s = chunk.split("-", 1)
+            width = len(lo_s)
+            for n in range(int(lo_s), int(hi_s) + 1):
+                nodes.append("%s%s" % (prefix, str(n).zfill(width)))
+        else:
+            nodes.append("%s%s" % (prefix, chunk))
+    return nodes
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+
+class SlurmStatExtractor(StatExtractor):
+    """Parse the squeue and sinfo files written by the qtop runner."""
+
+    def __init__(self, config, options):
+        StatExtractor.__init__(self, config, options)
+        # squeue with -o '%i|%P|%u|%T|%C|%R'
+        self.squeue_re = re.compile(
+            r"^\s*"
+            r"(?P<job_id>\d+(?:_\d+)?)\|"
+            r"(?P<queue>[\w,.-]+)\|"
+            r"(?P<user>[\w.-]+)\|"
+            r"(?P<state>[A-Z_]+)\|"
+            r"(?P<cpus>\d+)\|"
+            r"(?P<nodelist>.+?)\s*$"
+        )
+        # sinfo with -N -o '%N|%T|%P|%C'
+        self.sinfo_re = re.compile(
+            r"^\s*"
+            r"(?P<node>[\w.-]+)\|"
+            r"(?P<state>[A-Za-z*~+@]+)\|"
+            r"(?P<partition>[\w,.*-]+)\|"
+            r"(?P<cpus>[\d/]+)\s*$"
+        )
+
+    def extract_squeue(self, path):
+        """Return a list of dicts, one per job in the squeue file."""
+        jobs = []
+        with open(path, "r") as f:
+            for raw_line in f:
+                line = raw_line.rstrip("\n")
+                if not line.strip():
+                    continue
+                m = self.squeue_re.match(line)
+                if not m:
+                    logging.debug(
+                        "slurm: skipping unparseable squeue line: %r", line
+                    )
+                    continue
+                jobs.append(m.groupdict())
+        return jobs
+
+    def extract_sinfo(self, path):
+        """Return a list of dicts, one per worker-node row in sinfo (-N)."""
+        nodes = []
+        with open(path, "r") as f:
+            for raw_line in f:
+                line = raw_line.rstrip("\n")
+                if not line.strip():
+                    continue
+                m = self.sinfo_re.match(line)
+                if not m:
+                    logging.debug(
+                        "slurm: skipping unparseable sinfo line: %r", line
+                    )
+                    continue
+                nodes.append(m.groupdict())
+        return nodes
+
+
+# ---------------------------------------------------------------------------
+# Public batch-system interface
+# ---------------------------------------------------------------------------
+
+
+class SLURMBatchSystem(GenericBatchSystem):
+    @staticmethod
+    def get_mnemonic():
+        return "slurm"
+
+    def __init__(self, scheduler_output_filenames, config, options):
+        GenericBatchSystem.__init__(self)
+        self.config = config
+        self.options = options
+        self.squeue_path = scheduler_output_filenames["squeue_file"]
+        self.sinfo_path = scheduler_output_filenames["sinfo_file"]
+        self._extractor = SlurmStatExtractor(config, options)
+        self._squeue_jobs = self._extractor.extract_squeue(self.squeue_path)
+        self._sinfo_rows = self._extractor.extract_sinfo(self.sinfo_path)
+
+    # ---- worker nodes ---------------------------------------------------
+
+    def get_worker_nodes(self, job_ids, job_queues, options):
+        """Return the list of {domainname, state, qname, np} dicts qtop expects."""
+        # squeue tells us which nodes each job runs on; collect job -> nodelist
+        # so we can attach running jobs to their nodes later.
+        node_to_jobs = {}
+        for j in self._squeue_jobs:
+            if j["state"] not in SLURM_RUNNING_STATES:
+                continue
+            for node in expand_nodelist(j["nodelist"]):
+                node_to_jobs.setdefault(node, []).append(j["job_id"])
+
+        nodes_out = []
+        seen = set()
+        for row in self._sinfo_rows:
+            name = row["node"]
+            if name in seen:
+                continue
+            seen.add(name)
+            # CPUS column from sinfo -N is "alloc/idle/other/total"
+            total = row["cpus"].split("/")[-1] if "/" in row["cpus"] else row["cpus"]
+            np = int(total) if total.isdigit() else 0
+            # strip trailing * (loaded) and ~ (powered down) qualifiers
+            state = row["state"].rstrip("*~+@").lower()
+            nodes_out.append(
+                {
+                    "domainname": name,
+                    "state": state,
+                    "qname": [row["partition"]],
+                    "np": np,
+                    "core_job_map": {},
+                    "existing_busy_nodes": int(bool(node_to_jobs.get(name))),
+                    "jobs": node_to_jobs.get(name, []),
+                }
+            )
+        return nodes_out
+
+    # ---- jobs -----------------------------------------------------------
+
+    def get_jobs_info(self):
+        job_ids, user_names, job_states, job_queues = [], [], [], []
+        for j in self._squeue_jobs:
+            job_ids.append(j["job_id"])
+            user_names.append(j["user"])
+            job_states.append(j["state"])
+            job_queues.append(j["queue"])
+        return job_ids, user_names, job_states, job_queues
+
+    # ---- queues ---------------------------------------------------------
+
+    def get_queues_info(self):
+        """Aggregate per-partition counts from squeue."""
+        per_partition = {}
+        for j in self._squeue_jobs:
+            slot = per_partition.setdefault(
+                j["queue"], {"queued": 0, "run": 0, "lm": 0, "state": "?"}
+            )
+            if j["state"] in SLURM_RUNNING_STATES:
+                slot["run"] += 1
+            elif j["state"] in SLURM_QUEUED_STATES:
+                slot["queued"] += 1
+            slot["state"] = "E" if (slot["run"] + slot["queued"]) > 0 else "?"
+        queues_info = []
+        for name, counts in per_partition.items():
+            queues_info.append(
+                {
+                    "queue_name": name,
+                    "state": counts["state"],
+                    "lm": counts["lm"],
+                    "run": counts["run"],
+                    "queued": counts["queued"],
+                }
+            )
+        total_run = sum(c["run"] for c in per_partition.values())
+        total_queued = sum(c["queued"] for c in per_partition.values())
+        return queues_info, total_run, total_queued

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -6,7 +6,7 @@
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
 
-## scheduler possible values (currently supported): pbs, oar, sge
+## scheduler possible values (currently supported): pbs, oar, sge, slurm
 ## auto will try to detect available batch commands in the current system
 scheduler: auto
 
@@ -28,6 +28,9 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  slurm:
+    squeue_file: %(savepath)s/squeue%(pid)s.txt, squeue -h -o '%%i|%%P|%%u|%%T|%%C|%%R'
+    sinfo_file: %(savepath)s/sinfo%(pid)s.txt, sinfo -h -N -o '%%N|%%T|%%P|%%C'
   demo:
     demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
 
@@ -36,6 +39,7 @@ signature_commands:
   pbs: pbsnodes
   oar: oarnodes
   sge: qacct
+  slurm: sinfo
   demo: echo
 
 ## Utilises lxml module. Needs to be installed in your system.

--- a/tests/plugins/test_slurm.py
+++ b/tests/plugins/test_slurm.py
@@ -1,0 +1,174 @@
+"""Tests for the Slurm plugin."""
+import os
+import unittest
+
+from qtop_py.plugins.slurm import (
+    SLURM_QUEUED_STATES,
+    SLURM_RUNNING_STATES,
+    SLURMBatchSystem,
+    SlurmStatExtractor,
+    expand_nodelist,
+)
+
+CONTRIB = os.path.join(
+    os.path.dirname(__file__), "..", "..", "qtop_py", "contrib"
+)
+
+
+class _AttrBag:
+    """Tiny stand-in for argparse.Namespace / qtop's options object.
+
+    Defaults the attributes that qtop's StatExtractor expects to read, so
+    plugin tests can spin one up without piping a full CLI namespace through.
+    """
+
+    _DEFAULTS = {"ANONYMIZE": False, "REMAP": False}
+
+    def __init__(self, **kw):
+        for k, v in self._DEFAULTS.items():
+            setattr(self, k, v)
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _make_bs():
+    return SLURMBatchSystem(
+        scheduler_output_filenames={
+            "squeue_file": os.path.join(CONTRIB, "squeue.txt"),
+            "sinfo_file": os.path.join(CONTRIB, "sinfo.txt"),
+        },
+        config={},
+        options=_AttrBag(),
+    )
+
+
+class ExpandNodelistTests(unittest.TestCase):
+    def test_single_node(self):
+        self.assertEqual(expand_nodelist("wn001"), ["wn001"])
+
+    def test_range(self):
+        self.assertEqual(
+            expand_nodelist("wn[001-003]"),
+            ["wn001", "wn002", "wn003"],
+        )
+
+    def test_mixed_range_and_singles(self):
+        self.assertEqual(
+            expand_nodelist("wn[001,003-004]"),
+            ["wn001", "wn003", "wn004"],
+        )
+
+    def test_reason_is_empty(self):
+        self.assertEqual(expand_nodelist("(Priority)"), [])
+        self.assertEqual(expand_nodelist("(Resources)"), [])
+
+    def test_blank_is_empty(self):
+        self.assertEqual(expand_nodelist(""), [])
+        self.assertEqual(expand_nodelist(None), [])
+
+    def test_width_preserved(self):
+        # 4-digit zero-pad must be preserved
+        self.assertEqual(
+            expand_nodelist("node[0008-0010]"),
+            ["node0008", "node0009", "node0010"],
+        )
+
+
+class JobsInfoTests(unittest.TestCase):
+    def test_all_jobs_parsed(self):
+        bs = _make_bs()
+        ids, users, states, queues = bs.get_jobs_info()
+        # Sample file has 7 rows.
+        self.assertEqual(len(ids), 7)
+        self.assertIn("alice", users)
+        self.assertIn("RUNNING", states)
+        self.assertIn("PENDING", states)
+        self.assertIn("short", queues)
+        self.assertIn("gpu", queues)
+
+
+class QueuesInfoTests(unittest.TestCase):
+    def test_aggregates_match_sample(self):
+        bs = _make_bs()
+        queues_info, total_run, total_queued = bs.get_queues_info()
+        names = {q["queue_name"] for q in queues_info}
+        self.assertEqual(names, {"short", "long", "gpu"})
+        # 4 running (1001, 1002, 1005, 1006, 1007) - actually 5 RUNNING + 1 COMPLETING
+        self.assertEqual(total_run, 5)
+        # 2 pending
+        self.assertEqual(total_queued, 2)
+
+
+class WorkerNodesTests(unittest.TestCase):
+    def test_sinfo_nodes_collected(self):
+        bs = _make_bs()
+        nodes = bs.get_worker_nodes(job_ids=[], job_queues=[], options=_AttrBag())
+        names = [n["domainname"] for n in nodes]
+        # Sample sinfo has 9 distinct nodes
+        self.assertEqual(len(names), 9)
+        self.assertIn("wn001", names)
+        self.assertIn("wn020", names)
+
+    def test_node_state_strips_qualifier(self):
+        bs = _make_bs()
+        nodes = bs.get_worker_nodes(job_ids=[], job_queues=[], options=_AttrBag())
+        by_name = {n["domainname"]: n for n in nodes}
+        # wn003 is "mix*" -> "mix"
+        self.assertEqual(by_name["wn003"]["state"], "mix")
+        # wn020 is "idle~" -> "idle"
+        self.assertEqual(by_name["wn020"]["state"], "idle")
+
+    def test_running_jobs_attach_to_nodes(self):
+        bs = _make_bs()
+        nodes = bs.get_worker_nodes(job_ids=[], job_queues=[], options=_AttrBag())
+        by_name = {n["domainname"]: n for n in nodes}
+        # Job 1001 RUNNING on wn[001-002] -> both nodes mention it
+        self.assertIn("1001", by_name["wn001"]["jobs"])
+        self.assertIn("1001", by_name["wn002"]["jobs"])
+        # Job 1003 PENDING -> no node attribution
+        for n in nodes:
+            self.assertNotIn("1003", n["jobs"])
+
+    def test_cpu_count_takes_total(self):
+        bs = _make_bs()
+        nodes = bs.get_worker_nodes(job_ids=[], job_queues=[], options=_AttrBag())
+        by_name = {n["domainname"]: n for n in nodes}
+        # "4/0/0/4" -> 4
+        self.assertEqual(by_name["wn001"]["np"], 4)
+        # "24/8/0/32" -> 32
+        self.assertEqual(by_name["wn010"]["np"], 32)
+
+
+class ExtractorRobustnessTests(unittest.TestCase):
+    def test_extractor_skips_blank_lines(self, tmpdir=None):
+        # Write a small ad-hoc file alongside the contrib dir
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as f:
+            f.write("\n")  # blank
+            f.write("1234|short|alice|RUNNING|4|wn001\n")
+            f.write("garbage line that won't match\n")
+            f.write("1235|short|bob|PENDING|2|(Priority)\n")
+            path = f.name
+        try:
+            ext = SlurmStatExtractor(config={}, options=_AttrBag())
+            rows = ext.extract_squeue(path)
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["user"], "alice")
+            self.assertEqual(rows[1]["state"], "PENDING")
+        finally:
+            os.unlink(path)
+
+
+class ConstantsTests(unittest.TestCase):
+    def test_state_sets_are_frozen(self):
+        # We export read-only state buckets so callers can pattern-match.
+        self.assertIn("RUNNING", SLURM_RUNNING_STATES)
+        self.assertIn("COMPLETING", SLURM_RUNNING_STATES)
+        self.assertIn("PENDING", SLURM_QUEUED_STATES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Implements a Slurm plugin for qtop, addressing #356 (Challenge #3).

This is an alternative implementation to PR #361 (`@asiokun`). The maintainer can pick whichever fits the project direction better. Notable design differences from #361:

- **Single-file plugin** at `qtop_py/plugins/slurm.py` (~210 lines), patterned after `oar.py` rather than `pbs.py` since Slurm's text output is closer in shape to OAR than to PBS.
- **Pipe-separated** `squeue`/`sinfo` formats (`%i|%P|%u|%T|%C|%R` and `%N|%T|%P|%C`) instead of whitespace tables. Avoids ambiguity with job names that contain spaces, partition lists, and node-state qualifiers (`mix*`, `idle~`) without forcing fixed column widths.
- **Width-preserving node-list expansion** (`wn[0008-0010]` → `wn0008, wn0009, wn0010`).
- 14 unit tests covering: node-list expansion (single, range, mixed, reason placeholder, blank, width), squeue parsing, queue aggregation, sinfo parsing with state-qualifier stripping, CPU-total extraction from the `alloc/idle/other/total` field, running-job attribution to worker nodes, blank-line and garbage-line tolerance.

The maintainer is free to pick whichever PR (this one or #361) better matches the project direction; both can serve as reference, and the test patterns from either can fold into the merge candidate.

## Files added

- `qtop_py/plugins/slurm.py` — plugin
- `qtop_py/contrib/squeue.txt` — sample squeue output (7 jobs across 3 partitions, mix of RUNNING / PENDING / COMPLETING)
- `qtop_py/contrib/sinfo.txt` — sample sinfo output (9 nodes across 3 partitions, mix of alloc / idle / mix / down with various state qualifiers)
- `tests/plugins/test_slurm.py` — 14 unit tests covering parser robustness, the GenericBatchSystem contract, and the node-list expander

## Files modified

- `qtopconf.yaml` — register `slurm` in:
  - the documentation comment listing supported schedulers
  - the `schedulers:` block (with `squeue_file` and `sinfo_file` command templates)
  - the `signature_commands:` block (using `sinfo` to detect a Slurm-equipped host)

## Test evidence

```
python -m pytest tests/plugins/test_slurm.py -v
# 14 passed

python -m ruff check qtop_py/plugins/slurm.py tests/plugins/test_slurm.py
# All checks passed
```

A note on the full suite: this branch is off `develop` directly, which has a pre-existing import-time issue on non-Linux dev machines (`from signal import SIGPIPE`). PR #395 (also from me, against issue #355) fixes that and several other modernization items so the full pytest suite collects on a Windows dev machine. The Slurm plugin itself does not depend on those changes — it imports cleanly on its own (`tests/plugins/test_slurm.py` collects and runs independently).

## Targeting

PR is filed against `develop` per the issue's instruction.

## DCO

Commit is signed off (`Signed-off-by:` trailer present).

## AI-assisted disclosure

Per `CONTRIBUTING.md`'s AI-assisted-contributions clause: this patch was prepared with significant assistance from an AI coding assistant. I read every change, validated it locally, and am responsible for the submission. Happy to answer questions about any specific design choice.
