### PR TITLE
20260523: add editor defaults and PR guidance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## Summary
+## Related
+Refs #
+## Validation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,13 @@ name: build-qtop
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
       - 'releases/**'
   pull_request:
-    branches:    
-      - master
+    branches:
+      - main
+      - develop
 
 jobs:
   build-project:
@@ -19,7 +21,7 @@ jobs:
           python-version: '3.10'
       - run: pip install build twine
       - run: pyproject-build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: qtop-dist
           path: dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292 ## Please do not bump the version unless you provide proof of rhel8/python3.6 compatibility
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.292 ## Please do not bump the version unless you provide proof of rhel8/python3.6 compatibility
+    hooks:
+      - id: ruff
+        args: [--fix] ##

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ You may contribute in the following ways:
 * Help with outreach and onboard new contributors by assisting them directly
 * Write and/or lead collaborations proposals, including grants or other fundraising or help with community efforts
 
-## Branching And Release Flow
+## Branching, Releases, And Pull Requests
 
 Please keep the branch flow lightweight:
 
@@ -37,6 +37,10 @@ Please keep the branch flow lightweight:
 - Use short-lived topic branches named after the issue or change, for example `fix-327-branching-docs`.
 - Use `releases/*` branches only when preparing or stabilizing a release.
 - Keep release notes in the PR body until the maintainer decides they belong in `CHANGELOG.rst`.
+- Keep pull requests small and focused on one concern.
+- Avoid unrelated reformatting or generated artifacts.
+- Include the reasoning and validation needed for review.
+- Run the relevant build and test checks before asking for review.
 
 [1] https://wiki.linuxfoundation.org/dco
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ You may contribute in the following ways:
 * Help with outreach and onboard new contributors by assisting them directly
 * Write and/or lead collaborations proposals, including grants or other fundraising or help with community efforts
 
+## Branching And Release Flow
+
+Please keep the branch flow lightweight:
+
+- Open ordinary feature, fix, documentation, and challenge PRs against `develop`.
+- Keep `main` for reviewed release-ready snapshots.
+- Use short-lived topic branches named after the issue or change, for example `fix-327-branching-docs`.
+- Use `releases/*` branches only when preparing or stabilizing a release.
+- Keep release notes in the PR body until the maintainer decides they belong in `CHANGELOG.rst`.
+
 [1] https://wiki.linuxfoundation.org/dco
 
 [2] https://developercertificate.org/

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -4,6 +4,7 @@ qtop.py guide
 -  `Introduction <#introduction>`__
 -  `Quickstart <#quickstart>`__
 -  `Demo case study <#demo-case-study>`__
+-  `Bundled scheduler case studies <#bundled-scheduler-case-studies>`__
 -  `Output walkthrough <#output-walkthrough>`__
 -  `Watchmode <#watch-mode>`__
 -  `Instant Replay <#instant-replay>`__
@@ -123,6 +124,20 @@ For an interactive session, use watch mode. The optional value after
 While in watch mode, the movement keys from `Keyboard
 shortcuts <#keyboard-shortcuts>`__ let you move through the matrix,
 transpose it, switch node ID display, apply filters, or quit.
+
+Bundled scheduler case studies
+------------------------------
+
+The ``qtop_py/contrib`` directory contains captured scheduler snapshots
+for quick checks without access to a live cluster:
+
+::
+
+    ./qtop -s qtop_py/contrib -c ON -Fadvv -b sge
+    ./qtop -s qtop_py/contrib -c ON -Frdvvv -b oar
+    ./qtop -s qtop_py/contrib -c ON -raF -b pbs
+
+Use ``-s`` for saved scheduler files and ``-b`` for the matching parser.
 
 Output walkthrough
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,20 @@ packages = ["qtop_py"]
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 lint.select = ["E", "F", "I"] ##
-lint.ignore = ["E722"]
+lint.ignore = ["E722", "I001"]
 
-# Assuming you're developing for Python 3.10
-target-version = "py310" ##
+# Ruff v0.0.292 cannot target Python 3.6; use its lowest supported target.
+target-version = "py37" ##
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths
+
+[tool.ruff.per-file-ignores]
+"qtop_py/plugins/oar.py" = ["F401"]
+"qtop_py/plugins/sge.py" = ["F401", "F841"]
+"qtop_py/qtop.py" = ["E402", "F401", "F403", "F405", "F841"]
+"qtop_py/serialiser.py" = ["F401"]
+"qtop_py/utils.py" = ["F403"]
+"tests/test_qtop.py" = ["F401", "F841"]
+"tests/test_yaml_parser.py" = ["F401"]
+"tests/ui/test_viewport.py" = ["F811"]

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1573,7 +1573,6 @@ class TextDisplay(object):
                 colorize(num_of_nodes, pattern=userid_pat),
                 sep=colorize(config["SEPARATOR"], pattern=userid_pat),
                 width1=1 + conditional_width,
-                width3=3 + conditional_width,
                 width4=4 + conditional_width,
                 width5=5 + conditional_width,
                 width18=18 + conditional_width,

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -156,6 +156,7 @@ def read_yaml_config_block(line, fin, get_lines):
     parent_container = block
     open_containers = list()
     open_containers.append(block)
+    key_value = {}
 
     # if len(line) > 1:  # non-empty line
     #     key_value, parent_container = process_line(line, fin, get_lines, parent_container)
@@ -171,7 +172,7 @@ def read_yaml_config_block(line, fin, get_lines):
     while len(line) > 1:  # as long as a blank line is not reached (i.e. block is not complete)
         # if line[0] == 0 or (line[0] != 0 and line[1] == '-'):  # same level
         # key_value used below belongs to previous line. It will work for first block line because of short circuit logic
-        if line[0] == 0 or (line[0] == 1 and (next(iter(key_value)) == "-")) or (line[0] == -1 and line[1] == "-"):  # same level or entry level
+        if line[0] == 0 or (line[0] == 1 and key_value and (next(iter(key_value)) == "-")) or (line[0] == -1 and line[1] == "-"):  # same level or entry level
             key_value, container = process_line(line, fin, get_lines, parent_container)
             for k in key_value:
                 pass  # assign dict's sole key to k


### PR DESCRIPTION
This updates #411 after Fotis pointed out the five-issue requirement in #358.

The PR now handles five previous issues in one small patch:

- #154: adds root editor defaults and keeps PR guidance focused.
- #327: documents a lightweight branch/release flow and aligns CI branch filters.
- #328: adds bundled SGE/OAR/PBS scheduler case-study commands to the docs.
- #330: fixes the malformed pre-commit config, sets the lowest ruff target supported by ruff 0.0.292, keeps a narrow legacy lint baseline, and fixes two small ruff findings.
- #331: adds a minimal pull request template without duplicating the issue-template work already open in #389.

I left #333 alone because #389 already covers the CODE_OF_CONDUCT file.

Closes #154
Closes #327
Closes #328
Addresses #330
Addresses #331
/claim #358

Validated locally:

python3.11 -m pytest -q
python3.11 -m ruff check .
git diff --check upstream/develop
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); YAML.load_file(".pre-commit-config.yaml")'
/tmp/qtop-build-venv/bin/pyproject-build --outdir /tmp/qtop-build-out
/tmp/qtop-install-venv/bin/qtop --help
docker run --rm -v "$PWD":/work -w /work python:3.6 bash -lc 'python --version && python -m compileall -q qtop_py tests tools && PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Fadvv -b sge >/tmp/sge.out && PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -raF -b pbs >/tmp/pbs.out && PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Frdvvv -b oar >/tmp/oar.out'
PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Fadvv -b sge
PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -raF -b pbs
PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Frdvvv -b oar

The three sample renders are here:

SGE:
![SGE render](https://gist.githubusercontent.com/JohnChen034/a8454f1f46158bdda54cffca4db15c32/raw/484bff60d808630704caeb19fafb3a3bd5eb82e3/sge.svg)

PBS:
![PBS render](https://gist.githubusercontent.com/JohnChen034/a8454f1f46158bdda54cffca4db15c32/raw/c702d912d61ef2cb5f108957c9d1fab83a4bdade/pbs.svg)

OAR:
![OAR render](https://gist.githubusercontent.com/JohnChen034/a8454f1f46158bdda54cffca4db15c32/raw/967430a4225df83f7bb7f85f0ace987f2e7319ab/oar.svg)

RHEL8/Python 3.6 note: the Docker smoke run used `python:3.6` / Python 3.6.15 for compileall plus the SGE/PBS/OAR bundled samples. Ruff 0.0.292 cannot target Python 3.6 directly, so the config uses its lowest supported target, `py37`, while leaving the pinned ruff version unchanged.

Diff size: 77 insertions, 16 deletions.

AI assistance: OpenAI Codex in Codex desktop, GPT-5.5, assisted with issue review, patch preparation, and validation. I reviewed the final diff and validation output.

Assisted using Codex.
