### PR TITLE
ci: drop runtime eval fortifications

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,14 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
 
 jobs:
   run-pytest:
@@ -11,4 +19,5 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install pytest
+      - run: make fortifications
       - run: python -m pytest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - test
+
+pytest-qtop:
+  stage: test
+  image: python:3.10
+  before_script:
+    - pip install pytest
+  script:
+    - make fortifications
+    - python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: test test-pbs-samples test-slurm-samples fortifications
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -16,3 +16,6 @@ test-pbs-samples:
 test-slurm-samples:
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+
+fortifications:
+	$(PYTHON) tools/fortifications.py qtop_py tools tests

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -24,10 +24,18 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import signal, SIG_DFL
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -88,6 +96,48 @@ def literal_config_value(value):
         return value
 
 
+def extract_user_detail(regex, field):
+    match = re.match(r"""\s*re\.search\((['"])(?P<pattern>.*)\1,\s*field\)\.group\(0\)\s*$""", regex or "", re.DOTALL)
+    if not match:
+        return field.strip()
+
+    found = re.search(match.group("pattern"), field)
+    return found.group(0) if found else field.strip()
+
+
+def safe_remap_replacement(replacement):
+    if isinstance(replacement, str) and replacement.strip().startswith("lambda"):
+        logging.warning("Skipping lambda remapping from %s; executable config expressions are disabled.", QTOPCONF_YAML)
+        return None
+    return replacement
+
+
+def worker_node_sort_value(node, sort_name):
+    domainname = node["domainname"]
+    hostname = domainname.split(".", 1)[0]
+    if sort_name == "sort by nodename-notnum":
+        return re.sub(r"[^A-Za-z _.-]+", "", domainname) or "0"
+    if sort_name == "sort by nodename-notnum length":
+        return len(hostname.split("-")[0])
+    if sort_name == "sort by all numbers":
+        return int(re.sub(r"[A-Za-z _.-]+", "", domainname) or "0")
+    if sort_name == "sort by first letter":
+        return ord(domainname[0])
+    if sort_name == "sort by node state":
+        return ord(str(node["state"][0]))
+    if sort_name == "sort by nr of cores":
+        return int(node["np"])
+    if sort_name == "sort by core occupancy":
+        return len(node["core_job_map"])
+    if sort_name == "sort reset":
+        return 0
+    raise KeyError(sort_name)
+
+
+def worker_node_sort_key(node, sort_names):
+    return tuple(worker_node_sort_value(node, sort_name) for sort_name in sort_names if sort_name != "sort by custom definition")
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -137,7 +187,7 @@ def raw_mode(file):
     if args.ONLYSAVETOFILE:
         yield
     else:
-        if args.WATCH:
+        if args.WATCH and termios is not None:
             try:
                 old_attrs = termios.tcgetattr(file.fileno())
             except:  # noqa: E722  ## FIXME, ruff complaint
@@ -305,8 +355,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -388,12 +437,7 @@ def get_detail_of_name(account_jobs_table):
         except ValueError:
             break
         else:
-            try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
-                detail = field.strip()
-            finally:
-                detail_of_name[user] = detail
+            detail_of_name[user] = extract_user_detail(regex, field)
     return detail_of_name
 
 
@@ -772,7 +816,8 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        parsed = literal_config_value(val)
+        val = parsed if isinstance(parsed, bool) else val
         config[key] = val
 
     if args.TRANSPOSE:
@@ -1689,7 +1734,8 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        if SIGPIPE is not None:
+            signal(SIGPIPE, SIG_DFL)
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1712,7 +1758,8 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        if SIGPIPE is not None:
+                            signal(SIGPIPE, SIG_DFL)
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2012,7 +2059,9 @@ class Cluster(object):
             changed = False
             for remap_line in self.config["remapping"]:
                 pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                repl = safe_remap_replacement(repl)
+                if repl is None:
+                    continue
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2068,38 +2117,20 @@ class Cluster(object):
         return nodes_drop, workernode_dict, workernode_dict_remapped
 
     def _sort_worker_nodes(self):
-        order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
-        }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
-            # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_names = [sort_item[0] for sort_item in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_names = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=lambda node: worker_node_sort_key(node, sort_names), reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting config in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
-            logging.error(colorize(msg, color_func="Red_L"))
-        except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Unknown worker-node sorting key '%s'." % e
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes
@@ -2318,7 +2349,7 @@ def main():
     if args.ANONYMIZE and not args.EXPERIMENTAL:
         print("Anonymize should be ran with --experimental switch!! Exiting...")
         sys.exit(1)
-    if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
+    if (args.WATCH or args.REPLAY) and termios is not None:  # this is needed for the filtering/sorting options
         try:
             old_attrs = termios.tcgetattr(0)
         except termios.error:

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -11,7 +11,20 @@
 import pytest
 import re
 import datetime
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from types import SimpleNamespace
+from qtop_py.qtop import (
+    WNOccupancy,
+    decide_batch_system,
+    extract_user_detail,
+    get_date_obj_from_str,
+    JobNotFound,
+    load_yaml_config,
+    NoSchedulerFound,
+    safe_remap_replacement,
+    SchedulerNotSpecified,
+    update_config_with_cmdline_vars,
+    worker_node_sort_key,
+)
 
 
 @pytest.fixture
@@ -58,6 +71,42 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_extract_user_detail_supports_configured_re_search():
+    regex = r"re.search('(?<=<)[^<>]+(?=>)', field).group(0)"
+    assert extract_user_detail(regex, "Example User <example@example.org>") == "example@example.org"
+    assert extract_user_detail(regex, "Example User") == "Example User"
+
+
+def test_cmdline_bool_parsing_does_not_execute_values(tmp_path):
+    sentinel = tmp_path / "executed"
+    args = SimpleNamespace(OPTION=["enabled=True", "payload=__import__('pathlib').Path(%r).touch()" % str(sentinel)], TRANSPOSE=False, REM_EMPTY_CORELINES=0)
+    config = {"rem_empty_corelines": "0"}
+
+    updated = update_config_with_cmdline_vars(args, config)
+
+    assert updated["enabled"] is True
+    assert updated["payload"].startswith("__import__")
+    assert not sentinel.exists()
+
+
+def test_lambda_remapping_is_not_executed(tmp_path):
+    sentinel = tmp_path / "executed"
+    replacement = "__import__('pathlib').Path(%r).touch()" % str(sentinel)
+
+    assert safe_remap_replacement("lambda m: %s" % replacement) is None
+    assert not sentinel.exists()
+
+
+def test_worker_node_sort_key_uses_named_sorters():
+    node = {"domainname": "wn01-03-003.example.org", "state": "R", "np": "16", "core_job_map": {"0": "alice"}}
+
+    assert worker_node_sort_key(node, ["sort by nodename-notnum", "sort by all numbers", "sort by nr of cores"]) == (
+        "wn--.example.org",
+        103003,
+        16,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Small repository health checks for CI and local review."""
+
+import argparse
+import ast
+import os
+import sys
+
+
+def iter_python_files(paths):
+    for path in paths:
+        if os.path.isfile(path) and path.endswith(".py"):
+            yield path
+            continue
+        for root, dirnames, filenames in os.walk(path):
+            dirnames[:] = [dirname for dirname in dirnames if dirname not in {".git", ".tox", ".venv", "__pycache__"}]
+            for filename in filenames:
+                if filename.endswith(".py"):
+                    yield os.path.join(root, filename)
+
+
+def find_eval_calls(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=path)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
+            yield node.lineno
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run qtop fortification checks.")
+    parser.add_argument("paths", nargs="+", help="Files or directories to inspect")
+    args = parser.parse_args()
+
+    findings = []
+    for path in iter_python_files(args.paths):
+        for lineno in find_eval_calls(path):
+            findings.append("%s:%s runtime eval() call" % (path, lineno))
+
+    if findings:
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+
+    print("fortifications ok: no runtime eval() calls found")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #433

## Summary
- remove remaining runtime eval() calls from qtop's config/user-detail parsing, remapping, sorting, and PBS/SGE queue-count paths
- add a small AST-based make fortifications check that fails on executable Python eval() calls
- run the same fortification entry point from GitHub Actions and GitLab CI, with permissions: contents: read on GitHub
- keep Windows import/auto-detection paths importable by guarding SIGPIPE/	ermios and replacing /usr/bin/which with shutil.which
- independent PoC for the shared Makefile + GitHub/GitLab pattern: https://github.com/Jorel97/ci-fortifications-makefile-poc

## Validation
- py -m pytest tests\\test_qtop.py -q -> 38 passed
- py -m pytest tests\\plugins\\test_pbs.py tests\\plugins\\test_slurm.py tests\\test_pbs_sample_regressions.py -q -> 34 passed, 6 existing deprecation warnings
- py tools\\fortifications.py qtop_py tools tests -> fortifications ok
- py -m py_compile qtop_py\\qtop.py qtop_py\\plugins\\pbs.py qtop_py\\plugins\\sge.py tools\\fortifications.py

AI assistance disclosure: OpenAI Codex GPT-5 assisted with implementation and validation; I am responsible for the submitted changes.