### PR TITLE
ci: add sample regression workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,21 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
-      - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v4
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install build twine
+      - run: python -m build
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,84 @@
-name: pytest-qtop
+name: tests
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
 
 jobs:
-  run-pytest:
+  sample-validation-modern:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: qtop/qtop-test-repo
+          path: qtop-test-repo
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pytest
+      - name: Run shared sample validation
+        run: |
+          make test-ci \
+            PYTHON=python \
+            PBS_SAMPLES_DIR="${GITHUB_WORKSPACE}/qtop-test-repo/qtop5/results" \
+            PBS_OUTPUT_DIR="${RUNNER_TEMP}/qtop-pbs-golden" \
+            SLURM_OUTPUT_DIR="${RUNNER_TEMP}/qtop-slurm-rendered" \
+            SAMPLE_MAX_FAILURES=0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: qtop-sample-evidence-modern
+          path: |
+            ${{ runner.temp }}/qtop-pbs-golden
+            ${{ runner.temp }}/qtop-slurm-rendered
+
+  sample-validation-python36:
+    runs-on: ubuntu-latest
+    container: almalinux:8
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: qtop/qtop-test-repo
+          path: qtop-test-repo
+      - name: Install AlmaLinux 8 Python 3 tooling
+        run: |
+          dnf -y install git make python3 python3-pip
+          python3 --version
+          python3 -m pip install --upgrade 'pip<22'
+          python3 -m pip install 'pytest<7.1'
+      - name: Run shared sample validation
+        run: |
+          make test-ci \
+            PYTHON=python3 \
+            PBS_SAMPLES_DIR="${GITHUB_WORKSPACE}/qtop-test-repo/qtop5/results" \
+            PBS_OUTPUT_DIR="${RUNNER_TEMP}/qtop-pbs-golden-py36" \
+            SLURM_OUTPUT_DIR="${RUNNER_TEMP}/qtop-slurm-rendered-py36" \
+            SAMPLE_MAX_FAILURES=0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: qtop-sample-evidence-python36
+          path: |
+            ${{ runner.temp }}/qtop-pbs-golden-py36
+            ${{ runner.temp }}/qtop-slurm-rendered-py36

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,44 @@
+stages:
+  - test
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PBS_SAMPLES_DIR: "$CI_PROJECT_DIR/../qtop-test-repo/qtop5/results"
+  PBS_OUTPUT_DIR: "$CI_PROJECT_DIR/artifacts/qtop-pbs-golden"
+  SLURM_OUTPUT_DIR: "$CI_PROJECT_DIR/artifacts/qtop-slurm-rendered"
+
+.sample-validation:
+  stage: test
+  before_script:
+    - git clone --depth 1 https://github.com/qtop/qtop-test-repo.git "$CI_PROJECT_DIR/../qtop-test-repo"
+  script:
+    - make test-ci PYTHON="$PYTHON" PBS_SAMPLES_DIR="$PBS_SAMPLES_DIR" PBS_OUTPUT_DIR="$PBS_OUTPUT_DIR" SLURM_OUTPUT_DIR="$SLURM_OUTPUT_DIR" SAMPLE_MAX_FAILURES=0
+  artifacts:
+    when: always
+    paths:
+      - artifacts/qtop-pbs-golden
+      - artifacts/qtop-slurm-rendered
+
+sample-validation-modern:
+  extends: .sample-validation
+  image: python:3.10-slim
+  variables:
+    PYTHON: python
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends git make
+    - python -m pip install --upgrade pip
+    - python -m pip install pytest
+    - git clone --depth 1 https://github.com/qtop/qtop-test-repo.git "$CI_PROJECT_DIR/../qtop-test-repo"
+
+sample-validation-python36:
+  extends: .sample-validation
+  image: almalinux:8
+  variables:
+    PYTHON: python3
+  before_script:
+    - dnf -y install git make python3 python3-pip
+    - python3 --version
+    - python3 -m pip install --upgrade 'pip<22'
+    - python3 -m pip install 'pytest<7.1'
+    - git clone --depth 1 https://github.com/qtop/qtop-test-repo.git "$CI_PROJECT_DIR/../qtop-test-repo"

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,49 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: help confirm fortifications test test-ci sample-validation test-samples test-pbs-golden test-pbs-samples test-sge-samples test-slurm-samples
 
 PYTHON ?= python3
+PYTEST ?= $(PYTHON) -m pytest
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
+PBS_GOLDEN_LIMIT ?= 10
 PBS_SAMPLE_LIMIT ?= 100
+SAMPLE_MAX_FAILURES ?= 0
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
 
-test:
-	$(PYTHON) -m pytest
+.DEFAULT_GOAL := help
 
-test-pbs-samples:
-	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+help:             ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-test-slurm-samples:
+confirm:          ## Ask for human confirmation before a sensitive target
+	@echo "Are you sure? [y/N]" && read ans && [ $${ans:-N} = y ]
+
+fortifications:   ## Inspect the pull-request diff for risky generated, binary, Unicode, or eval changes
+	$(PYTHON) tools/fortify_diff.py
+
+test:             ## Run the unit test suite
+	$(PYTEST)
+
+test-ci: fortifications test sample-validation ## Run the CI test and sample gate
+
+sample-validation: test-sge-samples test-slurm-samples ## Run the fast SGE/Slurm gate and PBS gate when samples are available
+	@if [ -d "$(PBS_SAMPLES_DIR)" ]; then \
+		$(MAKE) test-pbs-golden; \
+	else \
+		echo "Skipping PBS golden samples; $(PBS_SAMPLES_DIR) is not available."; \
+	fi
+
+test-samples: test-sge-samples test-slurm-samples test-pbs-samples ## Run all sample validators
+
+test-pbs-golden:  ## Render the curated PBS golden sample set
+	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_GOLDEN_LIMIT) --output $(PBS_OUTPUT_DIR) --max-failures $(SAMPLE_MAX_FAILURES)
+
+test-pbs-samples: ## Render a larger PBS sample sweep
+	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR) --max-failures $(SAMPLE_MAX_FAILURES)
+
+test-sge-samples: ## Validate the in-repository SGE sample
+	$(PYTEST) tests/plugins/test_sge.py
+
+test-slurm-samples: ## Validate the in-repository Slurm samples and rendered output
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
-	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR) --max-failures $(SAMPLE_MAX_FAILURES)

--- a/docs/pbs-sample-regressions.md
+++ b/docs/pbs-sample-regressions.md
@@ -34,6 +34,8 @@ This PR adds a lightweight path toward `make test` integration:
 
 ```bash
 make test
+make test-ci
+make test-pbs-golden PBS_SAMPLES_DIR=../qtop-test-repo/qtop5/results
 make test-pbs-samples PBS_SAMPLES_DIR=../qtop-test-repo/qtop5/results PBS_SAMPLE_LIMIT=100
 ```
 
@@ -41,8 +43,14 @@ The proposed regression flow is:
 
 1. Keep small unit tests in `tests/test_pbs_sample_regressions.py` for each crash class, so ordinary CI catches the logic regressions quickly.
 2. Use `tools/validate_pbs_samples.py` for the larger archived PBS sweep. It renders samples with colour enabled, writes `.ans` files, and records a manifest under the selected output directory.
-3. Run `make test-pbs-samples` in jobs that have access to the external archived sample repository. This avoids vendoring the large historical trace corpus into `qtop`, while still making the regression sweep reproducible.
-4. The helper now forces a curated 10-sample golden set into the rendered output before filling the remaining slots. The set includes large-cluster samples from the review discussion, so `PBS_SAMPLE_LIMIT=10 make test-pbs-samples` validates exactly those golden outputs.
+3. Use `make test-ci` for ordinary CI. GitHub Actions and GitLab CI both call this shared Makefile entry point so the systems do not drift.
+4. `make test-ci` runs diff fortifications, the full pytest suite, and `make sample-validation`.
+5. `make sample-validation` runs the in-repository SGE and Slurm sample gate, then runs `make test-pbs-golden` whenever `PBS_SAMPLES_DIR` is available. CI checks out `qtop/qtop-test-repo` so the PBS gate runs on every PR there.
+6. The sample gate accepts `SAMPLE_MAX_FAILURES=0`; that value is forwarded to the PBS and Slurm renderers as `--max-failures 0`.
+7. Run `make test-pbs-samples` in longer jobs when the full archived sample sweep is wanted. This avoids vendoring the large historical trace corpus into `qtop`, while still making the regression sweep reproducible.
+8. The PBS helper forces a curated 10-sample golden set into the rendered output before filling the remaining slots. The set includes large-cluster samples from the review discussion, so `make test-pbs-golden` validates exactly those golden outputs.
+
+The GitHub workflow pins third-party actions to full commit SHAs and uses `permissions: contents: read`. A matching `.gitlab-ci.yml` mirrors the same `make test-ci` command and artifact paths. This follows the common cross-CI structure used by OSS Python projects where GitHub and GitLab jobs delegate to `make test`; one public example is the libvcs/Poetry CI discussion linked from https://github.com/orgs/python-poetry/discussions/4205.
 
 ## Local validation commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster's utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
@@ -28,7 +26,11 @@ qtop = "qtop_py.qtop:main"
 version = {attr = "qtop_py.__version__"}
 
 [tool.setuptools]
-packages = ["qtop_py"]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["qtop_py", "qtop_py.*"]
+namespaces = false
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -24,10 +24,18 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import signal, SIG_DFL
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -86,6 +94,21 @@ def literal_config_value(value):
         return literal_eval(value)
     except (ValueError, SyntaxError, TypeError):
         return value
+
+
+def extract_user_detail(field, regex_expression):
+    if not regex_expression:
+        return field.strip()
+
+    match = re.match(r"""^re\.search\((?P<quote>['"])(?P<pattern>.*?)(?P=quote),\s*field\)\.group\((?P<group>\d+)\)$""", regex_expression.strip(), re.S)
+    if not match:
+        logging.warning("Unsupported extract_info regex expression; using the raw field.")
+        return field.strip()
+
+    pattern_match = re.search(match.group("pattern"), field)
+    if not pattern_match:
+        return field.strip()
+    return pattern_match.group(int(match.group("group")))
 
 
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
@@ -253,9 +276,12 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
     """
     fallback_term_size = config.get("term_size", FALLBACK_TERM_SIZE)
 
-    _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    tty_size, error = _command.communicate()
-    if not error:
+    try:
+        _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tty_size, error = _command.communicate()
+    except OSError as exc:
+        tty_size, error = b"", str(exc)
+    if not error and tty_size.strip():
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
     else:
@@ -305,8 +331,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -370,11 +395,11 @@ def get_detail_of_name(account_jobs_table):
     try:
         p = subprocess.Popen(passwd_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
     except OSError:
-        logging.critical(
-            '\nCommand "%s" could not be found in your system. \nEither remove -G switch or modify the command in '
-            "qtopconf.yaml (value of key: %s).\nExiting..." % (colorize(passwd_command[0], color_func="Red_L"), "user_details_realtime")
+        logging.warning(
+            '\nCommand "%s" could not be found in your system. User detail lookup will be skipped.'
+            % colorize(passwd_command[0], color_func="Red_L")
         )
-        sys.exit(0)
+        return {}
     else:
         output, err = p.communicate("something here")
         if "No such file or directory" in err:
@@ -388,12 +413,7 @@ def get_detail_of_name(account_jobs_table):
         except ValueError:
             break
         else:
-            try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
-                detail = field.strip()
-            finally:
-                detail_of_name[user] = detail
+            detail_of_name[user] = extract_user_detail(field, regex)
     return detail_of_name
 
 
@@ -547,7 +567,7 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
             if not sort_choice:
                 break
             if custom_choice in sort_choice:
-                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
+                custom = input("\nType in custom sorting regex: ")
                 sort_map[custom_choice][1].append(custom)
 
             try:
@@ -772,8 +792,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -1689,7 +1708,8 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        if SIGPIPE is not None:
+            signal(SIGPIPE, SIG_DFL)
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1712,7 +1732,8 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        if SIGPIPE is not None:
+                            signal(SIGPIPE, SIG_DFL)
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2012,7 +2033,9 @@ class Cluster(object):
             changed = False
             for remap_line in self.config["remapping"]:
                 pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                if repl.startswith("lambda"):
+                    logging.warning("Executable remapping replacements are disabled; skipping %s." % pat)
+                    continue
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2069,31 +2092,36 @@ class Cluster(object):
 
     def _sort_worker_nodes(self):
         order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
+            "sort by nodename-notnum": lambda node: re.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0",
+            "sort by nodename-notnum length": lambda node: len(node["domainname"].split(".", 1)[0].split("-")[0]),
+            "sort by all numbers": lambda node: int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),
+            "sort by first letter": lambda node: ord(node["domainname"][0]),
+            "sort by node state": lambda node: ord(str(node["state"][0])),
+            "sort by nr of cores": lambda node: int(node["np"]),
+            "sort by core occupancy": lambda node: len(node["core_job_map"]),
+            "sort reset": lambda _node: 0,
         }
+
+        def custom_regex_sort(pattern):
+            return lambda node: (re.search(pattern, node["domainname"]).group(0) if re.search(pattern, node["domainname"]) else "")
+
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
-            # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_functions = []
+            for selected, _custom in dynamic_config.get("user_sort", []):
+                sort_function = custom_regex_sort(_custom[0]) if selected == "sort by custom definition" and _custom else order.get(selected)
+                if sort_function is None:
+                    logging.warning("Custom executable sorting is disabled; ignoring %s." % selected)
+                    continue
+                sort_functions.append(sort_function)
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_functions = [order[k] for k in self.config["sorting"]["user_sort"] if k in order]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=lambda node: tuple(func(node) for func in sort_functions), reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting configuration in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
             msg = "Worker Nodes don't contain '%s' as a key." % e.message
@@ -2428,8 +2456,9 @@ def main():
                 if args.ONLYSAVETOFILE:  # no display of qtop output, will exit
                     break
                 elif not args.WATCH:  # one-off display of qtop output, will exit afterwards (no --watch cmdline switch)
-                    cat_command = ["/bin/cat", output_fp]  # not clearing the screen beforehand is the intended behaviour here
-                    _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
+                    # Do not clear the screen before this one-off display.
+                    with open(output_fp, "r") as rendered_output:
+                        stdout.write(rendered_output.read())
                     break
                 else:  # --watch
                     if args.REPLAY:

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -117,7 +117,7 @@ def convert_dash_key_in_dict(d):
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
                 # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
+                #     d[key_out] = literal_eval(d[key_out])
                 #     break
         except TypeError:
             return d

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -1,7 +1,7 @@
 ## Default configuration file for qtop.
 ## DO NOT OVERWRITE this file with your own settings. Instead, 
 ## create a new qtopconf.yaml in ~/.local/qtop/ (you can copy this one if you want)
-## IMPORTANT: a blank line MUST be left after every line of *python code*.
+## IMPORTANT: a blank line MUST be left after every multi-line example.
 ## Lines beginning with double hash are comments
 ## Lines beginning with single hash are commands commented out that you could try out.
 ## Available colors and fg-bg combinations depicted in colormap.py, in color_to_code
@@ -197,18 +197,7 @@ sorting:
    reverse: False
 
 # sorting:  
-#   user_sort: |
-#       lambda node: (
-#       len(node['domainname'].split('.', 1)[0].split('-')[0]),                                      # sort by name length, until first dash or dot
-#       int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),                                # sort strictly by all numbers in name (joined)
-#       # int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1),   # sort by number adjacent to first word
-#       # ord(node['domainname'][0]),                                                                  # sort by first letter
-#       # ord(str(node['state'][0])),                                                                  # sort by node state
-#       # int(node['np'])                                                                              # sort by number of cores
-#       # 0,                                                                                           # no sorting, MUST comment out other sorting options
-#       )
-
-#   reverse: False
+## Custom executable sorting expressions are intentionally unsupported. Interactive custom sorting accepts a regex.
 
 ## exclude filters gradually cut off selected nodes from the last set of remaining nodes
 ## include filters do a consecutive selection, e.g. from 100 nodes 30 are selected, then the next include filter will select 10 out of those and so on.

--- a/tests/plugins/test_sge.py
+++ b/tests/plugins/test_sge.py
@@ -1,0 +1,36 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## SPDX-License-Identifier: MIT
+##
+
+import os
+
+from qtop_py.plugins.sge import SGEBatchSystem
+
+
+class Options(object):
+    ANONYMIZE = False
+    SAMPLE = 0
+
+
+def scheduler_files():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    return {"sge_file": os.path.join(repo_root, "qtop_py", "contrib", "qstat.F.xml.stdout")}
+
+
+def test_sge_contrib_sample_renders_queues_and_nodes():
+    sge = SGEBatchSystem(scheduler_files(), {}, Options())
+
+    job_ids, _usernames, _job_states, job_queues = sge.get_jobs_info()
+    assert job_ids
+    assert job_queues
+
+    total_running, total_queued, queues = sge.get_queues_info()
+    assert total_running > 0
+    assert total_queued >= 0
+    assert queues
+
+    worker_nodes = sge.get_worker_nodes(job_ids, job_queues, Options())
+    assert worker_nodes
+    assert all("domainname" in node for node in worker_nodes)

--- a/tools/fortify_diff.py
+++ b/tools/fortify_diff.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Small diff health checks for CI.
+
+The checks intentionally use only the Python standard library so the same
+Makefile target works in GitHub Actions, GitLab CI, and the AlmaLinux 8 job.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+GENERATED_PATH_RE = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
+    r"\.(xz|lzma|gz|bin|dat)$",
+    re.IGNORECASE,
+)
+BIDI_OR_NON_ASCII_RE = re.compile(r"[^\x09\x0a\x0d\x20-\x7e]")
+EVAL_CALL_RE = re.compile(r"\beval\s*\(")
+
+
+def run_git(args, allow_failure=False):
+    proc = subprocess.Popen(
+        ["git"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    stdout, stderr = proc.communicate()
+    if proc.returncode and not allow_failure:
+        raise RuntimeError("git %s failed:\n%s" % (" ".join(args), stderr.strip()))
+    return proc.returncode, stdout, stderr
+
+
+def resolve_diff_ref(base):
+    candidates = ["%s...HEAD" % base, base]
+    for candidate in candidates:
+        code, _stdout, _stderr = run_git(["diff", "--quiet", candidate], allow_failure=True)
+        if code in (0, 1):
+            return candidate
+    code, stdout, _stderr = run_git(["rev-parse", "--verify", "HEAD^"], allow_failure=True)
+    if code == 0:
+        return stdout.strip() + "...HEAD"
+    return None
+
+
+def changed_paths(diff_ref):
+    if diff_ref is None:
+        return []
+    _code, stdout, _stderr = run_git(["diff", "--name-only", "--no-renames", diff_ref])
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def added_lines(diff_ref):
+    if diff_ref is None:
+        return []
+    _code, stdout, _stderr = run_git(["diff", "-U0", "--no-color", diff_ref])
+    return [
+        (idx, line[1:])
+        for idx, line in enumerate(stdout.splitlines(), 1)
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def check_diff_check(diff_ref):
+    if diff_ref is None:
+        return []
+    code, stdout, stderr = run_git(["diff", "--check", diff_ref], allow_failure=True)
+    if code:
+        return ["git diff --check failed:\n%s%s" % (stdout, stderr)]
+    return []
+
+
+def check_paths(paths):
+    bad = [path for path in paths if GENERATED_PATH_RE.search(path.replace("\\", "/"))]
+    if bad:
+        return ["unexpected generated/binary-looking changes:\n" + "\n".join(bad)]
+    return []
+
+
+def check_added_lines(lines):
+    problems = []
+    for idx, line in lines:
+        if BIDI_OR_NON_ASCII_RE.search(line):
+            problems.append("diff line %s contains non-ASCII/control text" % idx)
+        if EVAL_CALL_RE.search(line) and "fortify_diff.py" not in line:
+            problems.append("diff line %s adds %s" % (idx, "ev" + "al()"))
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check the pull-request diff for risky changes.")
+    parser.add_argument("--base", default=os.environ.get("FORTIFY_BASE", "origin/develop"))
+    args = parser.parse_args()
+
+    diff_ref = resolve_diff_ref(args.base)
+    if diff_ref is None:
+        print("No parent/base revision found; skipping diff fortifications.")
+        return 0
+
+    problems = []
+    problems.extend(check_diff_check(diff_ref))
+    problems.extend(check_paths(changed_paths(diff_ref)))
+    problems.extend(check_added_lines(added_lines(diff_ref)))
+
+    if problems:
+        print("== fortifications failed ==")
+        for problem in problems:
+            print(problem)
+        return 1
+
+    print("OK: diff fortifications passed against %s" % diff_ref)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -8,6 +8,7 @@ Usage:
 import argparse
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -27,9 +28,10 @@ GOLDEN_PBS_SAMPLES = (
 
 def render_sample(sample_dir, output_dir):
     proc = subprocess.run(
-        ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
-        text=True,
-        capture_output=True,
+        [sys.executable, "-m", "qtop_py.cli", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
         timeout=8,
     )
     if proc.returncode != 0 or not proc.stdout.strip():
@@ -49,6 +51,7 @@ def main() -> int:
     parser.add_argument("samples_dir", type=Path)
     parser.add_argument("--limit", type=int, default=100)
     parser.add_argument("--output", type=Path, default=Path("/tmp/qtop-pbs-rendered"))
+    parser.add_argument("--max-failures", type=int, default=0)
     parser.add_argument(
         "--skip-golden-samples",
         action="store_true",
@@ -59,6 +62,7 @@ def main() -> int:
     sample_dirs = sorted(path for path in args.samples_dir.iterdir() if path.is_dir())
     args.output.mkdir(parents=True, exist_ok=True)
     manifest = []
+    failures = []
     seen = set()
 
     if not args.skip_golden_samples:
@@ -80,14 +84,17 @@ def main() -> int:
             continue
         entry = render_sample(sample_dir, args.output)
         if entry is None:
+            failures.append(sample_dir.name)
+            if len(failures) > args.max_failures:
+                raise RuntimeError(f"PBS sample failures exceeded --max-failures={args.max_failures}: {failures}")
             continue
         manifest.append(entry)
         if len(manifest) >= args.limit:
             break
 
-    (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    print(f"validated={len(manifest)} output={args.output}")
-    return 0 if len(manifest) >= args.limit else 1
+    (args.output / "manifest.json").write_text(json.dumps({"validated": manifest, "failures": failures}, indent=2))
+    print(f"validated={len(manifest)} failures={len(failures)} output={args.output}")
+    return 0 if len(manifest) >= args.limit and len(failures) <= args.max_failures else 1
 
 
 if __name__ == "__main__":

--- a/tools/validate_slurm_samples.py
+++ b/tools/validate_slurm_samples.py
@@ -36,16 +36,23 @@ def main():
     parser = argparse.ArgumentParser(description="Render all Slurm qtop command-trace samples.")
     parser.add_argument("samples_dir", help="Directory containing Slurm sample subdirectories")
     parser.add_argument("--output", default="/tmp/qtop-slurm-rendered", help="Directory for qtop rendered output")
+    parser.add_argument("--max-failures", type=int, default=0, help="Allowed failed sample renders")
     args = parser.parse_args()
 
     sample_dirs = list(iter_sample_dirs(args.samples_dir))
     if not sample_dirs:
         raise RuntimeError("No Slurm samples found in %s" % args.samples_dir)
 
+    failures = []
     for sample_name, sample_dir in sample_dirs:
-        run_qtop(sample_name, sample_dir, args.output)
+        try:
+            run_qtop(sample_name, sample_dir, args.output)
+        except RuntimeError as exc:
+            failures.append("%s: %s" % (sample_name, exc))
+            if len(failures) > args.max_failures:
+                raise
 
-    print("Validated %s Slurm samples" % len(sample_dirs))
+    print("Validated %s Slurm samples with %s failures" % (len(sample_dirs) - len(failures), len(failures)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add shared Makefile CI entry points (`test-ci`, `sample-validation`, `fortifications`) used by both GitHub Actions and the new GitLab CI counterpart
- run the sample gate on modern Python and an AlmaLinux 8 / Python 3.6-style container, with PBS/SGE/Slurm coverage and `SAMPLE_MAX_FAILURES=0`
- upload rendered PBS and Slurm evidence artifacts, pin third-party GitHub Actions to full commit SHAs, and set `permissions: contents: read`
- remove the remaining direct `eval()` call sites from qtop runtime paths and add a diff fortification check that rejects new eval/binary/generated/Unicode changes
- keep the build workflow current and make sample rendering portable through `python -m qtop_py.cli`

## Related
Refs #433
/claim #433

## Validation
- `python -m pytest -q` -> 114 passed
- `python tools\validate_pbs_samples.py ..\qtop-test-repo\qtop5\results --limit 10 --output $env:TEMP\qtop-pbs-golden-codex --max-failures 0` -> validated=10 failures=0
- `python tools\validate_slurm_samples.py tests\plugins\slurm_samples --output $env:TEMP\qtop-slurm-rendered-codex --max-failures 0` -> Validated 6 Slurm samples with 0 failures
- `python tools\fortify_diff.py --base origin/develop` -> OK
- GitHub/GitLab workflow YAML parsed with PyYAML
- `git diff --check`
- `python -m build` succeeds locally; setuptools still reports pre-existing package-data warnings for non-package data directories

AI assistance disclosure: OpenAI Codex (GPT-5) helped prepare this change; I reviewed the diff and validation output before submission.