### PR TITLE
bugfix: default missing empty coreline config

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -761,7 +761,7 @@ def get_output_size(max_line_len, output_fp, max_height=0):
 
 
 def update_config_with_cmdline_vars(args, config):
-    config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
+    config["rem_empty_corelines"] = int(config.get("rem_empty_corelines", 0))
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
         val = eval(val) if ("True" in val or "False" in val) else val

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,12 +12,40 @@ import pytest
 import re
 import datetime
 import sys
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import (
+    WNOccupancy,
+    decide_batch_system,
+    load_yaml_config,
+    JobNotFound,
+    SchedulerNotSpecified,
+    NoSchedulerFound,
+    get_date_obj_from_str,
+    update_config_with_cmdline_vars,
+)
 
 
 @pytest.fixture
 def config():
     return {}
+
+
+class CmdlineArgs(object):
+    OPTION = []
+    TRANSPOSE = False
+    REM_EMPTY_CORELINES = 0
+
+
+def test_update_config_defaults_missing_rem_empty_corelines():
+    args = CmdlineArgs()
+
+    assert update_config_with_cmdline_vars(args, {})["rem_empty_corelines"] == 0
+
+
+def test_update_config_applies_rem_empty_corelines_increment_with_default():
+    args = CmdlineArgs()
+    args.REM_EMPTY_CORELINES = 2
+
+    assert update_config_with_cmdline_vars(args, {})["rem_empty_corelines"] == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Default missing `rem_empty_corelines` config values to `0` before applying CLI overrides
- Add regression coverage for legacy/minimal configs without that option

Fixes #290

## Validation
- `PYTHONPATH=. uvx --with pytest pytest tests/test_qtop.py -q`
- `python3 -m py_compile qtop_py/qtop.py tests/test_qtop.py`
- `git diff --check`

## AI disclosure
I used OpenAI Codex to inspect the code path, make this small fix, and run the validation commands.