### PR TITLE
chore: modernize packaging and config parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
    - repo: https://github.com/astral-sh/ruff-pre-commit
      # Ruff version.
-     rev: v0.0.292
+     rev: v0.15.13
      hooks:
        - id: ruff
-         args: [--fix] ##
+         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
 ]
-requires-python = ">=3"
+requires-python = ">=3.10"
 
 [project.urls]
 "Homepage" = "https://github.com/qtop/qtop"
@@ -27,16 +25,24 @@ qtop = "qtop_py.qtop:main"
 [tool.setuptools.dynamic]
 version = {attr = "qtop_py.__version__"}
 
-[tool.setuptools]
-packages = ["qtop_py"]
+[tool.setuptools.packages.find]
+include = ["qtop_py*"]
+
+[tool.setuptools.package-data]
+"*" = [
+    "contrib/*",
+    "inputs/*",
+    "web/*",
+    "qtop.sh",
+]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-lint.select = ["E", "F", "I"] ##
+lint.select = ["E", "F", "I"]
 lint.ignore = ["E722"]
 
 # Assuming you're developing for Python 3.10
-target-version = "py310" ##
+target-version = "py310"
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -26,10 +26,18 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import SIG_DFL, signal
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -47,6 +55,11 @@ from qtop_py.serialiser import GenericBatchSystem
 from qtop_py.web import Web
 from qtop_py import __version__
 import time
+
+
+def reset_sigpipe():
+    if SIGPIPE is not None:
+        signal(SIGPIPE, SIG_DFL)
 
 
 # TODO make the following work with py files instead of qtop.colormap files
@@ -305,8 +318,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -772,7 +784,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = literal_config_value(val) if val in ("True", "False") else val
         config[key] = val
 
     if args.TRANSPOSE:
@@ -1688,7 +1700,7 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        reset_sigpipe()
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1711,7 +1723,7 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        reset_sigpipe()
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:


### PR DESCRIPTION
## Summary

Addresses part of #355 by modernizing project maintenance metadata and removing a few legacy Python 2 / unsafe parsing leftovers.

Changes included:
- remove the obsolete Travis CI Python 2 configuration
- update the Ruff pre-commit hook version
- fix pyproject.toml metadata to use the existing README, require Python 3.10+, and use package discovery
- simplify MANIFEST.in and remove references to files that no longer exist
- replace several unnecessary eval() calls with ast.literal_eval() or direct integer conversion
- make import-time behavior more portable by handling missing SIGPIPE / termios
- replace hardcoded /usr/bin/which scheduler detection with shutil.which

## Validation

- python -m pytest
  - 90 passed, 6 warnings
- python -m build
  - sdist and wheel built successfully
- git diff --check
  - passed

## Notes

AI assistance was used to prepare this maintenance patch. I reviewed and validated the resulting changes locally.