### PR TITLE
Prepare qtop maintenance tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,5 @@ include ROADMAP.rst
 
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
 recursive-include tests *.py
+recursive-include docs *.rst *.md *.png
+recursive-include tools *.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtop.py [![Build Status](https://travis-ci.org/qtop/qtop.svg)](https://travis-ci.org/qtop/qtop) ![python versions](https://img.shields.io/badge/python-2.5%2C%202.6%2C%202.7-blue.svg)
+# qtop.py
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
 ]
-requires-python = ">=3"
+requires-python = ">=3.6"
 
 [project.urls]
 "Homepage" = "https://github.com/qtop/qtop"
@@ -35,8 +33,8 @@ packages = ["qtop_py"]
 lint.select = ["E", "F", "I"] ##
 lint.ignore = ["E722"]
 
-# Assuming you're developing for Python 3.10
-target-version = "py310" ##
+# Keep lint suggestions compatible with the oldest supported runtime.
+target-version = "py36" ##
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -772,7 +772,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = literal_config_value(val) if ("True" in val or "False" in val) else val
         config[key] = val
 
     if args.TRANSPOSE:

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,7 +12,7 @@ import pytest
 import re
 import datetime
 import sys
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str, update_config_with_cmdline_vars
 
 
 @pytest.fixture
@@ -59,6 +59,20 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_cmdline_option_does_not_execute_boolean_values(tmp_path):
+    class Args:
+        OPTION = ["overwrite_sample_file=False or __import__('pathlib').Path(%r).touch()" % str(tmp_path / "executed")]
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    config = {"rem_empty_corelines": "0"}
+
+    updated = update_config_with_cmdline_vars(Args(), config)
+
+    assert updated["overwrite_sample_file"] == Args.OPTION[0].split("=", 1)[1]
+    assert not (tmp_path / "executed").exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- update the Ruff pre-commit hook and remove the obsolete Travis CI file/badge
- clean `MANIFEST.in` so the source distribution references current files instead of removed paths
- replace targeted config literal `eval(...)` usage with `ast.literal_eval` handling and add regression coverage

## Verification
- `.venv/bin/python -m pytest` -> 96 passed
- `.venv312/bin/python -m pytest` -> 96 passed
- `.venv312/bin/python -m build --sdist` -> succeeds
- source distribution install smoke test: `pip install dist/qtop-0.9.20260515.tar.gz` and `qtop --version`
- `.venv312/bin/pre-commit validate-config`
- Python 3.6 syntax parse check with `ast.parse(feature_version=(3, 6))`
- `git diff --check`

## Notes
- Targets the `develop` branch and addresses maintenance items from #355.
- AI assistance was used for implementation support; I reviewed the changes and validation results before submitting.

Signed-off-by: Taka <syorinji5@gmail.com>