### PR TITLE
Fix #357: Add -V and --version flags

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -15,7 +15,11 @@
 ##
 
 import sys
-
+import argparse
+if '--version' in sys.argv or '-V' in sys.argv:
+    print("qtop 0.2")
+    sys.exit(0)
+    
 here = sys.path[0]
 
 from operator import itemgetter

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -17,7 +17,7 @@
 import sys
 import argparse
 if '--version' in sys.argv or '-V' in sys.argv:
-    print("qtop 0.2")
+  print("qtop %s" % __version__)
     sys.exit(0)
     
 here = sys.path[0]


### PR DESCRIPTION
Hi! This adds the requested -V and --version flags to print the current version (qtop 0.2) and exit, resolving issue #357.