### PR TITLE
fix: use Python 3 input for interactive prompts

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -541,13 +541,13 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
 
         dynamic_config["user_sort"] = []
         while True:
-            sort_choice = raw_input(
+            sort_choice = input(
                 "\nChoose sorting order, or Enter to exit:-> ",
             )
             if not sort_choice:
                 break
             if custom_choice in sort_choice:
-                custom = raw_input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
+                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
                 sort_map[custom_choice][1].append(custom)
 
             try:
@@ -606,7 +606,7 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
 
         dynamic_config["filtering"] = []
         while True:
-            filter_choice = raw_input(
+            filter_choice = input(
                 "\nChoose Filter command, or Enter to exit:-> ",
             )
             if not filter_choice:
@@ -622,7 +622,7 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
 
             filter_args = []
             while True:
-                user_input = raw_input("\nEnter argument, or Enter to exit:-> ")
+                user_input = input("\nEnter argument, or Enter to exit:-> ")
                 if not user_input:
                     break
                 filter_args.append(user_input)
@@ -660,7 +660,7 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
 
         dynamic_config["highlight"] = []
         while True:
-            filter_choice = raw_input(
+            filter_choice = input(
                 "\nChoose Highlight command, or Enter to exit:-> ",
             )
             if not filter_choice:
@@ -676,7 +676,7 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
 
             filter_args = []
             while True:
-                user_input = raw_input("\nEnter argument, or Enter to exit:-> ")
+                user_input = input("\nEnter argument, or Enter to exit:-> ")
                 if not user_input:
                     break
                 filter_args.append(user_input)


### PR DESCRIPTION
## Summary
- replace the remaining Python 2 `raw_input(...)` calls in interactive sort/filter/highlight prompts with Python 3 `input(...)`
- keep the prompt text and dynamic config behavior unchanged

## Why
`develop` already targets Python 3, but these interactive branches still raise `NameError` on Python 3.6+ whenever a user opens the runtime sort/filter/highlight prompts. This is a small Python 3 compatibility cleanup for #355 without overlapping the larger Travis/MANIFEST/pre-commit/eval work in other PRs.

## Validation
- `python -m py_compile qtop_py/qtop.py` passed on Python 3.13.3
- `ast.parse(..., feature_version=(3, 6))` passed for `qtop_py/qtop.py`
- `rg -n "raw_input" qtop_py/qtop.py` returned no matches
- `python -m pytest tests/test_yaml_parser.py -q` passed: 24 passed
- `python -m pytest -q` on Windows is still blocked before tests run by the existing POSIX-only import issue: `ImportError: cannot import name 'SIGPIPE' from 'signal'`. I left that out of scope because separate open PRs already address it.

AI assistance disclosure: OpenAI Codex / GPT-5 helped prepare the patch and PR text; I reviewed the diff and validation output before submitting.