### PR TITLE
20260522: use qtop command in output hints

### DIFF
--- a/qtop_py/contrib/oar1_dvv_out.ref
+++ b/qtop_py/contrib/oar1_dvv_out.ref
@@ -1,6 +1,6 @@
 
-./qtop.py ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
-Please try it with watch: /home/sfranky/PycharmProjects/qtop/qtop.py -s <SOURCEDIR> -w [<every_nr_of_sec>]
+qtop ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
+Please try it with watch: qtop -s <SOURCEDIR> -w [<every_nr_of_sec>]
 ...and thank you for watching ;)
 
 [1;30m===> [0;m[1;37mJob accounting summary[0;m[1;30m <=== [0;m[1;37m2016-11-15 22:57:26[0;m WORKDIR = /home/sfranky/PycharmProjects/qtop

--- a/qtop_py/contrib/pbs_dvv_out.ref
+++ b/qtop_py/contrib/pbs_dvv_out.ref
@@ -1,6 +1,6 @@
 
-./qtop.py ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
-Please try it with watch: /home/sfranky/PycharmProjects/qtop/qtop.py -s <SOURCEDIR> -w [<every_nr_of_sec>]
+qtop ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
+Please try it with watch: qtop -s <SOURCEDIR> -w [<every_nr_of_sec>]
 ...and thank you for watching ;)
 
 [1;30m===> [0;m[1;37mJob accounting summary[0;m[1;30m <=== [0;m[1;37m2016-11-15 22:59:00[0;m WORKDIR = /home/sfranky/PycharmProjects/qtop

--- a/qtop_py/contrib/sger_dvv_out.ref
+++ b/qtop_py/contrib/sger_dvv_out.ref
@@ -1,6 +1,6 @@
 
-./qtop.py ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
-Please try it with watch: /home/sfranky/PycharmProjects/qtop/qtop.py -s <SOURCEDIR> -w [<every_nr_of_sec>]
+qtop ## Queueing System report tool. For feedback and updates, see: https://github.com/qtop/qtop
+Please try it with watch: qtop -s <SOURCEDIR> -w [<every_nr_of_sec>]
 ...and thank you for watching ;)
 
 [1;30m===> [0;m[1;37mJob accounting summary[0;m[1;30m <=== [0;m[1;37m2016-11-15 21:46:58[0;m WORKDIR = /home/sfranky/PycharmProjects/qtop

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -784,6 +784,10 @@ def update_config_with_cmdline_vars(args, config):
     return config
 
 
+def watch_command_hint():
+    return "Please try it with watch: qtop -s <SOURCEDIR> -w [<every_nr_of_sec>]"
+
+
 def attempt_faster_xml_parsing(config):
     if config["faster_xml_parsing"]:
         try:
@@ -1457,7 +1461,7 @@ class TextDisplay(object):
         print(
             "%(del)s%(name)s \nv%(version)s ## For feedback and updates, see: %(link)s"
             % {
-                "name": "PBS" if self.args.CLASSIC else colorize("./qtop.py     ## Queueing System report tool. Press ? for " "help", "Cyan_L"),
+                "name": "PBS" if self.args.CLASSIC else colorize("qtop          ## Queueing System report tool. Press ? for " "help", "Cyan_L"),
                 "del": ansi_delete_char,
                 "link": colorize("https://github.com/qtop/qtop", "Cyan_L"),
                 "version": __version__,
@@ -1468,7 +1472,7 @@ class TextDisplay(object):
             print(colorize(msg, "Blue"))
 
         if not self.args.WATCH:
-            print("Please try it with watch: %s/qtop.py -s <SOURCEDIR> -w [<every_nr_of_sec>]" % QTOPPATH)
+            print(watch_command_hint())
         print(colorize("===> ", "Gray_D") + colorize("Job accounting summary", "White") + colorize(" <=== ", "Gray_D") + colorize(str(datetime.datetime.today())[:-7], "White"))
 
         print(

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -236,3 +236,10 @@ def test_get_date_obj_from_str(s, now, day_meant):
     at 22:10 at night, the user inputs again 21:00 (the same day is implied)
     """
     assert get_date_obj_from_str(s, now).day == day_meant
+
+
+def test_watch_command_hint_uses_console_script():
+    from qtop_py.qtop import watch_command_hint
+
+    assert watch_command_hint() == "Please try it with watch: qtop -s <SOURCEDIR> -w [<every_nr_of_sec>]"
+    assert "qtop.py" not in watch_command_hint()


### PR DESCRIPTION
/opire try
/claim #358

## Summary

This is a small code-backed slice for challenge #358, tied to the still-open output/package cleanup notes in #187.

The installed launcher is now `qtop`, but the interactive banner and watch-mode hint still pointed users at `./qtop.py` or an installed `.../qtop.py` path. This updates those user-facing hints to the supported `qtop` command and refreshes the three bundled sample-output references to match.

Diff budget: 19 insertions and 8 deletions by `git diff --numstat` across 5 files, under the 40 LOC challenge cap.

## Validation

- `PYTHONPATH=. uvx --with pytest pytest tests/test_qtop.py -q` -> 35 passed
- `PYTHONPATH=. uvx --with pytest pytest tests/test_qtop.py::test_watch_command_hint_uses_console_script -q` -> 1 passed
- `PYTHONPATH=. python3 -m py_compile qtop_py/qtop.py tests/test_qtop.py`
- `git diff --check`
- `PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Fadvv -b pbs > /tmp/qtop-358-pbs.txt`
- `PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Fadvv -b sge > /tmp/qtop-358-sge.txt`
- `PYTHONPATH=. ./qtop -s qtop_py/contrib -c ON -Fadvv -b oar > /tmp/qtop-358-oar.txt`
- `grep -H "Please try it with watch" /tmp/qtop-358-pbs.txt /tmp/qtop-358-sge.txt /tmp/qtop-358-oar.txt` confirmed the `qtop -s ... -w` hint in all three outputs.
- `grep -H "qtop.py" /tmp/qtop-358-pbs.txt /tmp/qtop-358-sge.txt /tmp/qtop-358-oar.txt` returned no matches.

Ruff note: I also ran `uvx ruff check qtop_py/qtop.py tests/test_qtop.py --select E9,F821,F811,F841 --output-format=concise`. It reports the same seven pre-existing `F841` findings on a clean `origin/develop` worktree and on this branch, so this PR does not introduce a focused ruff regression. I did not broaden the patch to unrelated lint cleanup because of the #358 LOC cap.

RHEL8/Python 3.6 compatibility: the code change uses plain Python 3-compatible function syntax and string literals only. I do not have a local Python 3.6 interpreter in this environment; local syntax checks were run with Python 3.14.3, and the `uvx`/pytest run used Python 3.12.8.

## Render Screenshots

External gist with all three render captures: https://gist.github.com/jamilahmadzai/68cd4d3d9143205c4b47ae9321c36727

PBS:
![PBS render](https://gist.githubusercontent.com/jamilahmadzai/68cd4d3d9143205c4b47ae9321c36727/raw/c818fb7f33fdeb61fe928749c09ba2bcfd98733f/qtop-358-pbs.svg)

SGE:
![SGE render](https://gist.githubusercontent.com/jamilahmadzai/68cd4d3d9143205c4b47ae9321c36727/raw/b8efe4f65946c99c8af96d8c5a43b3cc2c171db1/qtop-358-sge.svg)

OAR:
![OAR render](https://gist.githubusercontent.com/jamilahmadzai/68cd4d3d9143205c4b47ae9321c36727/raw/c007ce325b2dde6a34417908a9cf9f1c2d558e1b/qtop-358-oar.svg)

## AI Disclosure

AI assistance used: OpenAI Codex, GPT-5, in the Codex desktop environment. I reviewed the issue context, diff, and validation output before submitting.

## Payout
Payment method: Opire bounty-platform payout to GitHub user `@jamilahmadzai`.

