### PR TITLE
20260523: clean up manifest packaging rules

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,53 +1,14 @@
 include CHANGELOG.rst
-include CONTRIBUTING.rst
+include CONTRIBUTING.md
 include helpfile.txt
-include Makefile
-include MANIFEST.in
 include LICENSE
 include qtopconf.yaml
-include qtop.py
 include qtop
-include qtop_py/cli.py
-include qtop_py/colormap.py
-include qtop_py/constants.py
-include qtop_py/contrib/func_tests.sh
-include qtop_py/contrib/oar1_dvv_out.ref
-include qtop_py/contrib/oarnodes_s_Y.txt
-include qtop_py/contrib/oarnodes_Y.txt
-include qtop_py/contrib/oarstat.txt
-include qtop_py/contrib/pbs_dvv_out.ref
-include qtop_py/contrib/pbsnodes_a.txt
-include qtop_py/contrib/qstat.F.xml.stdout
-include qtop_py/contrib/qstat_q.txt
-include qtop_py/contrib/qstat.txt
-include qtop_py/contrib/qtop_demo.gif
-include qtop_py/contrib/sger_dvv_out.ref
-include qtop_py/fileutils.py
-include qtop_py/__init__.py
-include qtop_py/inputs/joboutputs.sh
-include qtop_py/inputs/jobstatuses.sh
-include qtop_py/inputs/jobsubmits.sh
-include qtop_py/inputs/qtop-input.jdl
-include qtop_py/inputs/qtop-input.sh
-include qtop_py/plugins/demo.py
-include qtop_py/plugins/__init__.py
-include qtop_py/plugins/oar.py
-include qtop_py/plugins/pbs.py
-include qtop_py/plugins/sge.py
-include qtop_py/serialiser.py
-include qtop_py/ui/__init__.py
-include qtop_py/ui/viewport.py
-include qtop_py/utils.py
-include qtop_py/web/index.html
-include qtop_py/web.py
-include qtop_py/yaml_parser.py
-include qtop_py/qtop.sh
-include README.rst
+include README.md
 include ROADMAP.rst
-include setup.py
-include tests/plugins/__init__.py
-include tests/plugins/test_pbs.py
-include tests/test_qtop.py
-include tests/test_yaml_parser.py
-include tests/ui/__init__.py
-include tests/ui/test_viewport.py
+
+recursive-include docs *.rst
+recursive-include qtop_py *.gif *.html *.jdl *.py *.ref *.sh *.stdout *.txt
+recursive-include tests *.py
+
+global-exclude __pycache__ *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = """
     qtop: the fast text mode way to monitor your cluster's utilization and status;
     the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},


### PR DESCRIPTION
## Summary
- replaces the long hand-maintained `MANIFEST.in` file list with recursive include rules
- removes stale manifest references to files that are no longer in the repo (`README.rst`, `CONTRIBUTING.rst`, `setup.py`, `qtop.py`, `Makefile`)
- updates `pyproject.toml` to use the current `README.md` metadata file

Fixes #245 as a small #358 slice.

## Validation
- `python -m build --sdist` succeeds and includes docs, qtop_py resources, and tests in the source distribution
- `python -m pytest tests\plugins\test_pbs.py -q` -> 9 passed
- `python -m compileall -q qtop_py tests`
- `git diff --check`

Full `python -m pytest -q` does not collect on this Windows environment because `qtop_py/qtop.py` imports `signal.SIGPIPE`, which is not available on Windows. No runtime Python files are changed in this PR.

`python -m ruff check` currently reports existing repo-wide Python lint findings on main; this PR only changes packaging metadata.

## Challenge notes
- PR is under 100 LOC.
- Cluster screenshots are not applicable: this does not change qtop scheduler execution or rendering behavior.
- AI assistance: OpenAI GPT-5 Codex in Codex desktop on 2026-05-23.

/claim #358