### PR TITLE
Add Slurm scheduler support with trace fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-pbs-samples
+.PHONY: test test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -10,3 +10,6 @@ test:
 
 test-pbs-samples:
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+
+test-slurm-samples:
+	$(PYTHON) -m pytest tests/plugins/test_slurm.py

--- a/qtop_py/plugins/__init__.py
+++ b/qtop_py/plugins/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["oar", "pbs", "sge", "demo"]
+__all__ = ["oar", "pbs", "sge", "slurm", "demo"]

--- a/qtop_py/plugins/slurm.py
+++ b/qtop_py/plugins/slurm.py
@@ -1,0 +1,222 @@
+import logging
+import re
+from collections import defaultdict
+
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
+
+
+RUNNING_STATES = {"R", "CG", "CF", "RUNNING", "COMPLETING", "CONFIGURING"}
+QUEUED_STATES = {"PD", "PENDING"}
+SLURM_STATE_ALIASES = {
+    "RUNNING": "R",
+    "PENDING": "PD",
+    "COMPLETING": "CG",
+    "CONFIGURING": "CF",
+    "FAILED": "F",
+    "CANCELLED": "CA",
+    "CANCELED": "CA",
+    "SUSPENDED": "S",
+    "TIMEOUT": "TO",
+}
+
+
+class SlurmStatExtractor(StatExtractor):
+    def extract_squeue(self, orig_file):
+        jobs = []
+        with open(orig_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                try:
+                    job_id, queue, user, state, cpus, nodes = line.split("|", 5)
+                except ValueError:
+                    logging.warning("Skipping unparsable Slurm squeue line: %s" % line)
+                    continue
+
+                user = self.anonymize(user, "users")
+                state = self.normalize_job_state(state)
+                jobs.append(
+                    {
+                        "JobId": job_id,
+                        "Queue": queue.rstrip("*"),
+                        "UnixAccount": user,
+                        "S": state,
+                        "CPUs": int(cpus or 0),
+                        "Nodes": nodes,
+                    }
+                )
+        return jobs
+
+    @staticmethod
+    def normalize_job_state(state):
+        state = state.strip().upper()
+        return SLURM_STATE_ALIASES.get(state, state)
+
+
+class SlurmBatchSystem(GenericBatchSystem):
+    @staticmethod
+    def get_mnemonic():
+        return "slurm"
+
+    def __init__(self, scheduler_output_filenames, config, options):
+        self.squeue_file = scheduler_output_filenames.get("squeue_file")
+        self.sinfo_file = scheduler_output_filenames.get("sinfo_file")
+        self.config = config
+        self.options = options
+        self.slurm_stat_maker = SlurmStatExtractor(self.config, self.options)
+
+    def get_jobs_info(self):
+        job_ids, usernames, job_states, queue_names = [], [], [], []
+        for qstat in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            job_ids.append(qstat["JobId"])
+            usernames.append(qstat["UnixAccount"])
+            job_states.append(qstat["S"])
+            queue_names.append(qstat["Queue"])
+        return job_ids, usernames, job_states, queue_names
+
+    def get_queues_info(self):
+        queue_stats = defaultdict(lambda: {"queue_name": "", "run": 0, "queued": 0, "lm": "--", "state": "E R"})
+        for job in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            queue = job["Queue"]
+            queue_stats[queue]["queue_name"] = queue
+            if job["S"] in RUNNING_STATES:
+                queue_stats[queue]["run"] += 1
+            elif job["S"] in QUEUED_STATES:
+                queue_stats[queue]["queued"] += 1
+
+        qstatq_list = list(queue_stats.values())
+        total_running_jobs = sum(queue["run"] for queue in qstatq_list)
+        total_queued_jobs = sum(queue["queued"] for queue in qstatq_list)
+        return total_running_jobs, total_queued_jobs, qstatq_list
+
+    def get_worker_nodes(self, job_ids, job_queues, options):
+        worker_nodes = self._read_sinfo_nodes(self.sinfo_file)
+        nodes_by_name = {node["domainname"]: node for node in worker_nodes}
+
+        for job in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            if job["S"] not in RUNNING_STATES:
+                continue
+            target_nodes = expand_slurm_nodelist(job["Nodes"])
+            if not target_nodes:
+                continue
+
+            remaining_cpus = max(job["CPUs"], 1)
+            target_count = len(target_nodes)
+            while remaining_cpus:
+                made_progress = False
+                for node_name in target_nodes:
+                    node = nodes_by_name.setdefault(node_name, self._empty_node(node_name, job["Queue"]))
+                    self._append_job_to_next_core(node, job["JobId"])
+                    remaining_cpus -= 1
+                    made_progress = True
+                    if not remaining_cpus:
+                        break
+                if not made_progress or target_count == 0:
+                    break
+
+        worker_nodes = list(nodes_by_name.values())
+        return self.ensure_worker_nodes_have_qnames(worker_nodes, job_ids, job_queues)
+
+    def _read_sinfo_nodes(self, sinfo_file):
+        nodes = []
+        anonymize = self.slurm_stat_maker.anonymize_func()
+        with open(sinfo_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                try:
+                    node_name, state, queue, cpus = line.split("|", 3)
+                except ValueError:
+                    logging.warning("Skipping unparsable Slurm sinfo line: %s" % line)
+                    continue
+                domainname = node_name if not self.options.ANONYMIZE else anonymize(node_name, "wns")
+                nodes.append(
+                    {
+                        "domainname": domainname,
+                        "state": map_slurm_node_state(state),
+                        "np": parse_slurm_cpu_total(cpus),
+                        "core_job_map": {},
+                        "qname": [queue.rstrip("*")],
+                    }
+                )
+        return nodes
+
+    @staticmethod
+    def _empty_node(node_name, queue):
+        return {"domainname": node_name, "state": "b", "np": 1, "core_job_map": {}, "qname": [queue]}
+
+    @staticmethod
+    def _append_job_to_next_core(node, job_id):
+        core_job_map = node["core_job_map"]
+        next_core = len(core_job_map)
+        if next_core >= int(node["np"]):
+            node["np"] = next_core + 1
+        core_job_map[next_core] = job_id
+
+
+def parse_slurm_cpu_total(cpu_field):
+    try:
+        return int(cpu_field.split("/")[-1])
+    except (IndexError, ValueError):
+        return 0
+
+
+def map_slurm_node_state(state):
+    state = state.lower().split("+", 1)[0].rstrip("*~#")
+    if state in {"idle"}:
+        return "-"
+    if state in {"alloc", "allocated"}:
+        return "b"
+    if state in {"mix", "mixed"}:
+        return "%"
+    if state.startswith("drain"):
+        return "d"
+    if state.startswith("down") or state in {"fail", "failing"}:
+        return "d"
+    if state in {"comp", "completing"}:
+        return "c"
+    return state[:1] or "-"
+
+
+def expand_slurm_nodelist(nodelist):
+    if not nodelist or nodelist.startswith("("):
+        return []
+
+    expanded = []
+    for part in _split_top_level_commas(nodelist):
+        match = re.match(r"^(?P<prefix>[^\[]+)\[(?P<inner>[^\]]+)\]$", part)
+        if not match:
+            expanded.append(part)
+            continue
+
+        prefix = match.group("prefix")
+        for item in match.group("inner").split(","):
+            if "-" in item:
+                start, end = item.split("-", 1)
+                width = max(len(start), len(end))
+                for value in range(int(start), int(end) + 1):
+                    expanded.append("%s%s" % (prefix, str(value).zfill(width)))
+            else:
+                expanded.append("%s%s" % (prefix, item))
+    return expanded
+
+
+def _split_top_level_commas(value):
+    parts = []
+    buf = []
+    depth = 0
+    for char in value:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+            continue
+        buf.append(char)
+    if buf:
+        parts.append("".join(buf))
+    return parts

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -6,7 +6,7 @@
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
 
-## scheduler possible values (currently supported): pbs, oar, sge
+## scheduler possible values (currently supported): pbs, oar, sge, slurm
 ## auto will try to detect available batch commands in the current system
 scheduler: auto
 
@@ -28,6 +28,9 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  slurm:
+    squeue_file: %(savepath)s/squeue%(pid)s.txt, squeue -h -o '%i|%P|%u|%T|%C|%R'
+    sinfo_file: %(savepath)s/sinfo%(pid)s.txt, sinfo -h -N -o '%N|%T|%P|%C'
   demo:
     demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
 
@@ -36,6 +39,7 @@ signature_commands:
   pbs: pbsnodes
   oar: oarnodes
   sge: qacct
+  slurm: sinfo
   demo: echo
 
 ## Utilises lxml module. Needs to be installed in your system.
@@ -97,6 +101,15 @@ state_abbreviations:
     Rq: queued_of_user
     Rt: transferring_of_user
     Rr: running_of_user    
+  slurm:
+    R: running_of_user
+    PD: queued_of_user
+    CG: exiting_of_user
+    CF: waiting_of_user
+    CA: cancelled_of_user
+    F: failed_of_user
+    TO: expired_of_user
+    S: suspended_of_user
   demo:
     Q: queued_of_user
     R: running_of_user
@@ -270,12 +283,12 @@ workernodes_matrix:
      yaml_key: state
      label: Node state
      max_len: 5
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - queue name:
      yaml_key: qname
      label: queue name
      max_len: 13
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - core_user_map:
      options1: {}
      options2: {}

--- a/tests/inputs/slurm_sinfo_1.txt
+++ b/tests/inputs/slurm_sinfo_1.txt
@@ -1,0 +1,4 @@
+node001|mixed|batch*|2/2/0/4
+node002|allocated|batch*|4/0/0/4
+node003|completing|debug|1/3/0/4
+node004|idle|debug|0/4/0/4

--- a/tests/inputs/slurm_sinfo_2.txt
+++ b/tests/inputs/slurm_sinfo_2.txt
@@ -1,0 +1,3 @@
+gpu01|alloc|compute|8/0/0/8
+gpu02|mix|compute|4/4/0/8
+gpu03|drain|long|0/8/0/8

--- a/tests/inputs/slurm_sinfo_3.txt
+++ b/tests/inputs/slurm_sinfo_3.txt
@@ -1,0 +1,3 @@
+rack-a7|idle|short|0/16/0/16
+rack-a8|down|short|0/0/16/16
+rack-b01|allocated|short|1/15/0/16

--- a/tests/inputs/slurm_squeue_1.txt
+++ b/tests/inputs/slurm_squeue_1.txt
@@ -1,0 +1,3 @@
+101|batch|alice|RUNNING|4|node[001-002]
+102|batch|bob|PENDING|2|(Resources)
+103|debug|carol|COMPLETING|1|node003

--- a/tests/inputs/slurm_squeue_2.txt
+++ b/tests/inputs/slurm_squeue_2.txt
@@ -1,0 +1,3 @@
+201|compute|dana|R|8|gpu[01-02]
+202|compute|erin|PD|1|(Priority)
+203|long|frank|SUSPENDED|2|gpu03

--- a/tests/inputs/slurm_squeue_3.txt
+++ b/tests/inputs/slurm_squeue_3.txt
@@ -1,0 +1,3 @@
+301|short|gina|CONFIGURING|1|rack-a[7-8],rack-b01
+302|short|hank|FAILED|1|(NonZeroExitCode)
+303|batch|irene|CANCELLED|1|(JobHeldUser)

--- a/tests/plugins/test_slurm.py
+++ b/tests/plugins/test_slurm.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+import pytest
+
+from qtop_py.plugins.slurm import (
+    SlurmBatchSystem,
+    SlurmStatExtractor,
+    expand_slurm_nodelist,
+    map_slurm_node_state,
+    parse_slurm_cpu_total,
+)
+
+
+INPUTS = Path(__file__).parents[1] / "inputs"
+
+
+class Options:
+    ANONYMIZE = False
+
+
+@pytest.mark.parametrize(
+    "nodelist, expected",
+    (
+        ("node001", ["node001"]),
+        ("node[001-003,005]", ["node001", "node002", "node003", "node005"]),
+        ("rack-a[7-8],rack-b01", ["rack-a7", "rack-a8", "rack-b01"]),
+        ("(Resources)", []),
+    ),
+)
+def test_expand_slurm_nodelist(nodelist, expected):
+    assert expand_slurm_nodelist(nodelist) == expected
+
+
+@pytest.mark.parametrize(
+    "cpu_field, expected",
+    (
+        ("2/2/0/4", 4),
+        ("8", 8),
+        ("", 0),
+    ),
+)
+def test_parse_slurm_cpu_total(cpu_field, expected):
+    assert parse_slurm_cpu_total(cpu_field) == expected
+
+
+@pytest.mark.parametrize(
+    "state, expected",
+    (
+        ("idle", "-"),
+        ("allocated", "b"),
+        ("mix*", "%"),
+        ("drain", "d"),
+        ("down", "d"),
+        ("completing", "c"),
+    ),
+)
+def test_map_slurm_node_state(state, expected):
+    assert map_slurm_node_state(state) == expected
+
+
+def test_extract_squeue_normalizes_states_and_fields():
+    extractor = SlurmStatExtractor({}, Options())
+
+    jobs = extractor.extract_squeue(str(INPUTS / "slurm_squeue_1.txt"))
+
+    assert jobs == [
+        {"JobId": "101", "Queue": "batch", "UnixAccount": "alice", "S": "R", "CPUs": 4, "Nodes": "node[001-002]"},
+        {"JobId": "102", "Queue": "batch", "UnixAccount": "bob", "S": "PD", "CPUs": 2, "Nodes": "(Resources)"},
+        {"JobId": "103", "Queue": "debug", "UnixAccount": "carol", "S": "CG", "CPUs": 1, "Nodes": "node003"},
+    ]
+
+
+@pytest.mark.parametrize("case_id", (1, 2, 3))
+def test_slurm_batch_system_reads_trace_cases(case_id):
+    batch = SlurmBatchSystem(
+        {
+            "squeue_file": str(INPUTS / "slurm_squeue_%s.txt" % case_id),
+            "sinfo_file": str(INPUTS / "slurm_sinfo_%s.txt" % case_id),
+        },
+        {},
+        Options(),
+    )
+
+    job_ids, usernames, job_states, queue_names = batch.get_jobs_info()
+    worker_nodes = batch.get_worker_nodes(job_ids, queue_names, Options())
+    total_running, total_queued, queue_info = batch.get_queues_info()
+
+    assert len(job_ids) == 3
+    assert len(usernames) == 3
+    assert len(job_states) == 3
+    assert len(queue_names) == 3
+    assert worker_nodes
+    assert all("domainname" in node for node in worker_nodes)
+    assert all("core_job_map" in node for node in worker_nodes)
+    assert total_running >= 1
+    assert total_queued >= 0
+    assert queue_info
+
+
+def test_running_slurm_jobs_are_mapped_to_nodes():
+    batch = SlurmBatchSystem(
+        {
+            "squeue_file": str(INPUTS / "slurm_squeue_1.txt"),
+            "sinfo_file": str(INPUTS / "slurm_sinfo_1.txt"),
+        },
+        {},
+        Options(),
+    )
+
+    job_ids, _, _, queues = batch.get_jobs_info()
+    nodes = {node["domainname"]: node for node in batch.get_worker_nodes(job_ids, queues, Options())}
+
+    assert set(nodes["node001"]["core_job_map"].values()) == {"101"}
+    assert set(nodes["node002"]["core_job_map"].values()) == {"101"}
+    assert set(nodes["node003"]["core_job_map"].values()) == {"103"}
+    assert nodes["node004"]["core_job_map"] == {}


### PR DESCRIPTION
/claim #356
/opire try

## Summary
- Add a Slurm scheduler plugin using controlled `squeue` and `sinfo` trace output.
- Register Slurm in plugin discovery, scheduler config, signatures, and worker-node matrix config.
- Add three Slurm trace fixture pairs covering running, pending, completing, suspended, failed, cancelled, mixed, drained, down, and idle states.
- Add focused tests for Slurm nodelist expansion, state mapping, queue summaries, and worker-node job placement.

## Testing
- `python -m pytest tests/plugins/test_slurm.py -q` could not run locally because `pytest` is not installed.
- Python compile check passed.
- Manual `SlurmBatchSystem` smoke check passed.
