### PR TITLE
Fix #337

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -257,7 +257,7 @@ class PBSBatchSystem(GenericBatchSystem):
             else:
                 pbs_values["np"] = block.get("resources_available.ncpus", 0)
 
-            if block.get("gpus", 0) > 0:  # this should be rare.
+            if self._get_gpu_count(block) > 0:  # this should be rare.
                 pbs_values["gpus"] = block["gpus"]
 
             try:  # this should turn up more often, hence the try/except.
@@ -354,6 +354,13 @@ class PBSBatchSystem(GenericBatchSystem):
                 else:
                     reading = False
         return result
+
+    @staticmethod
+    def _get_gpu_count(block):
+        try:
+            return int(block.get("gpus", 0))
+        except (TypeError, ValueError):
+            return 0
 
     @staticmethod
     def _read_block(fin):

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -10,6 +10,7 @@
 
 from qtop_py.plugins import pbs
 import pytest
+from types import SimpleNamespace
 
 
 @pytest.mark.parametrize('core_selections, result',
@@ -38,3 +39,28 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+def test_get_worker_nodes_accepts_string_gpu_counts(tmp_path):
+    pbsnodes_file = tmp_path / "pbsnodes_a.txt"
+    pbsnodes_file.write_text(
+        "node001.example.org\n"
+        "     state = free\n"
+        "     np = 8\n"
+        "     gpus = 0\n"
+        "\n"
+    )
+    options = SimpleNamespace(ANONYMIZE=False)
+    batch_system = pbs.PBSBatchSystem({"pbsnodes_file": str(pbsnodes_file)}, {}, options)
+
+    worker_nodes = batch_system.get_worker_nodes([], [], options)
+
+    assert worker_nodes == [
+        {
+            "domainname": "node001.example.org",
+            "state": "-",
+            "np": "8",
+            "core_job_map": {},
+            "qname": [],
+        }
+    ]


### PR DESCRIPTION
## Fix #337\n\nImplemented the PBS parser fix for issue #337.\n\nChanged [qtop_py/plugins/pbs.py](/tmp/bounty-qtop_337-wjk_n36m/repo/qtop_py/plugins/pbs.py:260) so  from  is converted to an integer before comparison, avoiding the Python 3  crash. Added a regression test in [tests/plugins/test_pbs.py](/tmp/bounty-qtop_337-wjk_n36m/repo/tests/plugins/test_pbs.py:44) covering  as parsed from .\n\nVerification:\n........................................................................ [ 84%]
.............                                                            [100%]
85 passed in 0.29s passes: .\n\n\n\n---\n*Auto-generated bounty fix*