### PR TITLE
20260522: fix: accept PBS qstat special job names

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -12,11 +12,12 @@ try:
     import ujson as json
 except ImportError:
     import json
+import itertools
 import logging
 import re
-from qtop_py.serialiser import StatExtractor, GenericBatchSystem
+
 import qtop_py.fileutils as fileutils
-import itertools
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
 
 
 class PBSStatExtractor(StatExtractor):
@@ -24,8 +25,8 @@ class PBSStatExtractor(StatExtractor):
         StatExtractor.__init__(self, config, options)
         self.user_q_search = (
             r"^(?P<host_name>(?P<job_id>[0-9\[\]-]+)\.(?P<domain>[\w*-]+))\s+"
-            r"(?P<name>[\w%.=+/{}*-]+)\s+"
-            r"(?P<user>[A-Za-z0-9.*]+)\s+"
+            r"(?P<name>[\w#&@%:.=+/${}*-]+)\s+"
+            r"(?P<user>[\w.*-]+)\s+"
             r"(?P<time>\d+:\d*:?\d*\*?|0)\s+"
             r"(?P<state>[BCEFHMQRSTUWX])\s+"
             r"(?P<queue_name>\w+)"

--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -42,6 +42,22 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
     ]
 
 
+def test_pbs_qstat_regex_accepts_special_job_names(tmp_path):
+    qstat_file = tmp_path / "qstat.txt"
+    qstat_file.write_text(
+        "Job id           Name             User             Time Use S Queue\n"
+        "---------------- ---------------- ---------------- -------- - -----\n"
+        "807140.delta     Lambda&S10       haotian.teng     22:41:42 R gpu\n"
+        "1507877.delta    compile_sim_${h  i.xxxxxx         0 H normal\n"
+    )
+    extractor = PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+
+    assert extractor._extract_qstat_regex(str(qstat_file)) == [
+        {"JobId": "807140", "UnixAccount": "haotian.teng", "S": "R", "Queue": "gpu"},
+        {"JobId": "1507877", "UnixAccount": "i.xxxxxx", "S": "H", "Queue": "normal"},
+    ]
+
+
 def test_decide_remapping_handles_mixed_numeric_and_named_nodes():
     cluster = qtop.Cluster.__new__(qtop.Cluster)
     cluster.total_wn = 2


### PR DESCRIPTION
## Summary

- widen the PBS `qstat` regex so job names containing characters reported in #303, such as `&` and `$`, are not dropped
- allow hyphenated Unix account names in the same parser path
- add a regression test with the `Lambda&S10` and `compile_sim_${h` examples from the old issue discussion

## Bounty / issue context

This is a small code-only fix for an older pre-2026-05-15 issue, matching the allowed path described in qtop challenge #358.

/claim #358

Closes #303.

## Challenge #358 alignment

- Base branch: `develop`
- Rebased on current `origin/develop` after maintainer feedback on 2026-05-22
- Code size: 2 files, 21 insertions, 4 deletions, under the 100 LOC cap
- Compatibility: implementation uses only Python syntax compatible with the existing parser path; no Python 3.7+ syntax was introduced
- DCO: commit is signed off

## Tests

- `python3 -m pytest tests/test_pbs_sample_regressions.py tests/plugins/test_pbs.py -q` -> 16 passed
- `python3 -m pytest -q` -> 94 passed
- `/tmp/qtop-ruff-venv/bin/python -m ruff check qtop_py/plugins/pbs.py tests/test_pbs_sample_regressions.py` -> passed with project-pinned `ruff==0.0.292`
- `python3 -m compileall -q qtop_py tests/test_pbs_sample_regressions.py` -> passed
- `git diff --check origin/develop...HEAD` -> passed

Note: full-repo `ruff check .` currently reports pre-existing issues outside this PR's changed files, so I kept the ruff validation scoped to the files changed here to avoid mixing unrelated cleanup into this <100 LOC fix.

## AI disclosure

AI assistance was used via OpenAI Codex, a GPT-5-based coding agent, to inspect the issue, prepare the patch, rebase/respond to maintainer feedback, and draft this PR text. I reviewed the diff and validated it with the tests above.
