### PR TITLE
20260522: docs: triage poolMappings issue closeout

### DIFF
--- a/docs/poolmappings-issue-closeout-2026-05.md
+++ b/docs/poolmappings-issue-closeout-2026-05.md
@@ -1,0 +1,25 @@
+# poolMappings issue closeout notes, 2026-05
+
+Candidate resolution paths for Challenge #358:
+
+- #98: re-test `-G` with a missing `user_details_cache`; close if current
+  config validation logs a warning instead of raising `NoneType.split`,
+  otherwise add a tiny guard around the pool-mapping detail command.
+- #210: split into three decisions. The top summary already reports
+  total/up/free nodes and pool mappings already include per-user node counts;
+  keep only the queue-level node availability request open as a focused follow-up.
+- #299: avoid per-user shelling from the display loop. If this is still wanted,
+  add an optional cached group lookup beside GECOS with a fixture-backed test;
+  otherwise close as a stale site-local customization.
+- #303: add one PBS parser fixture for a job name containing `&` and close once
+  the qstat line no longer logs an unexpected-character parse error.
+- #304: re-check ANSI background mappings with a small color fixture; close if
+  current output is stable, otherwise fix width accounting for background-color
+  escape sequences only.
+
+Suggested order: #304, #303, #98, #210, then #299. That path starts with
+the narrowest verification tasks, keeps runtime changes reviewable, and leaves
+larger feature decisions until the stale reports have fresh evidence.
+
+Current sample-run evidence was collected on PBS, OAR, and SGE contrib data and
+attached to the PR discussion rather than committed to the main repository.


### PR DESCRIPTION
## Summary
- refresh the Challenge #358 closeout note so it covers five older issues: #98, #210, #299, #303, and #304
- propose focused resolution paths without changing runtime code
- keep the repository change documentation-only and under the 100 LOC challenge limit

## Challenge alignment
- PR branch is rebased onto `qtop/qtop:develop` at `7f5c6c3`
- PR base remains `develop`
- added line count: 25 LOC in one Markdown file
- screenshots/evidence are kept outside the main repo per `CONTRIBUTING.md`

## Three cluster good-run screenshots
PBS contrib sample, qtop `v0.9.20260515`, Python `3.12.3`:

![PBS good run](https://raw.githubusercontent.com/KLSGG/qtop-artifacts/codex/qtop-413-evidence/pr-413/qtop-pbs-goodrun.png)

OAR contrib sample, qtop `v0.9.20260515`, Python `3.12.3`:

![OAR good run](https://raw.githubusercontent.com/KLSGG/qtop-artifacts/codex/qtop-413-evidence/pr-413/qtop-oar-goodrun.png)

SGE contrib sample, qtop `v0.9.20260515`, Python `3.12.3`:

![SGE good run](https://raw.githubusercontent.com/KLSGG/qtop-artifacts/codex/qtop-413-evidence/pr-413/qtop-sge-goodrun.png)

Artifact notes and text captures: https://github.com/KLSGG/qtop-artifacts/tree/codex/qtop-413-evidence/pr-413

## Verification
- `git diff --check origin/develop...HEAD`
- `git diff --numstat origin/develop...HEAD` -> `25 0 docs/poolmappings-issue-closeout-2026-05.md`
- `python3 -m qtop_py.cli -c ON -s qtop_py/contrib -raF -b pbs` -> passed on WSL Ubuntu / Python 3.12.3
- `python3 -m qtop_py.cli -c ON -s qtop_py/contrib -Fardvvv -b oar` -> passed on WSL Ubuntu / Python 3.12.3
- `python3 -m qtop_py.cli -s qtop_py/contrib -c ON -Fadvv -b sge` -> passed on WSL Ubuntu / Python 3.12.3
- `python3 -m ruff check .` not run: this WSL image has no `pip`/`ruff` installed; the PR only changes Markdown
- `python3 -m pytest -q` not run: this WSL image has no `pip`/`pytest` installed; the PR only changes Markdown
- Python 3.6/RHEL8 note: no local Python 3.6 interpreter is available here; this PR introduces no runtime Python code or syntax

## AI disclosure
OpenAI Codex / GPT-5 in Codex Desktop assisted with issue triage, drafting, and verification notes on 2026-05-20 and 2026-05-22. I reviewed the final change before submission.

/claim #358