### PR TITLE
Prepare qtop codebase for future challenge testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -56,7 +56,7 @@ class SGEStatExtractor(StatExtractor):
             try:
                 all_values = self._extract_job_info(all_values, queue_elem, "job_list", queue_name=queue_name_elem.text)
             except ValueError:
-                logging.warn("No jobs found in XML file!")
+                logging.warning("No jobs found in XML file!")
 
         # look for the remaining, pending jobs, found later in the xml file
         job_info_elem = root.find("./job_info")
@@ -66,7 +66,7 @@ class SGEStatExtractor(StatExtractor):
             try:
                 all_values = self._extract_job_info(all_values, job_info_elem, "job_list", queue_name="Pending")
             except ValueError:
-                logging.warn("No jobs found in XML file!")
+                logging.warning("No jobs found in XML file!")
 
         return all_values
 
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/serialiser.py
+++ b/qtop_py/serialiser.py
@@ -36,7 +36,7 @@ class StatExtractor(object):
         try:
             job_id, user, job_state, queue = [m.group(x) for x in re_match_positions]
         except AttributeError:
-            logging.warn("Line: %s not properly parsed by regex expression. Assuming alternative qstat format." % line.strip())
+            logging.warning("Line: %s not properly parsed by regex expression. Assuming alternative qstat format." % line.strip())
             raise
         job_id = job_id.split(".")[0]
         user = self.anonymize(user, "users")


### PR DESCRIPTION
## Summary

This PR addresses part of #355 by preparing the codebase for the follow-up challenges and making local testing cleaner for contributors.

Changes included:

- remove the obsolete Travis CI configuration that only targeted Python 2.6/2.7
- modernize the Ruff pre-commit configuration format and version
- clean `MANIFEST.in` by removing entries for files that are no longer present in the repository
- replace direct `eval(config[key])` usage in config parsing with `ast.literal_eval(...)`
- remove unnecessary `eval(str(...))` conversions in the PBS and SGE queue totals
- replace deprecated `logging.warn(...)` calls with `logging.warning(...)`

## Test evidence

Current environment:

```console
$ PYTHONPATH=. pytest -q
90 passed in 0.10s
```

Python 3.12 compatibility check:

```console
$ python3.12 -m venv .venv312
$ PYTHONPATH=. .venv312/bin/python -m pip install -q pytest
$ PYTHONPATH=. .venv312/bin/python -m pytest -q
90 passed in 0.12s
```

Diff sanity check:

```console
$ git diff --check
# no output
```

## Notes

I kept the scope intentionally small and aligned with the issue request. The broader remaining `eval(...)` usages around configured regexes/lambdas/sort expressions appear to need a more careful design pass, so I did not change them in this PR.
