### PR TITLE
20260520: fix filtering without explicit remap

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1970,9 +1970,12 @@ class Cluster(object):
         numeric_workernodes = [wn for wn in self.workernode_list if isinstance(wn, int)]
         has_mixed_or_non_numeric_wns = len(numeric_workernodes) != len(self.workernode_list)
         has_exotic_starting_wn = bool(numeric_workernodes) and min(numeric_workernodes) >= int(self.config["exotic_starting_wn_nr"])
+        user_filters = dynamic_config.get("filtering", self.config["filtering"])
+        user_filtering = user_filters and user_filters[0]
 
         if (
             self.args.BLINDREMAP
+            or user_filtering
             or len(self.node_subclusters) > 1
             or has_exotic_starting_wn
             or self.offdown_nodes >= self.total_wn * float(self.config["percentage"])
@@ -1987,6 +1990,7 @@ class Cluster(object):
 
         if logging.getLogger().isEnabledFor(logging.DEBUG) and REMAP:
             user_request = self.args.BLINDREMAP and "The user has requested it (blindremap switch)" or False
+            filter_request = user_filtering and "filtering requires remapping to avoid re-adding filtered nodes as placeholders" or False
 
             subclusters = len(self.node_subclusters) > 1 and "there are different WN namings, e.g. wn001, wn002, ..., ps001, ps002, ... etc" or False
 
@@ -1997,7 +2001,7 @@ class Cluster(object):
             numbering_collisions = has_mixed_or_non_numeric_wns and "there are numbering collisions or non-numbered WNs" or False
 
             print()
-            logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))
+            logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, filter_request, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))
 
         return REMAP
 

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1991,7 +1991,6 @@ class Cluster(object):
 
         if logging.getLogger().isEnabledFor(logging.DEBUG) and REMAP:
             user_request = self.args.BLINDREMAP and "The user has requested it (blindremap switch)" or False
-            filter_request = user_filtering and "filtering requires remapping to avoid re-adding filtered nodes as placeholders" or False
 
             subclusters = len(self.node_subclusters) > 1 and "there are different WN namings, e.g. wn001, wn002, ..., ps001, ps002, ... etc" or False
 
@@ -2002,7 +2001,7 @@ class Cluster(object):
             numbering_collisions = has_mixed_or_non_numeric_wns and "there are numbering collisions or non-numbered WNs" or False
 
             print()
-            logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, filter_request, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))
+            logging.debug("Remapping decided due to: \n\t %s" % filter(None, [user_request, user_filtering, subclusters, exotic_starting, percentage_unassigned, numbering_collisions]))
 
         return REMAP
 

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1970,7 +1970,7 @@ class Cluster(object):
         numeric_workernodes = [wn for wn in self.workernode_list if isinstance(wn, int)]
         has_mixed_or_non_numeric_wns = len(numeric_workernodes) != len(self.workernode_list)
         has_exotic_starting_wn = bool(numeric_workernodes) and min(numeric_workernodes) >= int(self.config["exotic_starting_wn_nr"])
-        user_filters = dynamic_config.get("filtering", self.config["filtering"])
+        user_filters = globals().get("dynamic_config", {}).get("filtering") or self.config.get("filtering")
         user_filtering = user_filters and user_filters[0]
 
         if (

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1970,7 +1970,8 @@ class Cluster(object):
         numeric_workernodes = [wn for wn in self.workernode_list if isinstance(wn, int)]
         has_mixed_or_non_numeric_wns = len(numeric_workernodes) != len(self.workernode_list)
         has_exotic_starting_wn = bool(numeric_workernodes) and min(numeric_workernodes) >= int(self.config["exotic_starting_wn_nr"])
-        user_filters = globals().get("dynamic_config", {}).get("filtering") or self.config.get("filtering")
+        dynamic_filters = globals().get("dynamic_config", {})
+        user_filters = dynamic_filters["filtering"] if "filtering" in dynamic_filters else self.config.get("filtering")
         user_filtering = user_filters and user_filters[0]
 
         if (

--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -59,7 +59,8 @@ def test_filtering_name_patterns_removes_nodes_without_user_remap(monkeypatch):
     monkeypatch.setattr(qtop, "args", args, raising=False)
     monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
     monkeypatch.setattr(qtop, "user_to_color", {}, raising=False)
-    config = {"exotic_starting_wn_nr": 1000, "filtering": [{"exclude_name_patterns": ["wn002"]}], "percentage": 0.8, "remapping": [], "sorting": {}, "workernodes_matrix": [{"wn id lines": {"max_len": 0}}]}
+    config = dict(exotic_starting_wn_nr=1000, filtering=[{"exclude_name_patterns": ["wn002"]}], percentage=0.8, remapping=[], sorting={})
+    config["workernodes_matrix"] = [{"wn id lines": {"max_len": 0}}]
     nodes = [{"domainname": name, "state": [qtop.utils.ColorStr("-")], "np": 1, "core_job_map": {}} for name in ["wn001.example", "wn002.example", "wn003.example"]]
     document = SimpleNamespace(jobs_dict={}, queues_dict={}, total_running_jobs=0, total_queued_jobs=0)
 

--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -54,6 +54,33 @@ def test_decide_remapping_handles_mixed_numeric_and_named_nodes():
     assert cluster.decide_remapping(["1", ""]) is True
 
 
+def test_filtering_name_patterns_removes_nodes_without_user_remap(monkeypatch):
+    args = SimpleNamespace(ANONYMIZE=False, BLINDREMAP=False, COLOR="OFF", REMAP=False)
+    monkeypatch.setattr(qtop, "args", args, raising=False)
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    monkeypatch.setattr(qtop, "user_to_color", {}, raising=False)
+    config = {"exotic_starting_wn_nr": 1000, "filtering": [{"exclude_name_patterns": ["wn002"]}], "percentage": 0.8, "remapping": [], "sorting": {}, "workernodes_matrix": [{"wn id lines": {"max_len": 0}}]}
+    nodes = [{"domainname": name, "state": [qtop.utils.ColorStr("-")], "np": 1, "core_job_map": {}} for name in ["wn001.example", "wn002.example", "wn003.example"]]
+    document = SimpleNamespace(jobs_dict={}, queues_dict={}, total_running_jobs=0, total_queued_jobs=0)
+
+    cluster = qtop.Cluster(document, nodes, qtop.WNFilter, config, args)
+
+    assert [node["domainname"] for node in cluster.workernode_dict.values()] == ["wn001.example", "wn003.example"]
+
+
+def test_dynamic_empty_filtering_does_not_force_remapping(monkeypatch):
+    monkeypatch.setattr(qtop, "dynamic_config", {"filtering": []}, raising=False)
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.total_wn = 3
+    cluster.args = SimpleNamespace(BLINDREMAP=False)
+    cluster.node_subclusters = {"wn"}
+    cluster.workernode_list = [1, 2, 3]
+    cluster.offdown_nodes = 0
+    cluster.config = {"exotic_starting_wn_nr": 1000, "filtering": [{"exclude_name_patterns": ["wn002"]}], "percentage": 0.8}
+
+    assert cluster.decide_remapping(["1", "2", "3"]) is False
+
+
 def test_valid_corejobs_skips_jobs_missing_from_qstat():
     occupancy = qtop.WNOccupancy.__new__(qtop.WNOccupancy)
 

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,51 +12,12 @@ import pytest
 import re
 import datetime
 import sys
-
-from qtop_py import qtop, utils
-from qtop_py.qtop import Cluster, WNFilter, WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
 
 
 @pytest.fixture
 def config():
     return {}
-
-
-def test_filtering_name_patterns_removes_nodes_without_user_remap(monkeypatch):
-    Args = type("Args", (object,), {"ANONYMIZE": False, "BLINDREMAP": False, "COLOR": "OFF", "REMAP": False})
-    monkeypatch.setattr(qtop, "args", Args(), raising=False)
-    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
-    monkeypatch.setattr(qtop, "user_to_color", {}, raising=False)
-    Document = type("Document", (object,), {"jobs_dict": {}, "queues_dict": {}, "total_running_jobs": 0, "total_queued_jobs": 0})
-    cluster_config = {
-        "exotic_starting_wn_nr": 1000,
-        "filtering": [{"exclude_name_patterns": ["wn002"]}],
-        "percentage": 0.8,
-        "remapping": [],
-        "sorting": {},
-        "workernodes_matrix": [{"wn id lines": {"max_len": 0}}],
-    }
-    worker_nodes = [{"domainname": name, "state": [utils.ColorStr("-")], "np": 1, "core_job_map": {}} for name in ["wn001.example", "wn002.example", "wn003.example"]]
-
-    cluster = Cluster(Document(), worker_nodes, WNFilter, cluster_config, Args())
-
-    filtered_names = [node["domainname"] for node in cluster.workernode_dict.values()]
-    assert filtered_names == ["wn001.example", "wn003.example"]
-    assert all(node["domainname"] != "N/A" for node in cluster.workernode_dict.values())
-
-
-def test_dynamic_empty_filtering_does_not_force_remapping(monkeypatch):
-    Args = type("Args", (object,), {"BLINDREMAP": False})
-    monkeypatch.setattr(qtop, "dynamic_config", {"filtering": []}, raising=False)
-    cluster = Cluster.__new__(Cluster)
-    cluster.total_wn = 3
-    cluster.args = Args()
-    cluster.node_subclusters = {"wn"}
-    cluster.workernode_list = [1, 2, 3]
-    cluster.offdown_nodes = 0
-    cluster.config = {"exotic_starting_wn_nr": 1000, "filtering": [{"exclude_name_patterns": ["wn002"]}], "percentage": 0.8}
-
-    assert cluster.decide_remapping(["1", "2", "3"]) is False
 
 
 def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -45,6 +45,20 @@ def test_filtering_name_patterns_removes_nodes_without_user_remap(monkeypatch):
     assert all(node["domainname"] != "N/A" for node in cluster.workernode_dict.values())
 
 
+def test_dynamic_empty_filtering_does_not_force_remapping(monkeypatch):
+    Args = type("Args", (object,), {"BLINDREMAP": False})
+    monkeypatch.setattr(qtop, "dynamic_config", {"filtering": []}, raising=False)
+    cluster = Cluster.__new__(Cluster)
+    cluster.total_wn = 3
+    cluster.args = Args()
+    cluster.node_subclusters = {"wn"}
+    cluster.workernode_list = [1, 2, 3]
+    cluster.offdown_nodes = 0
+    cluster.config = {"exotic_starting_wn_nr": 1000, "filtering": [{"exclude_name_patterns": ["wn002"]}], "percentage": 0.8}
+
+    assert cluster.decide_remapping(["1", "2", "3"]) is False
+
+
 def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     class Args:
         CONFFILE = None

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,12 +12,37 @@ import pytest
 import re
 import datetime
 import sys
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+
+from qtop_py import qtop, utils
+from qtop_py.qtop import Cluster, WNFilter, WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
 
 
 @pytest.fixture
 def config():
     return {}
+
+
+def test_filtering_name_patterns_removes_nodes_without_user_remap(monkeypatch):
+    Args = type("Args", (object,), {"ANONYMIZE": False, "BLINDREMAP": False, "COLOR": "OFF", "REMAP": False})
+    monkeypatch.setattr(qtop, "args", Args(), raising=False)
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    monkeypatch.setattr(qtop, "user_to_color", {}, raising=False)
+    Document = type("Document", (object,), {"jobs_dict": {}, "queues_dict": {}, "total_running_jobs": 0, "total_queued_jobs": 0})
+    cluster_config = {
+        "exotic_starting_wn_nr": 1000,
+        "filtering": [{"exclude_name_patterns": ["wn002"]}],
+        "percentage": 0.8,
+        "remapping": [],
+        "sorting": {},
+        "workernodes_matrix": [{"wn id lines": {"max_len": 0}}],
+    }
+    worker_nodes = [{"domainname": name, "state": [utils.ColorStr("-")], "np": 1, "core_job_map": {}} for name in ["wn001.example", "wn002.example", "wn003.example"]]
+
+    cluster = Cluster(Document(), worker_nodes, WNFilter, cluster_config, Args())
+
+    filtered_names = [node["domainname"] for node in cluster.workernode_dict.values()]
+    assert filtered_names == ["wn001.example", "wn003.example"]
+    assert all(node["domainname"] != "N/A" for node in cluster.workernode_dict.values())
 
 
 def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):


### PR DESCRIPTION
/claim #358

Fixes #287 as a small code-backed slice of Challenge #5.

## Summary
- Treat configured worker-node filtering as a reason to enter the remap path, even when the user did not pass `-a` / `--blindremapping`.
- Preserve the explicit `dynamic_config["filtering"] = []` cleared-filter state so clearing filters does not force remapping.
- Add focused regressions for filtering without explicit remap and for the cleared-filter edge case.

## Validation
- Targeted regressions: passed via a small local runner that shims Windows-missing POSIX imports (`SIGPIPE`, `termios`) before calling the focused tests.
- `ruff check tests/test_pbs_sample_regressions.py` with repo-pinned `ruff==0.0.292`: passed.
- `python -m pytest tests/test_qtop.py -q`: blocked on Windows during collection by pre-existing POSIX import assumptions (`signal.SIGPIPE` missing before `termios` is reached).
- Python 3.6 grammar check: touched files parse with `ast.parse(..., feature_version=(3, 6))`.
- `git diff --check`: passed.
- GitHub DCO check: passing.

## Notes
- Net diff: 33 insertions, 1 deletion, under the 40 LOC challenge limit.
- I could not produce the requested 3 cluster screenshots locally because this checkout cannot run qtop on Windows before POSIX-only imports are loaded. The behavioral regressions are covered directly in tests.
- AI assistance: OpenAI Codex in Codex Desktop, GPT-5, assisted with scouting, implementation, and validation; I reviewed the diff and am responsible for the submitted change.

Assisted by Codesx.