### PR TITLE
Add shared editor defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This adds a small root .editorconfig so the basic editor defaults are written down in the repo instead of being left to each local setup.

It keeps normal text files on LF/UTF-8 with final newlines, trims trailing whitespace, keeps YAML on 2 spaces, and leaves Makefile recipes on tabs. No runtime behavior changes.

Closes #154
/claim #358

Validated with:

git diff --check origin/develop...HEAD
/Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pytest -q

Assisted using Codex.
