### PR TITLE
chore: modernize packaging and test setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.md
 include helpfile.txt
 include Makefile
 include MANIFEST.in
+include pyproject.toml
 include LICENSE
 include qtopconf.yaml
 include qtop
@@ -11,3 +12,5 @@ include ROADMAP.rst
 
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
 recursive-include tests *.py
+recursive-include docs *.rst *.md *.png
+recursive-include tools *.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtop.py [![Build Status](https://travis-ci.org/qtop/qtop.svg)](https://travis-ci.org/qtop/qtop) ![python versions](https://img.shields.io/badge/python-2.5%2C%202.6%2C%202.7-blue.svg)
+# qtop.py [![pytest-qtop](https://github.com/qtop/qtop/actions/workflows/pytest.yml/badge.svg)](https://github.com/qtop/qtop/actions/workflows/pytest.yml)
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
@@ -27,8 +25,8 @@ qtop = "qtop_py.qtop:main"
 [tool.setuptools.dynamic]
 version = {attr = "qtop_py.__version__"}
 
-[tool.setuptools]
-packages = ["qtop_py"]
+[tool.setuptools.packages.find]
+include = ["qtop_py", "qtop_py.*"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -21,6 +21,7 @@ here = sys.path[0]
 from operator import itemgetter
 from itertools import zip_longest, cycle, chain
 import subprocess
+import shutil
 import select
 import os
 import re
@@ -28,8 +29,16 @@ import json
 import datetime
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import SIG_DFL, signal
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
+TERMIO_ERROR = termios.error if termios is not None else OSError
 import contextlib
 import glob
 import tempfile
@@ -88,6 +97,11 @@ def literal_config_value(value):
         return value
 
 
+def reset_sigpipe():
+    if SIGPIPE is not None:
+        signal(SIGPIPE, SIG_DFL)
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -137,7 +151,7 @@ def raw_mode(file):
     if args.ONLYSAVETOFILE:
         yield
     else:
-        if args.WATCH:
+        if args.WATCH and termios is not None:
             try:
                 old_attrs = termios.tcgetattr(file.fileno())
             except:
@@ -305,11 +319,9 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
-            if system != "demo":
-                logging.debug("Auto-detected scheduler: %s" % system)
-                return system
+        if system != "demo" and shutil.which(batch_command):
+            logging.debug("Auto-detected scheduler: %s" % system)
+            return system
 
     raise SchedulerNotSpecified
 
@@ -772,8 +784,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -1688,7 +1699,7 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        reset_sigpipe()
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1711,7 +1722,7 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        reset_sigpipe()
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2320,7 +2331,7 @@ def main():
     if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
         try:
             old_attrs = termios.tcgetattr(0)
-        except termios.error:
+        except (AttributeError, TERMIO_ERROR):
             old_attrs = ""
         new_attrs = old_attrs[:]
 

--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -1,18 +1,22 @@
 from collections import OrderedDict
-from types import SimpleNamespace
 
 from qtop_py import qtop
 from qtop_py.plugins.pbs import PBSStatExtractor
 
 
+class Attrs:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
 def test_find_matrices_width_handles_empty_worker_nodes():
-    qtop.cluster = SimpleNamespace(highest_wn=0, workernode_list=[])
-    qtop.viewport = SimpleNamespace(h_term_size=80)
+    qtop.cluster = Attrs(highest_wn=0, workernode_list=[])
+    qtop.viewport = Attrs(h_term_size=80)
     qtop.config = {
         "workernodes_matrix": [{"wn id lines": {"min_masking_threshold": 30}}],
         "USER_CUT_MATRIX_WIDTH": None,
     }
-    qtop.args = SimpleNamespace(NOMASKING=False, REMAP=False)
+    qtop.args = Attrs(NOMASKING=False, REMAP=False)
 
     occupancy = qtop.WNOccupancy.__new__(qtop.WNOccupancy)
 
@@ -21,7 +25,7 @@ def test_find_matrices_width_handles_empty_worker_nodes():
 
 def test_general_attribute_lines_handle_empty_worker_node_dict():
     occupancy = qtop.WNOccupancy.__new__(qtop.WNOccupancy)
-    occupancy.cluster = SimpleNamespace(workernode_dict={})
+    occupancy.cluster = Attrs(workernode_dict={})
     config = {"scheduler": "pbs", "workernodes_matrix": [{"state": {"max_len": 1}}]}
 
     assert occupancy.calc_general_mult_attr_line("state", "state", config) == OrderedDict()
@@ -35,7 +39,7 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
         "this line does not match either supported qstat format\n"
         "1234.server      myjob            alice            00:01:00 R workq\n"
     )
-    extractor = PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+    extractor = PBSStatExtractor({}, Attrs(ANONYMIZE=False))
 
     assert extractor._extract_qstat_regex(str(qstat_file)) == [
         {"JobId": "1234", "UnixAccount": "alice", "S": "R", "Queue": "workq"}
@@ -45,7 +49,7 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
 def test_decide_remapping_handles_mixed_numeric_and_named_nodes():
     cluster = qtop.Cluster.__new__(qtop.Cluster)
     cluster.total_wn = 2
-    cluster.args = SimpleNamespace(BLINDREMAP=False)
+    cluster.args = Attrs(BLINDREMAP=False)
     cluster.node_subclusters = {"wn"}
     cluster.workernode_list = [1, "trueno_ita"]
     cluster.offdown_nodes = 0


### PR DESCRIPTION
## Summary
- remove obsolete Travis/Python 2 badges from the README and point at the GitHub Actions pytest workflow
- modernize the Ruff pre-commit config and pyproject packaging metadata
- clean the source distribution manifest to include pyproject, docs, and helper tools
- replace one command-line config eval path with literal parsing
- make qtop import/test collection work on platforms without SIGPIPE or termios and use shutil.which for scheduler auto-detection
- replace SimpleNamespace in PBS regression tests with a small local attribute helper

## Verification
- python -m pytest tests -p no:cacheprovider --basetemp=.pytest_tmp_escalated2
- python -m build
- python -m ruff check tests\\test_pbs_sample_regressions.py

Ruff on qtop_py/qtop.py still reports pre-existing broad issues such as E402/F405/F841 around the module-level layout and legacy globals; this PR keeps those outside scope.

AI assistance was used to help prepare and validate this maintenance change.

Refs #355