### PR TITLE
Hardening config overrides and packaging metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,11 @@ include qtop
 include README.md
 include ROADMAP.rst
 
-recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
+recursive-include qtop_py/contrib *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
+recursive-include qtop_py/inputs *.sh *.jdl
+recursive-include qtop_py/web *.html
 recursive-include tests *.py
+recursive-include docs *.rst *.md *.png
+recursive-include tools *.py
+
+global-exclude __pycache__ *.py[cod] .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtop.py [![Build Status](https://travis-ci.org/qtop/qtop.svg)](https://travis-ci.org/qtop/qtop) ![python versions](https://img.shields.io/badge/python-2.5%2C%202.6%2C%202.7-blue.svg)
+# qtop.py
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ dynamic = ["version"]
 description = """
     qtop: the fast text mode way to monitor your cluster's utilization and status;
     the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
 ]
-requires-python = ">=3"
+requires-python = ">=3.6"
 
 [project.urls]
 "Homepage" = "https://github.com/qtop/qtop"

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -772,8 +772,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     url="https://github.com/qtop/qtop",
     packages=find_packages(include=["qtop_py", "qtop_py.*"]),
     include_package_data=True,
-    python_requires=">=3",
+    python_requires=">=3.6",
     entry_points={"console_scripts": ["qtop=qtop_py.qtop:main"]},
 )

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -8,11 +8,13 @@
 ## SPDX-License-Identifier: MIT
 ##
 
-import pytest
-import re
 import datetime
+import re
 import sys
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+
+import pytest
+
+from qtop_py.qtop import WNOccupancy, decide_batch_system, get_date_obj_from_str, JobNotFound, load_yaml_config, NoSchedulerFound, SchedulerNotSpecified, update_config_with_cmdline_vars
 
 
 @pytest.fixture
@@ -59,6 +61,26 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_update_config_with_cmdline_vars_does_not_execute_option_values(tmp_path):
+    class Args:
+        OPTION = [
+            "transpose_wn_matrices=True",
+            "vertical_separator_every_X_columns=12",
+            "overwrite_sample_file=__import__('pathlib').Path(%r).touch() or False" % str(tmp_path / "executed"),
+        ]
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    config = {"rem_empty_corelines": "0"}
+
+    config = update_config_with_cmdline_vars(Args(), config)
+
+    assert config["transpose_wn_matrices"] is True
+    assert config["vertical_separator_every_X_columns"] == 12
+    assert config["overwrite_sample_file"].startswith("__import__")
+    assert not (tmp_path / "executed").exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Refs #355.
- Replace the remaining command-line config override `eval` path with the existing `literal_config_value` parser.
- Add regression coverage proving malicious option values are preserved as strings instead of executed, while booleans and integers still parse.
- Remove stale Python 2 / Travis README badges, align package metadata on Python 3.6+, fix the missing `README.md` pyproject reference, modernize the Ruff pre-commit config, and tighten MANIFEST package-data includes.

## Verification

- `.venv/bin/python -m pytest -q` -> 94 passed, 6 warnings on Python 3.12.13
- `.venv311/bin/python -m pytest -q` -> 94 passed, 7 warnings on Python 3.11.6
- `PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache39 /usr/bin/python3 -m compileall -q qtop_py tests tools setup.py` -> passed on Python 3.9.6
- `python3.11 -m compileall -q qtop_py tests tools setup.py` -> passed
- `python3.12 -m compileall -q qtop_py tests tools setup.py` -> passed
- `.venv/bin/python setup.py check -m -s` -> passed
- `HOME=/private/tmp/qtop-home .venv/bin/python tools/validate_pbs_samples.py /private/tmp/qtop-test-repo/qtop5/results --limit 10 --output /private/tmp/qtop-pbs-golden-10` -> validated=10
- `HOME=/private/tmp/qtop-home .venv/bin/python tools/validate_pbs_samples.py /private/tmp/qtop-test-repo/qtop5/results --limit 100 --output /private/tmp/qtop-pbs-rendered-100` -> validated=100

## Notes

AI assistance was used for discovery, implementation, and local verification. I reviewed the touched code and kept the patch scoped to issue #355 acceptance criteria.
