### PR TITLE
Add totals row to user pool mappings

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1563,31 +1563,53 @@ class TextDisplay(object):
             % {"msg": "Grid certificate DN (info only available under elevated privileges)" if self.args.CLASSIC else "      GECOS field or Grid certificate DN |"}
         )
         for line in account_jobs_table:
-            uid, runningjobs, queuedjobs, alljobs, user, num_of_nodes = line
+            uid = line[0]
             userid_pat = userid_to_userid_re_pat[str(uid)]
+            self.display_account_jobs_line(line, userid_pat, detail_of_name)
 
-            if self.args.COLOR == "OFF" or userid_pat == "account_not_colored" or user_to_color.get(userid_pat) == "reset":
-                conditional_width = 0
-                userid_pat = "account_not_colored"
-            else:
-                conditional_width = 12
+        totals = self.account_jobs_totals(account_jobs_table) if getattr(self.args, "SHOW_ACCOUNT_TOTALS", False) else None
+        if totals:
+            self.display_account_jobs_line(totals, "account_not_colored", detail_of_name)
 
-            print_string = ("[ {0:<{width1}}] " "{4:<{width18}}{sep}" "{3:>{width4}}   {1:>{width4}}   {2:>{width4}} {sep} " "{6:>{width5}} {sep} " "{5:<{width40}} {sep}").format(
-                colorize(str(uid), pattern=userid_pat),
-                colorize(str(runningjobs), pattern=userid_pat),
-                colorize(str(queuedjobs), pattern=userid_pat),
-                colorize(str(alljobs), pattern=userid_pat),
-                colorize(user, pattern=userid_pat),
-                colorize(detail_of_name.get(user, ""), pattern=userid_pat),
-                colorize(num_of_nodes, pattern=userid_pat),
-                sep=colorize(config["SEPARATOR"], pattern=userid_pat),
-                width1=1 + conditional_width,
-                width4=4 + conditional_width,
-                width5=5 + conditional_width,
-                width18=18 + conditional_width,
-                width40=40 + conditional_width,
-            )
-            print(print_string)
+    @staticmethod
+    def account_jobs_totals(account_jobs_table):
+        if not account_jobs_table:
+            return None
+
+        return [
+            "T",
+            sum(int(line[1]) for line in account_jobs_table),
+            sum(int(line[2]) for line in account_jobs_table),
+            sum(int(line[3]) for line in account_jobs_table),
+            "Totals",
+            sum(int(line[5]) for line in account_jobs_table),
+        ]
+
+    def display_account_jobs_line(self, line, userid_pat, detail_of_name):
+        uid, runningjobs, queuedjobs, alljobs, user, num_of_nodes = line
+
+        if self.args.COLOR == "OFF" or userid_pat == "account_not_colored" or user_to_color.get(userid_pat) == "reset":
+            conditional_width = 0
+            userid_pat = "account_not_colored"
+        else:
+            conditional_width = 12
+
+        print_string = ("[ {0:<{width1}}] " "{4:<{width18}}{sep}" "{3:>{width4}}   {1:>{width4}}   {2:>{width4}} {sep} " "{6:>{width5}} {sep} " "{5:<{width40}} {sep}").format(
+            colorize(str(uid), pattern=userid_pat),
+            colorize(str(runningjobs), pattern=userid_pat),
+            colorize(str(queuedjobs), pattern=userid_pat),
+            colorize(str(alljobs), pattern=userid_pat),
+            colorize(user, pattern=userid_pat),
+            colorize(detail_of_name.get(user, ""), pattern=userid_pat),
+            colorize(str(num_of_nodes), pattern=userid_pat),
+            sep=colorize(config["SEPARATOR"], pattern=userid_pat),
+            width1=1 + conditional_width,
+            width4=4 + conditional_width,
+            width5=5 + conditional_width,
+            width18=18 + conditional_width,
+            width40=40 + conditional_width,
+        )
+        print(print_string)
 
     def display_matrix(self, wns_occupancy, print_char_start, print_char_stop):
         """

--- a/qtop_py/utils.py
+++ b/qtop_py/utils.py
@@ -57,6 +57,7 @@ def parse_qtop_cmdline_args():
     parser.add_argument("-1", "--disablesection1", action="store_true", dest="sect_1_off", default=False, help="Disable first section of qtop, i.e. Job Accounting Summary")
     parser.add_argument("-2", "--disablesection2", action="store_true", dest="sect_2_off", default=False, help="Disable second section of qtop, i.e. Worker Node Occupancy")
     parser.add_argument("-3", "--disablesection3", action="store_true", dest="sect_3_off", default=False, help="Disable third section of qtop, i.e. User Accounts and Pool Mappings")
+    parser.add_argument("-4", "--accounttotals", action="store_true", dest="SHOW_ACCOUNT_TOTALS", default=False, help="Show totals row in User Accounts and Pool Mappings")
     parser.add_argument(
         "-a",
         "--blindremapping",

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -12,6 +12,9 @@
 import pytest
 import re
 import datetime
+import sys
+from qtop_py import qtop as qtop_module
+from qtop_py import utils as qtop_utils
 from qtop_py.qtop import (
     WNOccupancy,
     decide_batch_system,
@@ -19,6 +22,7 @@ from qtop_py.qtop import (
     SchedulerNotSpecified,
     NoSchedulerFound,
     get_date_obj_from_str,
+    TextDisplay,
 )
 
 
@@ -126,6 +130,78 @@ def test_create_user_job_counts_raises_jobnotfound():  # user_names, job_states,
             "exiting_of_user": {"sotiris": 0, "kostas": 1, "yannis": 0},
             "running_of_user": {"sotiris": 1, "yannis": 1},
         }
+
+
+@pytest.mark.parametrize("switch", ("-4", "--accounttotals"))
+def test_account_totals_cli_switch(monkeypatch, switch):
+    monkeypatch.setattr(sys, "argv", ["qtop", switch])
+
+    args = qtop_utils.parse_qtop_cmdline_args()
+
+    assert args.SHOW_ACCOUNT_TOTALS is True
+
+
+def test_display_user_accounts_pool_mappings_adds_totals(monkeypatch, capsys):
+    class Args(object):
+        COLOR = "OFF"
+        CLASSIC = False
+        SHOW_ACCOUNT_TOTALS = True
+
+    class WNSOccupancy(object):
+        account_jobs_table = [
+            ["0", 2, 3, 5, "alice", 1],
+            ["1", 4, 0, 4, "bob", 2],
+        ]
+        userid_to_userid_re_pat = {
+            "0": "account_not_colored",
+            "1": "account_not_colored",
+        }
+
+    args = Args()
+    monkeypatch.setattr(qtop_module, "args", args, raising=False)
+    monkeypatch.setattr(qtop_module, "config", {"SEPARATOR": "|"}, raising=False)
+    monkeypatch.setattr(qtop_module, "user_to_color", {}, raising=False)
+
+    wns_occupancy = WNSOccupancy()
+    display = TextDisplay(None, qtop_module.config, None, wns_occupancy, None, args)
+
+    display.display_user_accounts_pool_mappings(wns_occupancy)
+
+    output = capsys.readouterr().out
+    assert "[ T] Totals" in output
+    assert "|   9      6      3 |" in output
+    assert "|     3 |" in output
+
+
+def test_display_user_accounts_pool_mappings_hides_totals_by_default(monkeypatch, capsys):
+    class Args(object):
+        COLOR = "OFF"
+        CLASSIC = False
+        SHOW_ACCOUNT_TOTALS = False
+
+    class WNSOccupancy(object):
+        account_jobs_table = [
+            ["0", 2, 3, 5, "alice", 1],
+            ["1", 4, 0, 4, "bob", 2],
+        ]
+        userid_to_userid_re_pat = {
+            "0": "account_not_colored",
+            "1": "account_not_colored",
+        }
+
+    args = Args()
+    monkeypatch.setattr(qtop_module, "args", args, raising=False)
+    monkeypatch.setattr(qtop_module, "config", {"SEPARATOR": "|"}, raising=False)
+    monkeypatch.setattr(qtop_module, "user_to_color", {}, raising=False)
+
+    wns_occupancy = WNSOccupancy()
+    display = TextDisplay(None, qtop_module.config, None, wns_occupancy, None, args)
+
+    display.display_user_accounts_pool_mappings(wns_occupancy)
+
+    output = capsys.readouterr().out
+    assert "alice" in output
+    assert "[ T] Totals" not in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- make the user accounts and pool mappings totals row opt-in with `-4` / `--accounttotals`
- keep totals summing the displayed all/running/queued job columns and node memberships when enabled
- add regression coverage for CLI parsing, enabled rendering, and default suppression

Fixes #251

## Tests
- `UV_CACHE_DIR=/tmp/qtop-436-uv-cache uv run --with pytest python -m pytest tests/test_qtop.py::test_account_totals_cli_switch tests/test_qtop.py::test_display_user_accounts_pool_mappings_adds_totals tests/test_qtop.py::test_display_user_accounts_pool_mappings_hides_totals_by_default -q`
- `UV_CACHE_DIR=/tmp/qtop-436-uv-cache uv run --with pytest python -m pytest tests/test_qtop.py -q`
- `UV_CACHE_DIR=/tmp/qtop-436-uv-cache uv run --with pytest python -m pytest -q`
- `UV_CACHE_DIR=/tmp/qtop-436-uv-cache uv run --with ruff ruff check qtop_py/qtop.py qtop_py/utils.py tests/test_qtop.py`
- `git diff --check upstream/develop...HEAD`

AI assistance: OpenAI GPT-5 was used for this change. I reviewed the diff, ran the tests above, and take responsibility for the contribution.