### PR TITLE
Challenge #6: Improve testing and ci/cd cycles（human）

### DIFF
--- a/.github/scripts/fortifications.sh
+++ b/.github/scripts/fortifications.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== weird unicode/control chars =="
+git diff -U0 origin/main...HEAD \
+  | grep -nP '[^\x09\x0A\x0D\x20-\x7E]' \
+  && echo "FAIL: weird chars found" && exit 1 || echo "PASS"
+
+echo "== unexpected binary/generated changes =="
+git diff --name-only origin/main...HEAD \
+  | grep -Ei '(m4|autogen|configure|Makefile\.in|cmake)' \
+  && echo "FAIL: generated files in diff" && exit 1 || echo "PASS"
+
+echo "== checking for eval in codebase =="
+grep -rn "eval(" qtop_py/ --include="*.py" && echo "FAIL: eval found" && exit 1 || echo "PASS: no eval"
+
+echo "All fortifications passed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,23 +3,28 @@ name: build-qtop
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
       - 'releases/**'
   pull_request:
-    branches:    
-      - master
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
 
 jobs:
-  build-project:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v3
+      - run: make dist
+      - uses: actions/upload-artifact@v4
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,13 +2,23 @@ name: pytest-qtop
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
-  run-pytest:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+      - run: pip install pytest ruff
+      - name: Fortifications check
+        run: bash .github/scripts/fortifications.sh
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+stages:
+  - test
+  - build
+
+test:
+  stage: test
+  image: python:3.10
+  script:
+    - pip install pytest ruff
+    - make lint
+    - make test
+
+build:
+  stage: build
+  image: python:3.10
+  script:
+    - pip install build twine
+    - make dist
+  artifacts:
+    paths:
+      - dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: help test coverage lint lint-fix format-check format-fix dist confirm
+
+PYTHON ?= python3
+
+help:             ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help
+
+test:             ## Run tests
+	$(PYTHON) -m pytest
+
+coverage:         ## Run tests with coverage
+	$(PYTHON) -m pytest --cov=qtop_py --cov-report=term-missing
+
+lint:             ## Run ruff linter
+	ruff check .
+
+lint-fix:         ## Auto-fix lint issues
+	ruff check --fix .
+
+format-check:     ## Check formatting
+	ruff format --check .
+
+format-fix:       ## Auto-format
+	ruff format .
+
+dist:             ## Build distribution
+	pyproject-build
+
+confirm:          ## Confirm action
+	@echo "Are you sure? [y/N]" && read ans && [ $${ans:-N} = y ]


### PR DESCRIPTION
## Summary

  Improve CI/CD for qtop by adding a Makefile, fortifications check, hardened GitHub Actions, and
  GitLab CI configuration.

  ## Changes

  - **Makefile**: Added targets: `help`, `test`, `coverage`, `lint`, `lint-fix`, `format-check`,
  `format-fix`, `dist`, `confirm`
  - **pytest.yml**: Integrated with Makefile, added `permissions: contents: read`, added
  fortifications and lint steps
  - **build.yml**: Added `permissions: contents: read`, pinned to `main`/`develop` branches, uses
  `make dist`
  - **fortifications.sh**: Checks for unicode control chars, unexpected binary changes, and eval
  usage
  - **.gitlab-ci.yml**: Mirrors GitHub workflow to prevent CI drift

  (SDP) (human) Made with AI assistance (Claude Code).

  ## Screenshots

  ![make help](https://via.placeholder.com/400x100?text=make+help)