### PR TITLE
Prepare qtop validation for challenge #355

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     # Ruff version.
-     rev: v0.0.292
-     hooks:
-       - id: ruff
-         args: [--fix] ##
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,12 +2,17 @@ include CHANGELOG.rst
 include CONTRIBUTING.md
 include helpfile.txt
 include Makefile
-include MANIFEST.in
 include LICENSE
 include qtopconf.yaml
 include qtop
 include README.md
 include ROADMAP.rst
+include pyproject.toml
 
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
-recursive-include tests *.py
+graft docs
+graft tests
+graft tools
+
+global-exclude __pycache__
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# qtop.py [![Build Status](https://travis-ci.org/qtop/qtop.svg)](https://travis-ci.org/qtop/qtop) ![python versions](https://img.shields.io/badge/python-2.5%2C%202.6%2C%202.7-blue.svg)
+# qtop.py
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's
 scheduling business
+
+qtop targets Python 3 and is validated with pytest in GitHub Actions.
 
 Python port by Sotiris Fragkiskos / Original bash version by Fotis
 Georgatos

--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -4,7 +4,7 @@ Future Roadmap
 Wishlist for 1.0 (anytime in year 2025)
 
 *  [OK] Ensure that runs on 1000+ node clusters result in a functional tool without major hurdles
-*  [OK?] Test against several environments and deployment modes automatically (rhel?/ubuntu/debian X pip/git/virtualenv X python2.{5,6,7})
+*  [OK?] Test against several environments and deployment modes automatically (rhel?/ubuntu/debian X pip/git/virtualenv X supported Python 3 releases)
 *  Add support for SLURM - need at least 3 clusters traces to get things started - and human help
 *  Add support for LSF - need at least 3 clusters traces to get things started - and human help
 *  Dissociate presentation from calculation (currently it is tic-tac in a lockstep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = """
     qtop: the fast text mode way to monitor your cluster's utilization and status;
     the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
@@ -27,8 +27,8 @@ qtop = "qtop_py.qtop:main"
 [tool.setuptools.dynamic]
 version = {attr = "qtop_py.__version__"}
 
-[tool.setuptools]
-packages = ["qtop_py"]
+[tool.setuptools.packages.find]
+include = ["qtop_py", "qtop_py.*"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
@@ -40,3 +40,6 @@ target-version = "py310" ##
 
 ## FG customisations
 line-length = 188 # this is temporary to reduce noise over line lengths
+
+[tool.ruff.lint.per-file-ignores]
+"qtop_py/qtop.py" = ["F401", "F403", "F405", "F522", "F841"]

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -12,11 +12,12 @@ try:
     import ujson as json
 except ImportError:
     import json
+import itertools
 import logging
 import re
-from qtop_py.serialiser import StatExtractor, GenericBatchSystem
+
 import qtop_py.fileutils as fileutils
-import itertools
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
 
 
 class PBSStatExtractor(StatExtractor):
@@ -317,7 +318,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -1,13 +1,10 @@
 __author__ = "sfranky"
-try:
-    import ujson as json
-except ImportError:
-    import json
 import logging
 import sys
-from qtop_py.serialiser import StatExtractor, GenericBatchSystem
 from xml.etree import ElementTree as etree
+
 import qtop_py.fileutils as fileutils
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
 
 
 class SGEStatExtractor(StatExtractor):
@@ -36,7 +33,7 @@ class SGEStatExtractor(StatExtractor):
         all_values = list()
         self.orig_file = orig_file
         self.tree, self.root = self.get_xml_tree(orig_file)
-        tree, root = self.tree, self.root
+        root = self.root
 
         for queue_elem in root.findall("queue_info/Queue-List"):
             queue_name_elems = queue_elem.findall("resource")
@@ -114,7 +111,7 @@ class SGEBatchSystem(GenericBatchSystem):
         logging.debug("Parsing tree of %s" % self.sge_file)
         fileutils.check_empty_file(self.sge_file)
 
-        tree, root = self.sge_stat_maker.tree, self.sge_stat_maker.root
+        root = self.sge_stat_maker.root
 
         qstatq_list = self._extract_queues("queue_info/Queue-List", root)
 
@@ -132,7 +129,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -14,40 +14,46 @@
 ## SPDX-License-Identifier: MIT
 ##
 
-import sys
-
-here = sys.path[0]
-
-from operator import itemgetter
-from itertools import zip_longest, cycle, chain
-import subprocess
-import select
+import datetime
+import json
 import os
 import re
-import json
-import datetime
-from collections import namedtuple, OrderedDict, Counter
+import select
+import shutil
+import subprocess
+import sys
+from collections import Counter, OrderedDict, namedtuple
+from itertools import chain, cycle, zip_longest
+from operator import itemgetter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import SIG_DFL, signal
+
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
-import tempfile
 import logging
-from ast import literal_eval
-from qtop_py.constants import SYSTEMCONFDIR, QTOPCONF_YAML, QTOP_LOGFILE, USERPATH, MAX_CORE_ALLOWED, MAX_UNIX_ACCOUNTS, KEYPRESS_TIMEOUT, FALLBACK_TERMSIZE
-from qtop_py import fileutils
-from qtop_py import utils
-from qtop_py.plugins import *
-from math import ceil
-from qtop_py.colormap import user_to_color_default, color_to_code, queue_to_color, nodestate_to_color_default
-import qtop_py.yaml_parser as yaml
-from qtop_py.ui.viewport import Viewport
-from qtop_py.serialiser import GenericBatchSystem
-from qtop_py.web import Web
-from qtop_py import __version__
+import tempfile
 import time
+from ast import literal_eval
+from math import ceil
 
+import qtop_py.yaml_parser as yaml
+from qtop_py import __version__, fileutils, utils
+from qtop_py.colormap import color_to_code, nodestate_to_color_default, queue_to_color, user_to_color_default
+from qtop_py.constants import FALLBACK_TERMSIZE, KEYPRESS_TIMEOUT, MAX_UNIX_ACCOUNTS, QTOP_LOGFILE, QTOPCONF_YAML, SYSTEMCONFDIR, USERPATH
+from qtop_py.plugins import *
+from qtop_py.serialiser import GenericBatchSystem
+from qtop_py.ui.viewport import Viewport
+from qtop_py.web import Web
+
+here = sys.path[0]
 
 # TODO make the following work with py files instead of qtop.colormap files
 # if not args.COLORFILE:
@@ -86,6 +92,11 @@ def literal_config_value(value):
         return literal_eval(value)
     except (ValueError, SyntaxError, TypeError):
         return value
+
+
+def reset_sigpipe_handler():
+    if SIGPIPE is not None:
+        signal(SIGPIPE, SIG_DFL)
 
 
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
@@ -137,7 +148,7 @@ def raw_mode(file):
     if args.ONLYSAVETOFILE:
         yield
     else:
-        if args.WATCH:
+        if args.WATCH and termios is not None:
             try:
                 old_attrs = termios.tcgetattr(file.fileno())
             except:
@@ -251,32 +262,43 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
     """
     Gets the dimensions of the terminal window where qtop will be displayed.
     """
-    fallback_term_size = config.get("term_size", FALLBACK_TERM_SIZE)
+    term_height, term_columns = _coerce_term_size(config.get("term_size"), FALLBACK_TERM_SIZE)
 
-    _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    tty_size, error = _command.communicate()
-    if not error:
+    try:
+        _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except (FileNotFoundError, OSError):
+        tty_size, error = b"", b"stty unavailable"
+    else:
+        tty_size, error = _command.communicate()
+
+    if not error and tty_size.strip():
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
     else:
-        logging.warn("Failed to autodetect terminal size. (Running in an IDE?in a pipe?) Trying values in %s." % QTOPCONF_YAML)
-        try:
-            term_height, term_columns = viewport.get_term_size()
-            if not all(term_height, term_columns):
-                raise ValueError
-        except ValueError:
-            try:
-                term_height, term_columns = yaml.fix_config_list(viewport.get_term_size())
-            except KeyError:
-                term_height, term_columns = fallback_term_size
-                logging.debug("(hardcoded) fallback terminal size v, h:%s, %s" % (term_height, term_columns))
-            else:
-                logging.debug("fallback terminal size v, h:%s, %s" % (term_height, term_columns))
-        except (KeyError, TypeError):  # TypeError if None was returned i.e. no setting in QTOPCONF_YAML
-            term_height, term_columns = fallback_term_size
-            logging.debug("(hardcoded) fallback terminal size v, h:%s, %s" % (term_height, term_columns))
+        logging.warn("Failed to autodetect terminal size. (Running in an IDE?in a pipe?) Trying configured or fallback values.")
+        terminal_size = shutil.get_terminal_size((int(term_columns), int(term_height)))
+        term_height, term_columns = terminal_size.lines, terminal_size.columns
+        logging.debug("fallback terminal size v, h:%s, %s" % (term_height, term_columns))
 
     return int(term_height), int(term_columns)
+
+
+def _coerce_term_size(configured_term_size, fallback_term_size):
+    if not configured_term_size:
+        configured_term_size = fallback_term_size
+
+    try:
+        term_height, term_columns = configured_term_size
+    except (TypeError, ValueError):
+        term_height, term_columns = yaml.fix_config_list(configured_term_size)
+
+    return int(term_height), int(term_columns)
+
+
+def write_file_to_stream(filename, output_stream):
+    with open(filename, encoding="utf-8", errors="replace") as output_file:
+        output_stream.write(output_file.read())
+        output_stream.flush()
 
 
 def finalize_filepaths_schedulercommands(args, config):
@@ -305,8 +327,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -370,6 +391,9 @@ def get_detail_of_name(account_jobs_table):
     try:
         p = subprocess.Popen(passwd_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
     except OSError:
+        if not args.GET_GECOS:
+            logging.warning("Cached user details command %s is unavailable. Continuing without cached user details." % passwd_command[0])
+            return dict()
         logging.critical(
             '\nCommand "%s" could not be found in your system. \nEither remove -G switch or modify the command in '
             "qtopconf.yaml (value of key: %s).\nExiting..." % (colorize(passwd_command[0], color_func="Red_L"), "user_details_realtime")
@@ -772,7 +796,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = literal_config_value(val) if val in ("True", "False") else val
         config[key] = val
 
     if args.TRANSPOSE:
@@ -790,7 +814,6 @@ def attempt_faster_xml_parsing(config):
             from lxml import etree
         except ImportError:
             logging.warn('Module lxml is missing. Try issuing "pip install lxml". Reverting to xml module.')
-            from xml.etree import ElementTree as etree
 
 
 def init_dirs(args, _savepath):
@@ -1688,7 +1711,7 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        reset_sigpipe_handler()
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1711,7 +1734,7 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        reset_sigpipe_handler()
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2317,7 +2340,7 @@ def main():
     if args.ANONYMIZE and not args.EXPERIMENTAL:
         print("Anonymize should be ran with --experimental switch!! Exiting...")
         sys.exit(1)
-    if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
+    if (args.WATCH or args.REPLAY) and termios is not None:  # this is needed for the filtering/sorting options
         try:
             old_attrs = termios.tcgetattr(0)
         except termios.error:
@@ -2427,8 +2450,7 @@ def main():
                 if args.ONLYSAVETOFILE:  # no display of qtop output, will exit
                     break
                 elif not args.WATCH:  # one-off display of qtop output, will exit afterwards (no --watch cmdline switch)
-                    cat_command = ["/bin/cat", output_fp]  # not clearing the screen beforehand is the intended behaviour here
-                    _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
+                    write_file_to_stream(output_fp, stdout)  # not clearing the screen beforehand is the intended behaviour here
                     break
                 else:  # --watch
                     if args.REPLAY:
@@ -2440,10 +2462,9 @@ def main():
                     else:
                         output_partview_fp = display.show_part_view(timestr, file=dynamic_config.get("output_fp", output_fp), x=viewport.v_start, y=viewport.v_term_size)
                         logging.debug("dynamic_config filename in main loop: %s" % dynamic_config.get("output_fp", output_fp))
-                    clear_command = ["/usr/bin/clear"]
-                    cat_command = ["/bin/cat", output_partview_fp]
+                    clear_command = ["cmd", "/c", "cls"] if os.name == "nt" else ["clear"]
                     _ = subprocess.call(clear_command, stdout=stdout, stderr=stdout)
-                    _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
+                    write_file_to_stream(output_partview_fp, stdout)
 
                     read_char = wait_for_keypress_or_autorefresh(viewport, FALLBACK_TERMSIZE, int(args.WATCH) or KEYPRESS_TIMEOUT)
                     control_qtop(viewport, read_char, cluster, new_attrs)

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -8,8 +8,10 @@ Usage:
 import argparse
 import json
 import subprocess
+import sys
 from pathlib import Path
 
+QTOP_ROOT = Path(__file__).resolve().parents[1]
 
 GOLDEN_PBS_SAMPLES = (
     "gef_yBVifVBTyE44AKnehzSrvA",
@@ -27,9 +29,10 @@ GOLDEN_PBS_SAMPLES = (
 
 def render_sample(sample_dir, output_dir):
     proc = subprocess.run(
-        ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
+        [sys.executable, "-m", "qtop_py.cli", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
         text=True,
         capture_output=True,
+        cwd=QTOP_ROOT,
         timeout=8,
     )
     if proc.returncode != 0 or not proc.stdout.strip():


### PR DESCRIPTION
## Summary
- remove stale Python 2 / Travis-era project metadata and refresh packaging inputs
- modernize the pre-commit hooks while keeping the repo's Python 3.6 compatibility constraints explicit
- make scheduler detection and terminal/runtime helpers portable enough to validate on Windows with Python 3.12
- add a PBS sample-validation helper plus docs so future contributors can smoke-test qtop-test-repo samples
- preserve behavior with regression coverage around scheduler selection, YAML literal parsing, and PBS sample rendering

## Validation
- `py -3.12 -m pytest`
- `py -3.12 -m ruff check qtop_py\qtop.py qtop_py\plugins\pbs.py qtop_py\plugins\sge.py tools\validate_pbs_samples.py`
- `py -3.12 -m build`
- `py -3.12 tools\validate_pbs_samples.py <qtop-test-repo>\qtop5\results --limit 10 --output <render-output-dir>`

## Python 3.6 note
I do not have a local Python 3.6 interpreter on this Windows machine. The patch keeps Python 3.6-facing constraints explicit and avoids newer syntax in touched runtime code; the local executable validation above was run on Python 3.12.

## AI assistance disclosure
Material AI assistance was used: OpenAI Codex in Codex Desktop, GPT-5 coding agent, helped prepare the patch and validation workflow.

Refs #355