### PR TITLE
20260526: add initial slurm scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Georgatos
 ![Example](https://raw.githubusercontent.com/qtop/qtop/master/qtop_py/contrib/qtop_demo.gif)
 
 qtop.py is the python rewrite of qtop, a tool to monitor Torque, PBS,
-OAR or SGE clusters, etc. This release provides for the *instant replay*
+OAR, SGE, or Slurm clusters, etc. This release provides for the *instant replay*
 feature, which is handy for debugging scheduling mishaps as they occur.
 qtop is and will remain a work-in-progress project; it is intended to be
 built upon and extended - please come along ;)
@@ -46,7 +46,7 @@ To run a demo, just run
 
 Otherwise, for daily usage you can run
 
-    ./qtop -b sge -FGw ## replace sge with pbs or oar, depending on your setup (this is often picked up automagically) 
+    ./qtop -b sge -FGw ## replace sge with pbs, oar, or slurm, depending on your setup (this is often picked up automagically) 
 
 Try `--help` for all available options.
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -57,7 +57,7 @@ invoking it in demo mode:
     ./qtop.py -b demo
 
 When used, the ``-b`` switch must always be followed by one of the
-supported batch systems (as of version 0.8.9, pbs, sge, oar, demo).
+supported batch systems (as of version 0.8.9, pbs, sge, oar, slurm, demo).
 
 That should create and destroy fictional jobs in fictional machines from
 fictional users, and display all that in a colorful, yet much unhelpful
@@ -84,7 +84,7 @@ Demo case study
 ---------------
 
 Use demo mode when you want to learn qtop's display without access to a
-live PBS, SGE, or OAR cluster. The demo backend generates fictional
+live PBS, SGE, OAR, or Slurm cluster. The demo backend generates fictional
 worker nodes, jobs, queues, and users, so it is useful for checking the
 layout and keyboard workflow before pointing qtop at production
 scheduler data.
@@ -439,6 +439,9 @@ Scheduler configuration area
             oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
           sge:
             sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+          slurm:
+            slurm_nodes_file: %(savepath)s/slurm_nodes%(pid)s.txt, scontrol show nodes -o
+            slurm_jobs_file: %(savepath)s/slurm_jobs%(pid)s.txt, squeue -h -o %i|%u|%t|%P|%N
           demo:
             demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
     ---
@@ -492,6 +495,7 @@ installed.
           pbs: pbsnodes
           oar: oarnodes
           sge: qacct
+          slurm: sinfo
           demo: echo
     ---
 
@@ -606,7 +610,7 @@ Input selection
 ~~~~~~~~~~~~~~~
 
 -  ``-b SYSTEM`` selects the scheduler backend. Common values are
-   ``demo``, ``pbs``, ``sge``, and ``oar``.
+   ``demo``, ``pbs``, ``sge``, ``oar``, and ``slurm``.
 -  ``-s DIRECTORY`` reads scheduler output files from ``DIRECTORY``
    instead of running scheduler commands live.
 -  ``-f FILE`` uses a custom qtop configuration file.
@@ -658,7 +662,7 @@ Usage tips
 
 -  Start with ``./qtop -b demo`` when testing terminal size, color, or
    keyboard navigation. It avoids accidental scheduler calls.
--  On a live cluster, pass ``-b pbs``, ``-b sge``, or ``-b oar`` when
+-  On a live cluster, pass ``-b pbs``, ``-b sge``, ``-b oar``, or ``-b slurm`` when
    auto-detection is not enough.
 -  Use ``-s`` when another process has already collected scheduler
    output files. This is helpful for debugging and for reproducing an

--- a/qtop_py/plugins/__init__.py
+++ b/qtop_py/plugins/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["oar", "pbs", "sge", "demo"]
+__all__ = ["oar", "pbs", "sge", "slurm", "demo"]

--- a/qtop_py/plugins/slurm.py
+++ b/qtop_py/plugins/slurm.py
@@ -1,0 +1,180 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## SPDX-License-Identifier: MIT
+##
+
+import logging
+from collections import defaultdict
+
+import qtop_py.fileutils as fileutils
+from qtop_py.serialiser import GenericBatchSystem, StatExtractor
+
+
+class SlurmStatExtractor(StatExtractor):
+    def __init__(self, config, options):
+        StatExtractor.__init__(self, config, options)
+
+    @staticmethod
+    def parse_key_values(line):
+        values = {}
+        for token in line.strip().split():
+            if "=" not in token:
+                continue
+            key, value = token.split("=", 1)
+            values[key] = value
+        return values
+
+    @staticmethod
+    def normalize_node_state(state):
+        base_state = state.split("+", 1)[0].split("*", 1)[0].upper()
+        if base_state in ("IDLE", "COMPLETING"):
+            return "-"
+        if base_state in ("ALLOCATED", "MIXED"):
+            return "b"
+        if base_state in ("DOWN", "DRAIN", "DRAINED", "FAIL", "FAILING", "UNKNOWN", "NO_RESPOND"):
+            return "d"
+        return base_state[:1].lower() or "?"
+
+    @staticmethod
+    def expand_nodelist(nodelist):
+        if not nodelist or nodelist.startswith("("):
+            return []
+        if "[" not in nodelist:
+            return [nodelist]
+
+        prefix, rest = nodelist.split("[", 1)
+        ranges = rest.split("]", 1)[0]
+        nodes = []
+        for item in ranges.split(","):
+            if "-" in item:
+                start, end = item.split("-", 1)
+                width = len(start)
+                for idx in range(int(start), int(end) + 1):
+                    nodes.append("%s%s" % (prefix, str(idx).zfill(width)))
+            else:
+                nodes.append("%s%s" % (prefix, item))
+        return nodes
+
+    def extract_jobs(self, slurm_jobs_file):
+        jobs = []
+        try:
+            fileutils.check_empty_file(slurm_jobs_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % slurm_jobs_file)
+            return jobs
+
+        with open(slurm_jobs_file, "r") as fin:
+            for line in fin:
+                parts = line.rstrip("\n").split("|")
+                if len(parts) < 5:
+                    continue
+                job_id, user, state, partition, nodelist = parts[:5]
+                jobs.append(
+                    {
+                        "JobId": job_id,
+                        "UnixAccount": self.anonymize(user, "users"),
+                        "S": state,
+                        "Queue": self.anonymize(partition, "qs"),
+                        "Nodes": self.expand_nodelist(nodelist),
+                    }
+                )
+        return jobs
+
+    def extract_nodes(self, slurm_nodes_file):
+        nodes = []
+        try:
+            fileutils.check_empty_file(slurm_nodes_file)
+        except fileutils.FileEmptyError:
+            logging.error("File %s seems to be empty." % slurm_nodes_file)
+            return nodes
+
+        with open(slurm_nodes_file, "r") as fin:
+            for line in fin:
+                node = self.parse_key_values(line)
+                if not node.get("NodeName"):
+                    continue
+                nodes.append(node)
+        return nodes
+
+
+class SlurmBatchSystem(GenericBatchSystem):
+    @staticmethod
+    def get_mnemonic():
+        return "slurm"
+
+    def __init__(self, scheduler_output_filenames, config, options):
+        self.slurm_nodes_file = scheduler_output_filenames.get("slurm_nodes_file")
+        self.slurm_jobs_file = scheduler_output_filenames.get("slurm_jobs_file")
+        self.config = config
+        self.options = options
+        self.slurm_stat_maker = SlurmStatExtractor(self.config, self.options)
+
+    def get_worker_nodes(self, job_ids, job_queues, options):
+        nodes = self.slurm_stat_maker.extract_nodes(self.slurm_nodes_file)
+        jobs = self.slurm_stat_maker.extract_jobs(self.slurm_jobs_file)
+        node_jobs = defaultdict(list)
+
+        for job in jobs:
+            if job["S"] != "R":
+                continue
+            for node_name in job["Nodes"]:
+                node_jobs[node_name].append(job["JobId"])
+
+        worker_nodes = []
+        anonymize = self.slurm_stat_maker.anonymize_func() if self.options.ANONYMIZE else self.slurm_stat_maker.eponymize_func()
+        for node in nodes:
+            node_name = node["NodeName"]
+            core_job_map = dict((idx, job_id) for idx, job_id in enumerate(node_jobs[node_name]))
+            worker_nodes.append(
+                {
+                    "domainname": anonymize(node_name, "wns"),
+                    "state": self.slurm_stat_maker.normalize_node_state(node.get("State", "?")),
+                    "np": node.get("CPUTot", node.get("CPUs", 0)),
+                    "core_job_map": core_job_map,
+                }
+            )
+
+        return self.ensure_worker_nodes_have_qnames(worker_nodes, job_ids, job_queues)
+
+    def get_jobs_info(self):
+        jobs = self.slurm_stat_maker.extract_jobs(self.slurm_jobs_file)
+        job_ids, usernames, job_states, queue_names = [], [], [], []
+
+        for job in jobs:
+            job_ids.append(job["JobId"])
+            usernames.append(job["UnixAccount"])
+            job_states.append(job["S"])
+            queue_names.append(job["Queue"])
+
+        return job_ids, usernames, job_states, queue_names
+
+    def get_queues_info(self):
+        jobs = self.slurm_stat_maker.extract_jobs(self.slurm_jobs_file)
+        queues = defaultdict(lambda: {"run": 0, "queued": 0, "state": "?", "lm": 0})
+
+        for job in jobs:
+            queue = queues[job["Queue"]]
+            if job["S"] == "R":
+                queue["run"] += 1
+                queue["state"] = "R"
+            else:
+                queue["queued"] += 1
+                if queue["state"] == "?":
+                    queue["state"] = job["S"]
+
+        qstatq_list = []
+        for queue_name, values in queues.items():
+            qstatq_list.append(
+                {
+                    "queue_name": queue_name,
+                    "run": str(values["run"]),
+                    "queued": str(values["queued"]),
+                    "state": values["state"],
+                    "lm": values["lm"],
+                }
+            )
+
+        total_running_jobs = sum(int(q["run"]) for q in qstatq_list)
+        total_queued_jobs = sum(int(q["queued"]) for q in qstatq_list)
+        return total_running_jobs, total_queued_jobs, qstatq_list

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -6,7 +6,7 @@
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
 
-## scheduler possible values (currently supported): pbs, oar, sge
+## scheduler possible values (currently supported): pbs, oar, sge, slurm
 ## auto will try to detect available batch commands in the current system
 scheduler: auto
 
@@ -28,6 +28,9 @@ schedulers:
     oarstat_file: %(savepath)s/oarstat%(pid)s.txt, oarstat
   sge:
     sge_file: %(savepath)s/qstat%(pid)s.F.xml.stdout, qstat -F -xml -u '*'
+  slurm:
+    slurm_nodes_file: %(savepath)s/slurm_nodes%(pid)s.txt, scontrol show nodes -o
+    slurm_jobs_file: %(savepath)s/slurm_jobs%(pid)s.txt, squeue -h -o %i|%u|%t|%P|%N
   demo:
     demo_file: %(savepath)s/demo%(pid)s.txt, echo 'Demo here'
 
@@ -36,6 +39,7 @@ signature_commands:
   pbs: pbsnodes
   oar: oarnodes
   sge: qacct
+  slurm: sinfo
   demo: echo
 
 ## Utilises lxml module. Needs to be installed in your system.
@@ -97,6 +101,14 @@ state_abbreviations:
     Rq: queued_of_user
     Rt: transferring_of_user
     Rr: running_of_user    
+  slurm:
+    R: running_of_user
+    PD: queued_of_user
+    CG: completing_of_user
+    CD: completed_of_user
+    F: failed_of_user
+    CA: cancelled_of_user
+    TO: timeout_of_user
   demo:
     Q: queued_of_user
     R: running_of_user

--- a/tests/plugins/test_slurm.py
+++ b/tests/plugins/test_slurm.py
@@ -1,0 +1,31 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## SPDX-License-Identifier: MIT
+##
+
+from qtop_py.plugins import slurm
+
+
+def test_parse_key_values():
+    line = "NodeName=node001 CPUTot=64 CPUAlloc=2 State=MIXED"
+    assert slurm.SlurmStatExtractor.parse_key_values(line) == {
+        "NodeName": "node001",
+        "CPUTot": "64",
+        "CPUAlloc": "2",
+        "State": "MIXED",
+    }
+
+
+def test_normalize_node_state():
+    assert slurm.SlurmStatExtractor.normalize_node_state("IDLE") == "-"
+    assert slurm.SlurmStatExtractor.normalize_node_state("MIXED") == "b"
+    assert slurm.SlurmStatExtractor.normalize_node_state("ALLOCATED+") == "b"
+    assert slurm.SlurmStatExtractor.normalize_node_state("DOWN*") == "d"
+
+
+def test_expand_nodelist():
+    assert slurm.SlurmStatExtractor.expand_nodelist("node001") == ["node001"]
+    assert slurm.SlurmStatExtractor.expand_nodelist("node[001-003]") == ["node001", "node002", "node003"]
+    assert slurm.SlurmStatExtractor.expand_nodelist("node[001,003-004]") == ["node001", "node003", "node004"]
+    assert slurm.SlurmStatExtractor.expand_nodelist("(Priority)") == []


### PR DESCRIPTION
## Summary

Adds initial Slurm scheduler support for qtop.

This PR includes:
- `SlurmBatchSystem` plugin
- parsing for `scontrol show nodes -o`
- parsing for `squeue -h -o %i|%u|%t|%P|%N`
- Slurm scheduler config in `qtopconf.yaml`
- Slurm state abbreviations
- documentation updates mentioning Slurm
- unit tests for Slurm parsing helpers

## Related issue

Part of #356

## Bounty claim

/claim #356

## Validation

Ran locally:

```bash
python -m pytest tests/plugins/test_slurm.py
python -m pytest tests/plugins/test_pbs.py
python -m pytest tests/test_yaml_parser.py tests/plugins/test_slurm.py tests/plugins/test_pbs.py
python -m ruff check qtop_py/plugins/slurm.py tests/plugins/test_slurm.py
```

Results:
- Slurm plugin tests: 3 passed
- PBS plugin tests: 9 passed
- YAML parser + Slurm + PBS tests: 36 passed
- Ruff: all checks passed

Full test suite was not fully runnable on Windows because the existing code imports `SIGPIPE` from `signal`, which is not available on Windows.

## Slurm commands used

```bash
scontrol show nodes -o
squeue -h -o %i|%u|%t|%P|%N
```

## Notes / limitations

This is an initial Slurm backend. It provides the plugin, parser, config, and parser-level tests.

It does not yet include real cluster screenshots or three full >256-core cluster traces. I am noting this explicitly because #356 asks for those as part of the full challenge requirements.

## AI disclosure

AI assistance was used to draft and iterate on this change.

LLM used:
- OpenAI GPT-5 via Codex

I reviewed the generated code and ran the tests listed above.