### PR TITLE
20260521: add Slurm scheduler support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+PYTHON ?= python
+
+.PHONY: test test-slurm
+
+test:
+	$(PYTHON) -m pytest -q
+
+test-slurm:
+	$(PYTHON) -m pytest -q tests/plugins/test_slurm.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ qtop = "qtop_py.qtop:main"
 version = {attr = "qtop_py.__version__"}
 
 [tool.setuptools]
-packages = ["qtop_py"]
+packages = ["qtop_py", "qtop_py.plugins", "qtop_py.ui"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/qtop_py/contrib/sinfo.txt
+++ b/qtop_py/contrib/sinfo.txt
@@ -1,0 +1,3 @@
+wn[001-002]|batch*|mix|4
+wn003|debug|alloc|8
+wn004|batch|idle|4

--- a/qtop_py/contrib/slurm_case1_sinfo.txt
+++ b/qtop_py/contrib/slurm_case1_sinfo.txt
@@ -1,0 +1,3 @@
+wn[001-002]|batch*|mix|4
+wn003|debug|alloc|8
+wn004|batch|idle|4

--- a/qtop_py/contrib/slurm_case1_squeue.txt
+++ b/qtop_py/contrib/slurm_case1_squeue.txt
@@ -1,0 +1,3 @@
+1001|batch|alice|R|4|wn[001-002]
+1002|batch|bob|PD|1|(Priority)
+1003|debug|carol|R|2|wn003

--- a/qtop_py/contrib/slurm_case2_sinfo.txt
+++ b/qtop_py/contrib/slurm_case2_sinfo.txt
@@ -1,0 +1,3 @@
+gpu[01-02]|gpu*|mix|8
+cpu[001-004]|long|alloc|16
+cpu005|long|drain|16

--- a/qtop_py/contrib/slurm_case2_squeue.txt
+++ b/qtop_py/contrib/slurm_case2_squeue.txt
@@ -1,0 +1,3 @@
+2001|gpu|dana|R|8|gpu[01-02]
+2002|gpu|erin|CG|4|gpu02
+2003|long|frank|S|16|cpu[001-004]

--- a/qtop_py/contrib/slurm_case3_sinfo.txt
+++ b/qtop_py/contrib/slurm_case3_sinfo.txt
@@ -1,0 +1,2 @@
+rack[1-2]n[01-02]|short*|idle|2
+wn010|maint|down|2

--- a/qtop_py/contrib/slurm_case3_squeue.txt
+++ b/qtop_py/contrib/slurm_case3_squeue.txt
@@ -1,0 +1,3 @@
+3001|short|gina|PD|1|(Resources)
+3002|short|hank|R|1|rack[1-2]n[01-02]
+3003|maint|ivan|F|2|wn010

--- a/qtop_py/contrib/squeue.txt
+++ b/qtop_py/contrib/squeue.txt
@@ -1,0 +1,3 @@
+1001|batch|alice|R|4|wn[001-002]
+1002|batch|bob|PD|1|(Priority)
+1003|debug|carol|R|2|wn003

--- a/qtop_py/plugins/__init__.py
+++ b/qtop_py/plugins/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["oar", "pbs", "sge", "demo"]
+__all__ = ["oar", "pbs", "sge", "slurm", "demo"]

--- a/qtop_py/plugins/slurm.py
+++ b/qtop_py/plugins/slurm.py
@@ -1,0 +1,268 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 qtop contributors
+##
+## SPDX-License-Identifier: MIT
+##
+
+import logging
+import re
+
+import qtop_py.fileutils as fileutils
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
+
+
+def expand_slurm_nodelist(nodelist):
+    """
+    Expand Slurm's compact node-list syntax.
+
+    Examples:
+    node[001-003,007] -> node001, node002, node003, node007
+    rack[1-2]n[01-02] -> rack1n01, rack1n02, rack2n01, rack2n02
+    """
+    if not nodelist:
+        return []
+
+    expanded = []
+    for part in _split_top_level_commas(nodelist):
+        expanded.extend(_expand_slurm_part(part))
+    return expanded
+
+
+def _split_top_level_commas(value):
+    parts = []
+    depth = 0
+    start = 0
+    for idx, char in enumerate(value):
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(value[start:idx])
+            start = idx + 1
+    parts.append(value[start:])
+    return [part for part in parts if part]
+
+
+def _expand_slurm_part(part):
+    match = re.search(r"\[([^\]]+)\]", part)
+    if not match:
+        return [part]
+
+    prefix = part[: match.start()]
+    suffix = part[match.end() :]
+    values = []
+    for item in match.group(1).split(","):
+        if "-" in item:
+            start, stop = item.split("-", 1)
+            width = len(start)
+            for number in range(int(start), int(stop) + 1):
+                values.append(str(number).zfill(width))
+        else:
+            values.append(item)
+
+    expanded = []
+    for value in values:
+        for suffix_value in _expand_slurm_part(suffix):
+            expanded.append(prefix + value + suffix_value)
+    return expanded
+
+
+class SlurmStatExtractor(StatExtractor):
+    def __init__(self, config, options):
+        StatExtractor.__init__(self, config, options)
+
+    def extract_squeue(self, orig_file):
+        """
+        Parse:
+        squeue -h -o "%i|%P|%u|%t|%C|%R"
+        """
+        try:
+            fileutils.check_empty_file(orig_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % orig_file)
+            return []
+
+        jobs = []
+        with open(orig_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split("|")
+                if len(parts) != 6:
+                    logging.warning("Skipping malformed squeue line: %s" % line)
+                    continue
+                job_id, partition, user, state, cpus, nodelist = parts
+                jobs.append(
+                    {
+                        "JobId": job_id.split(".")[0],
+                        "Queue": partition,
+                        "UnixAccount": self.anonymize(user, "users"),
+                        "S": state,
+                        "CPUs": int(cpus or 0),
+                        "NodeList": nodelist,
+                    }
+                )
+        return jobs
+
+    def extract_sinfo(self, orig_file):
+        """
+        Parse:
+        sinfo -h -N -o "%N|%P|%t|%c"
+        """
+        try:
+            fileutils.check_empty_file(orig_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % orig_file)
+            return []
+
+        nodes = []
+        node_lookup = {}
+        with open(orig_file, "r") as fin:
+            for line in fin:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split("|")
+                if len(parts) != 4:
+                    logging.warning("Skipping malformed sinfo line: %s" % line)
+                    continue
+                nodelist, partition, state, cpus = parts
+                partition = partition.rstrip("*")
+                for node_name in expand_slurm_nodelist(nodelist):
+                    visible_node_name = self.anonymize(node_name, "wns")
+                    queue_name = self.anonymize(partition, "qs")
+                    mapped_state = _map_slurm_node_state(state)
+                    existing_node = node_lookup.get(visible_node_name)
+                    if existing_node is not None:
+                        if queue_name not in existing_node["qname"]:
+                            existing_node["qname"].append(queue_name)
+                        existing_node["state"] = _merge_node_state(existing_node["state"], mapped_state)
+                        existing_node["np"] = max(existing_node["np"], int(cpus or 0))
+                        continue
+                    node = {
+                        "domainname": visible_node_name,
+                        "qname": [queue_name],
+                        "state": mapped_state,
+                        "np": int(cpus or 0),
+                        "core_job_map": {},
+                    }
+                    node_lookup[visible_node_name] = node
+                    nodes.append(node)
+        return nodes
+
+
+class SlurmBatchSystem(GenericBatchSystem):
+    @staticmethod
+    def get_mnemonic():
+        return "slurm"
+
+    def __init__(self, scheduler_output_filenames, config, options):
+        self.sinfo_file = scheduler_output_filenames.get("sinfo_file")
+        self.squeue_file = scheduler_output_filenames.get("squeue_file")
+        self.config = config
+        self.options = options
+        self.slurm_stat_maker = SlurmStatExtractor(self.config, self.options)
+
+    def get_jobs_info(self):
+        job_ids, usernames, job_states, queue_names = [], [], [], []
+        for job in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            job_ids.append(job["JobId"])
+            usernames.append(job["UnixAccount"])
+            job_states.append(job["S"])
+            queue_names.append(job["Queue"])
+        return job_ids, usernames, job_states, queue_names
+
+    def get_queues_info(self):
+        queues = {}
+        for job in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            queue_name = job["Queue"]
+            queue = queues.setdefault(queue_name, {"queue_name": queue_name, "run": 0, "queued": 0, "lm": "--", "state": "E"})
+            if job["S"] in ("R", "CG"):
+                queue["run"] += 1
+            elif job["S"] in ("PD", "CF", "RF", "RH", "RQ", "RS", "RV"):
+                queue["queued"] += 1
+
+        qstatq_list = []
+        for queue in queues.values():
+            qstatq_list.append(
+                {
+                    "queue_name": queue["queue_name"],
+                    "run": str(queue["run"]),
+                    "queued": str(queue["queued"]),
+                    "lm": queue["lm"],
+                    "state": queue["state"],
+                }
+            )
+        total_running_jobs = sum(int(queue["run"]) for queue in qstatq_list)
+        total_queued_jobs = sum(int(queue["queued"]) for queue in qstatq_list)
+        return total_running_jobs, total_queued_jobs, qstatq_list
+
+    def get_worker_nodes(self, job_ids, job_queues, options):
+        nodes = self.slurm_stat_maker.extract_sinfo(self.sinfo_file)
+        node_lookup = dict((node["domainname"], node) for node in nodes)
+
+        for job in self.slurm_stat_maker.extract_squeue(self.squeue_file):
+            allocated_nodes = _get_allocated_nodes(job["NodeList"])
+            if not allocated_nodes:
+                continue
+            cores_per_node = max(1, int((job["CPUs"] + len(allocated_nodes) - 1) / len(allocated_nodes)))
+            for node_name in allocated_nodes:
+                visible_node_name = self.slurm_stat_maker.anonymize(node_name, "wns")
+                node = node_lookup.get(visible_node_name)
+                if node is None:
+                    node = {"domainname": visible_node_name, "qname": [], "state": "%", "np": cores_per_node, "core_job_map": {}}
+                    node_lookup[visible_node_name] = node
+                    nodes.append(node)
+                start_core = len(node["core_job_map"])
+                for core in range(start_core, start_core + cores_per_node):
+                    if core >= int(node["np"]):
+                        node["np"] = core + 1
+                    node["core_job_map"][str(core)] = job["JobId"]
+
+        return self.ensure_worker_nodes_have_qnames(nodes, job_ids, job_queues)
+
+
+def _get_allocated_nodes(nodelist_or_reason):
+    if not nodelist_or_reason or nodelist_or_reason.startswith("("):
+        return []
+    if nodelist_or_reason in ("None", "N/A"):
+        return []
+    return expand_slurm_nodelist(nodelist_or_reason)
+
+
+def _map_slurm_node_state(state):
+    state = state.lower().replace("*", "").replace("~", "").replace("$", "")
+    if state in ("idle", "idle+cloud", "idle+power"):
+        return "-"
+    if state in ("alloc", "allocated"):
+        return "b"
+    if state in ("mix", "mixed"):
+        return "%"
+    if state.startswith("down"):
+        return "d"
+    if state.startswith("drain") or state.startswith("drng"):
+        return "d"
+    if state.startswith("maint"):
+        return "m"
+    if state.startswith("comp"):
+        return "c"
+    if state.startswith("resv"):
+        return "r"
+    if state.startswith("fail"):
+        return "f"
+    if state.startswith("unk"):
+        return "?"
+    return state[:1] or "?"
+
+
+def _merge_node_state(first, second):
+    priority = {"d": 90, "f": 80, "m": 70, "%": 60, "b": 50, "c": 40, "r": 30, "-": 10, "?": 0}
+    if priority.get(second, 20) > priority.get(first, 20):
+        return second
+    return first

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -22,6 +22,7 @@ from operator import itemgetter
 from itertools import zip_longest, cycle, chain
 import subprocess
 import select
+import shutil
 import os
 import re
 import json
@@ -29,8 +30,16 @@ import datetime
 from collections import namedtuple, OrderedDict, Counter
 import os
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+try:
+    from signal import SIGPIPE, SIG_DFL, signal
+except ImportError:
+    from signal import SIG_DFL, signal
+
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -129,6 +138,8 @@ def raw_mode(file):
     Exits program with ^C or ^D
     """
     if args.ONLYSAVETOFILE:
+        yield
+    elif termios is None:
         yield
     else:
         if args.WATCH:
@@ -247,8 +258,11 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
     """
     fallback_term_size = config.get("term_size", FALLBACK_TERM_SIZE)
 
-    _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    tty_size, error = _command.communicate()
+    try:
+        _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tty_size, error = _command.communicate()
+    except OSError:
+        tty_size, error = b"", b"stty unavailable"
     if not error:
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
@@ -299,8 +313,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -1675,7 +1688,8 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        if SIGPIPE is not None:
+            signal(SIGPIPE, SIG_DFL)
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1698,7 +1712,8 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        if SIGPIPE is not None:
+                            signal(SIGPIPE, SIG_DFL)
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2304,8 +2319,8 @@ def main():
         sys.exit(1)
     if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
         try:
-            old_attrs = termios.tcgetattr(0)
-        except termios.error:
+            old_attrs = termios.tcgetattr(0) if termios is not None else ""
+        except Exception:
             old_attrs = ""
         new_attrs = old_attrs[:]
 

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -6,7 +6,7 @@
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
 
-## scheduler possible values (currently supported): pbs, oar, sge
+## scheduler possible values (currently supported): pbs, oar, sge, slurm
 ## auto will try to detect available batch commands in the current system
 scheduler: auto
 
@@ -28,6 +28,9 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  slurm:
+    sinfo_file: %(savepath)s/sinfo%(pid)s.txt, sinfo -h -N -o %%N|%%P|%%t|%%c
+    squeue_file: %(savepath)s/squeue%(pid)s.txt, squeue -h -o %%i|%%P|%%u|%%t|%%C|%%R
   demo:
     demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
 
@@ -36,6 +39,7 @@ signature_commands:
   pbs: pbsnodes
   oar: oarnodes
   sge: qacct
+  slurm: squeue
   demo: echo
 
 ## Utilises lxml module. Needs to be installed in your system.
@@ -97,6 +101,26 @@ state_abbreviations:
     Rq: queued_of_user
     Rt: transferring_of_user
     Rr: running_of_user    
+  slurm:
+    R: running_of_user
+    CG: running_of_user
+    PD: queued_of_user
+    CF: queued_of_user
+    RF: queued_of_user
+    RH: queued_of_user
+    RQ: queued_of_user
+    RS: queued_of_user
+    RV: queued_of_user
+    S: suspended_of_user
+    ST: suspended_of_user
+    CA: cancelled_of_user
+    CD: finished_of_user
+    F: failed_of_user
+    TO: failed_of_user
+    NF: failed_of_user
+    OOM: failed_of_user
+    BF: failed_of_user
+    PR: failed_of_user
   demo:
     Q: queued_of_user
     R: running_of_user
@@ -270,12 +294,12 @@ workernodes_matrix:
      yaml_key: state
      label: Node state
      max_len: 5
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - queue name:
      yaml_key: qname
      label: queue name
      max_len: 13
-     systems: [sge, oar, pbs, demo]
+     systems: [sge, oar, pbs, slurm, demo]
  - core_user_map:
      options1: {}
      options2: {}

--- a/tests/plugins/test_slurm.py
+++ b/tests/plugins/test_slurm.py
@@ -1,0 +1,54 @@
+from qtop_py.plugins import slurm
+
+
+class Options(object):
+    ANONYMIZE = False
+
+
+def test_expand_slurm_nodelist_simple_range():
+    assert slurm.expand_slurm_nodelist("wn[001-003,005]") == ["wn001", "wn002", "wn003", "wn005"]
+
+
+def test_expand_slurm_nodelist_multiple_groups():
+    assert slurm.expand_slurm_nodelist("rack[1-2]n[01-02]") == ["rack1n01", "rack1n02", "rack2n01", "rack2n02"]
+
+
+def test_extract_squeue(tmp_path):
+    squeue_file = tmp_path / "squeue.txt"
+    squeue_file.write_text("1001|batch|alice|R|4|wn[001-002]\n1002|debug|bob|PD|2|(Priority)\n")
+
+    extractor = slurm.SlurmStatExtractor({}, Options())
+
+    assert extractor.extract_squeue(str(squeue_file)) == [
+        {"JobId": "1001", "Queue": "batch", "UnixAccount": "alice", "S": "R", "CPUs": 4, "NodeList": "wn[001-002]"},
+        {"JobId": "1002", "Queue": "debug", "UnixAccount": "bob", "S": "PD", "CPUs": 2, "NodeList": "(Priority)"},
+    ]
+
+
+def test_extract_sinfo(tmp_path):
+    sinfo_file = tmp_path / "sinfo.txt"
+    sinfo_file.write_text("wn[001-002]|batch*|mix|64\nwn003|debug|idle|32\nwn004|batch|down|64\nwn001|debug|alloc|32\n")
+
+    extractor = slurm.SlurmStatExtractor({}, Options())
+    nodes = extractor.extract_sinfo(str(sinfo_file))
+
+    assert nodes[0]["domainname"] == "wn001"
+    assert nodes[0]["state"] == "%"
+    assert nodes[0]["np"] == 64
+    assert nodes[0]["qname"] == ["batch", "debug"]
+    assert nodes[2]["state"] == "-"
+    assert nodes[3]["state"] == "d"
+
+
+def test_get_worker_nodes_maps_running_jobs(tmp_path):
+    sinfo_file = tmp_path / "sinfo.txt"
+    squeue_file = tmp_path / "squeue.txt"
+    sinfo_file.write_text("wn[001-002]|batch|idle|4\n")
+    squeue_file.write_text("1001|batch|alice|R|4|wn[001-002]\n1002|batch|bob|PD|1|(Priority)\n")
+    batch = slurm.SlurmBatchSystem({"sinfo_file": str(sinfo_file), "squeue_file": str(squeue_file)}, {}, Options())
+
+    nodes = batch.get_worker_nodes(["1001", "1002"], ["batch", "batch"], Options())
+
+    assert nodes[0]["core_job_map"] == {"0": "1001", "1": "1001"}
+    assert nodes[1]["core_job_map"] == {"0": "1001", "1": "1001"}
+    assert nodes[0]["qname"] == ["batch"]


### PR DESCRIPTION
## Summary

- add a `slurm` scheduler plugin backed by `squeue` and `sinfo`
- add Slurm scheduler config, state abbreviations, package inclusion, and Makefile test targets
- add 3 Slurm trace fixture pairs plus unit coverage for node-list expansion, queue/job parsing, and worker-node mapping
- add small portability guards so the existing test suite can collect and run on Windows too

Fixes #356.

## Validation

- `python -m pytest -q` -> 89 passed
- `python -m ruff check qtop_py/plugins/slurm.py tests/plugins/test_slurm.py` -> passed
- `python -m qtop_py.qtop -s qtop_py\contrib -b slurm -O -3` -> smoke test passed with included Slurm fixtures

Smoke output excerpt:

```text
Summary: Total:4 Up:4 Free:1 Nodes | 6/20 cores |   2+1 jobs (R + Q)
Queues : batch: 1 + 1 | debug: 1 | * implies blocked
```

## Notes

The included traces are synthetic Slurm command outputs that exercise:

- compact node ranges across multiple nodes
- pending jobs with scheduler reasons instead of node lists
- mixed/allocated/idle/down/drain states
- nodes appearing in multiple partitions

I do not have access to three live Slurm clusters from this workstation, so I cannot provide real cluster screenshots in this PR yet.

## AI assistance disclosure

This patch was prepared with AI assistance from OpenAI GPT-5.5 in Codex Desktop on 2026-05-21. I reviewed the generated changes, ran the tests above, and take responsibility for the submitted code.
