### PR TITLE
20260527 (ORCID): Add Slurm RH state abbreviation

### DIFF
--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -551,6 +551,9 @@ State abbreviations
             S: cancelled_of_user
           sge:
              etc etc
+          slurm:
+            R: running_of_user
+            RH: hold_of_user  ## requeued_hold_of_user
 
     ---
 

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -103,6 +103,7 @@ state_abbreviations:
     Rr: running_of_user    
   slurm:
     R: running_of_user
+    RH: hold_of_user  ## requeued_hold_of_user
     PD: queued_of_user
     CA: cancelled_of_user
     CD: finished_of_user


### PR DESCRIPTION
Follow-up to #415 and Fotis's maintainer request: add the Slurm `RH` state abbreviation for `requeued_hold_of_user`, mapped to qtop's existing hold state.

Changes:
- Add `RH: hold_of_user  ## requeued_hold_of_user` to `qtopconf.yaml`.
- Mirror the same Slurm mapping in the state-abbreviation documentation example.

Validation:
- `venv/bin/python -m pytest tests/test_yaml_parser.py tests/plugins/test_slurm.py -q` -> 43 passed
- `PYTHON=venv/bin/python make test-slurm-samples` -> 19 Slurm tests passed, 6 samples validated
- `venv/bin/python -m pytest -q` -> 113 passed, 6 warnings
- `venv/bin/python -m ruff check .` -> pass
- `git diff --check` -> pass