### PR TITLE
Prepare qtop test and packaging setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,23 +3,25 @@ name: build-qtop
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
       - 'releases/**'
   pull_request:
-    branches:    
-      - master
+    branches:
+      - main
+      - develop
 
 jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v3
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,26 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - run: pip install pytest
       - run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.pytest_cache/
 *.py[cod]
 *$py.class
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include CHANGELOG.rst
 include CONTRIBUTING.md
 include helpfile.txt
-include Makefile
 include MANIFEST.in
 include LICENSE
 include qtopconf.yaml
@@ -9,5 +8,6 @@ include qtop
 include README.md
 include ROADMAP.rst
 
+recursive-include docs *.rst *.png
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
 recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
@@ -27,16 +25,17 @@ qtop = "qtop_py.qtop:main"
 [tool.setuptools.dynamic]
 version = {attr = "qtop_py.__version__"}
 
-[tool.setuptools]
-packages = ["qtop_py"]
+[tool.setuptools.packages.find]
+include = ["qtop_py*"]
 
 [tool.ruff]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-lint.select = ["E", "F", "I"] ##
-lint.ignore = ["E722"]
-
 # Assuming you're developing for Python 3.10
 target-version = "py310" ##
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths
+
+[tool.ruff.lint]
+# Enable pycodestyle (`E`), Pyflakes (`F`), and import sorting (`I`) codes by default.
+select = ["E", "F", "I"] ##
+ignore = ["E722"]

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -19,6 +19,10 @@ import qtop_py.fileutils as fileutils
 import itertools
 
 
+def _parse_job_count(value):
+    return int(str(value).strip())
+
+
 class PBSStatExtractor(StatExtractor):
     def __init__(self, config, options):
         StatExtractor.__init__(self, config, options)
@@ -317,7 +321,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return _parse_job_count(total_running_jobs), _parse_job_count(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -10,6 +10,10 @@ from xml.etree import ElementTree as etree
 import qtop_py.fileutils as fileutils
 
 
+def _parse_job_count(value):
+    return int(str(value).strip())
+
+
 class SGEStatExtractor(StatExtractor):
     def __init__(self, config, options, scheduler_output_filenames):
         StatExtractor.__init__(self, config, options)
@@ -56,7 +60,7 @@ class SGEStatExtractor(StatExtractor):
             try:
                 all_values = self._extract_job_info(all_values, queue_elem, "job_list", queue_name=queue_name_elem.text)
             except ValueError:
-                logging.warn("No jobs found in XML file!")
+                logging.warning("No jobs found in XML file!")
 
         # look for the remaining, pending jobs, found later in the xml file
         job_info_elem = root.find("./job_info")
@@ -66,7 +70,7 @@ class SGEStatExtractor(StatExtractor):
             try:
                 all_values = self._extract_job_info(all_values, job_info_elem, "job_list", queue_name="Pending")
             except ValueError:
-                logging.warn("No jobs found in XML file!")
+                logging.warning("No jobs found in XML file!")
 
         return all_values
 
@@ -132,7 +136,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, _parse_job_count(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -28,12 +28,20 @@ import json
 import datetime
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import signal, SIG_DFL
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
 import logging
+import shutil
 from ast import literal_eval
 from qtop_py.constants import SYSTEMCONFDIR, QTOPCONF_YAML, QTOP_LOGFILE, USERPATH, MAX_CORE_ALLOWED, MAX_UNIX_ACCOUNTS, KEYPRESS_TIMEOUT, FALLBACK_TERMSIZE
 from qtop_py import fileutils
@@ -88,6 +96,11 @@ def literal_config_value(value):
         return value
 
 
+def reset_sigpipe_handler():
+    if SIGPIPE is not None:
+        signal(SIGPIPE, SIG_DFL)
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -134,7 +147,7 @@ def raw_mode(file):
     Taken from http://stackoverflow.com/questions/11918999/key-listeners-in-python/11919074#11919074
     Exits program with ^C or ^D
     """
-    if args.ONLYSAVETOFILE:
+    if args.ONLYSAVETOFILE or termios is None:
         yield
     else:
         if args.WATCH:
@@ -259,7 +272,7 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
     else:
-        logging.warn("Failed to autodetect terminal size. (Running in an IDE?in a pipe?) Trying values in %s." % QTOPCONF_YAML)
+        logging.warning("Failed to autodetect terminal size. (Running in an IDE?in a pipe?) Trying values in %s." % QTOPCONF_YAML)
         try:
             term_height, term_columns = viewport.get_term_size()
             if not all(term_height, term_columns):
@@ -305,8 +318,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -772,7 +784,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = literal_config_value(val)
         config[key] = val
 
     if args.TRANSPOSE:
@@ -789,7 +801,7 @@ def attempt_faster_xml_parsing(config):
         try:
             from lxml import etree
         except ImportError:
-            logging.warn('Module lxml is missing. Try issuing "pip install lxml". Reverting to xml module.')
+            logging.warning('Module lxml is missing. Try issuing "pip install lxml". Reverting to xml module.')
             from xml.etree import ElementTree as etree
 
 
@@ -1170,7 +1182,7 @@ class WNOccupancy(object):
         min_len = min(user_max_len, real_max_len)
         max_len = max(user_max_len, real_max_len)
         if real_max_len > user_max_len:
-            logging.warn("Some longer %(attr)ss have been cropped due to %(attr)s length restriction by user" % {"attr": part_name})
+            logging.warning("Some longer %(attr)ss have been cropped due to %(attr)s length restriction by user" % {"attr": part_name})
 
         # initialisation of lines
         multiline_map = OrderedDict()
@@ -1688,7 +1700,7 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        reset_sigpipe_handler()
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1711,7 +1723,7 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        reset_sigpipe_handler()
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2010,7 +2022,7 @@ class Cluster(object):
             _host = state_corejob_dn["domainname"].split(".", 1)[0]
             changed = False
             for remap_line in self.config["remapping"]:
-                pat, repl = remap_line.items()[0]
+                pat, repl = next(iter(remap_line.items()))
                 repl = eval(repl) if repl.startswith("lambda") else repl
                 if re.search(pat, _host):
                     changed = True

--- a/qtop_py/serialiser.py
+++ b/qtop_py/serialiser.py
@@ -36,7 +36,7 @@ class StatExtractor(object):
         try:
             job_id, user, job_state, queue = [m.group(x) for x in re_match_positions]
         except AttributeError:
-            logging.warn("Line: %s not properly parsed by regex expression. Assuming alternative qstat format." % line.strip())
+            logging.warning("Line: %s not properly parsed by regex expression. Assuming alternative qstat format." % line.strip())
             raise
         job_id = job_id.split(".")[0]
         user = self.anonymize(user, "users")

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -38,3 +38,23 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+def test_get_queues_info_does_not_eval_total_counts(tmp_path):
+    class QstatMaker:
+        def extract_qstatq(self, _qstatq_file):
+            sentinel = tmp_path / "pbs-total-executed"
+            dangerous_value = "__import__('pathlib').Path(%r).touch()" % str(sentinel)
+            return [
+                {"queue_name": "workq", "run": "1", "queued": "0", "lm": "--", "state": "E R"},
+                {"Total_running": dangerous_value, "Total_queued": "0"},
+            ]
+
+    batch_system = pbs.PBSBatchSystem.__new__(pbs.PBSBatchSystem)
+    batch_system.qstat_maker = QstatMaker()
+    batch_system.qstatq_file = "unused"
+
+    with pytest.raises(ValueError):
+        batch_system.get_queues_info()
+
+    assert not (tmp_path / "pbs-total-executed").exists()

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,6 +12,7 @@ import pytest
 import re
 import datetime
 import sys
+import qtop_py.qtop as qtop
 from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
 
 
@@ -59,6 +60,41 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_update_config_with_cmdline_vars_does_not_eval_option_values(tmp_path):
+    class Args:
+        OPTION = []
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = False
+
+    sentinel = tmp_path / "cmdline-executed"
+    dangerous_value = "__import__('pathlib').Path(%r).touch()" % str(sentinel)
+    Args.OPTION = ["overwrite_sample_file=%s" % dangerous_value]
+
+    config = {"rem_empty_corelines": "0"}
+
+    updated_config = qtop.update_config_with_cmdline_vars(Args(), config)
+
+    assert updated_config["overwrite_sample_file"] == dangerous_value
+    assert not sentinel.exists()
+
+
+def test_do_name_remapping_accepts_python3_dict_items():
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.config = {
+        "workernodes_matrix": [{"wn id lines": {"max_len": 0}}],
+        "remapping": [{"^node": "host"}],
+    }
+    workernode_dict = {
+        "node001": {
+            "domainname": "node001.example.org",
+        }
+    }
+
+    remapped = cluster.do_name_remapping(workernode_dict)
+
+    assert remapped["node001"]["host"] == "host001"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #355

/claim #355

Summary:
- modernize Ruff pre-commit config to the current `ruff-check`/`ruff-format` hooks
- refresh GitHub Actions to run PR checks against `main` and `develop`, with a Python 3.8-3.13 test matrix
- clean packaging metadata/MANIFEST so `README.md`, docs, subpackages, plugins, UI, and packaged data build correctly
- replace unsafe `eval()` usage for CLI option values and PBS/SGE total job counts with literal/int parsing
- fix Python 3 portability issues in worker-node remapping and Windows import/runtime paths (`SIGPIPE`, `termios`, `/usr/bin/which`)
- add regression coverage for non-evaluated config values, PBS queue totals, and Python 3 remapping behavior

Verification:
- `python -m pytest` -> 96 passed on Windows / Python 3.13.7
- `python -m build` -> sdist and wheel built successfully

Compatibility note:
- CI now covers Python 3.8 through 3.13. I did not add 3.6/3.7 to the hosted matrix because those runtimes are EOL and are not reliable on current `ubuntu-latest` images/toolchains.

AI assistance was used for this change; I reviewed the patch and verified it locally.