### PR TITLE
Prepare maintenance baseline for future challenges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,8 @@
-include CHANGELOG.rst
-include CONTRIBUTING.md
-include helpfile.txt
-include Makefile
-include MANIFEST.in
-include LICENSE
-include qtopconf.yaml
-include qtop
-include README.md
-include ROADMAP.rst
+include CHANGELOG.rst CONTRIBUTING.md helpfile.txt LICENSE Makefile qtop qtopconf.yaml README.md ROADMAP.rst
 
-recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
+recursive-include qtop_py/contrib *.gif *.ref *.sh *.stdout *.txt
+recursive-include qtop_py/inputs *.jdl *.sh
+recursive-include qtop_py/web *.html
 recursive-include tests *.py
+
+global-exclude __pycache__ *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtop.py [![Build Status](https://travis-ci.org/qtop/qtop.svg)](https://travis-ci.org/qtop/qtop) ![python versions](https://img.shields.io/badge/python-2.5%2C%202.6%2C%202.7-blue.svg)
+# qtop.py [![pytest-qtop](https://github.com/qtop/qtop/actions/workflows/pytest.yml/badge.svg)](https://github.com/qtop/qtop/actions/workflows/pytest.yml) ![python versions](https://img.shields.io/badge/python-3.6--3.12-blue.svg)
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
 ]
-requires-python = ">=3"
+requires-python = ">=3.6"
 
 [project.urls]
 "Homepage" = "https://github.com/qtop/qtop"
@@ -28,15 +26,14 @@ qtop = "qtop_py.qtop:main"
 version = {attr = "qtop_py.__version__"}
 
 [tool.setuptools]
-packages = ["qtop_py"]
+packages = ["qtop_py", "qtop_py.plugins", "qtop_py.ui"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 lint.select = ["E", "F", "I"] ##
 lint.ignore = ["E722"]
 
-# Assuming you're developing for Python 3.10
-target-version = "py310" ##
+target-version = "py37" ##
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -26,10 +26,18 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import SIG_DFL, signal
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -134,7 +142,7 @@ def raw_mode(file):
     Taken from http://stackoverflow.com/questions/11918999/key-listeners-in-python/11919074#11919074
     Exits program with ^C or ^D
     """
-    if args.ONLYSAVETOFILE:
+    if args.ONLYSAVETOFILE or termios is None:
         yield
     else:
         if args.WATCH:
@@ -305,8 +313,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -772,8 +779,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -1688,7 +1694,8 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        if SIGPIPE is not None:
+            signal(SIGPIPE, SIG_DFL)
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1711,7 +1718,8 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        if SIGPIPE is not None:
+                            signal(SIGPIPE, SIG_DFL)
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2318,10 +2326,13 @@ def main():
         print("Anonymize should be ran with --experimental switch!! Exiting...")
         sys.exit(1)
     if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
-        try:
-            old_attrs = termios.tcgetattr(0)
-        except termios.error:
+        if termios is None:
             old_attrs = ""
+        else:
+            try:
+                old_attrs = termios.tcgetattr(0)
+            except termios.error:
+                old_attrs = ""
         new_attrs = old_attrs[:]
 
     available_batch_systems = discover_qtop_batch_systems()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,5 @@ setup(
     url="https://github.com/qtop/qtop",
     packages=find_packages(include=["qtop_py", "qtop_py.*"]),
     include_package_data=True,
-    python_requires=">=3",
-    entry_points={"console_scripts": ["qtop=qtop_py.qtop:main"]},
+    python_requires=">=3.6",
 )

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,7 +12,7 @@ import pytest
 import re
 import datetime
 import sys
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str, update_config_with_cmdline_vars
 
 
 @pytest.fixture
@@ -58,6 +58,32 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["transpose_wn_matrices"] is True
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
+    assert not sentinel.exists()
+
+
+def test_update_config_with_cmdline_vars_does_not_eval_values(tmp_path):
+    class Args:
+        OPTION = []
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    sentinel = tmp_path / "executed"
+    dangerous_value = "__import__('pathlib').Path(%r).touch() or True" % str(sentinel)
+    Args.OPTION = [
+        "overwrite_sample_file=" + dangerous_value,
+        "faster_xml_parsing=True",
+        "vertical_separator_every_X_columns=3",
+    ]
+    config = {
+        "rem_empty_corelines": "0",
+        "transpose_wn_matrices": False,
+    }
+
+    update_config_with_cmdline_vars(Args(), config)
+
+    assert config["overwrite_sample_file"] == dangerous_value
+    assert config["faster_xml_parsing"] is True
+    assert config["vertical_separator_every_X_columns"] == 3
     assert not sentinel.exists()
 
 


### PR DESCRIPTION
## Summary

Addresses qtop/qtop#355 by preparing a small maintenance baseline for future challenges:

- replaces the stale Travis/Python 2 README badges with the current GitHub Actions pytest badge and Python 3.6-3.12 support badge
- modernizes the Ruff pre-commit config from the legacy `v0.0.292` hook format to the current `repos:` format and `v0.15.13`
- cleans `MANIFEST.in` so source distributions include the intended data/test files while excluding cache/bytecode artifacts
- aligns package metadata around `README.md`, Python `>=3.6`, and explicit subpackages for modern builds
- removes unsafe `eval` usage in command-line config overrides and queue total coercion
- improves import-time portability for Windows test collection by guarding Unix-only `SIGPIPE` and `termios`

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q`
  - `94 passed, 6 warnings`
- Python 3.6 syntax parse check using `ast.parse(..., feature_version=(3, 6))`
  - passed
- `python setup.py check --metadata --strict`
  - passed, with existing setuptools beta warning for `[tool.setuptools]`
- `python setup.py sdist`
  - passed; verified plugin and UI packages are included in the generated sdist
- `git diff --check`
  - passed

## Notes

Ruff's current documented `target-version` values start at `py37`, so this keeps package metadata at `>=3.6`, uses `target-version = "py37"` for Ruff, and includes an explicit Python 3.6 syntax parse check as compatibility evidence.

AI assistance was used to inspect the codebase and prepare the patch; I reviewed the changes and ran the validation above.
