### PR TITLE
ci: add shared sample gate for GitHub and GitLab

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build-qtop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -15,13 +18,14 @@ jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
-      - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v4
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install build twine
+      - run: make build
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,59 @@
 name: pytest-qtop
 
-on: push
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.9'
+          - '3.10'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pytest coverage ruff==0.0.292
+      - run: make fortify
+      - run: make lint
+      - run: make test
+      - run: make coverage
+      - run: mkdir -p artifacts
+      - run: python -m coverage xml -o artifacts/coverage.xml
+      - run: make sample-gate SAMPLE_OUTPUT_DIR=artifacts/sample-gate SAMPLE_MAX_FAILURES=0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: sample-gate-${{ matrix.python-version }}
+          path: artifacts/
+
+  almalinux8-sample-gate:
+    runs-on: ubuntu-latest
+    container: almalinux:8
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - run: dnf install -y python36 make git
+      - run: make sample-gate PYTHON=python3.6 SAMPLE_OUTPUT_DIR=artifacts/sample-gate SAMPLE_MAX_FAILURES=0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: sample-gate-almalinux8-python36
+          path: artifacts/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+stages:
+  - test
+  - build
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  SAMPLE_OUTPUT_DIR: "artifacts/sample-gate"
+  SAMPLE_MAX_FAILURES: "0"
+
+pytest:
+  image: python:3.10-slim
+  stage: test
+  before_script:
+    - apt-get update && apt-get install -y --no-install-recommends make git && rm -rf /var/lib/apt/lists/*
+    - python -m pip install --upgrade pip
+    - python -m pip install pytest coverage ruff==0.0.292
+  script:
+    - make fortify BASE_REF=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-origin/develop}
+    - make lint
+    - make test
+    - make coverage
+    - mkdir -p artifacts
+    - python -m coverage xml -o artifacts/coverage.xml
+    - make sample-gate SAMPLE_OUTPUT_DIR=$SAMPLE_OUTPUT_DIR SAMPLE_MAX_FAILURES=$SAMPLE_MAX_FAILURES
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: artifacts/coverage.xml
+  coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+)%/'
+
+almalinux8-sample-gate:
+  image: almalinux:8
+  stage: test
+  before_script:
+    - dnf install -y python36 make git
+  script:
+    - make sample-gate PYTHON=python3.6 SAMPLE_OUTPUT_DIR=$SAMPLE_OUTPUT_DIR SAMPLE_MAX_FAILURES=$SAMPLE_MAX_FAILURES
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+
+build:
+  image: python:3.10-slim
+  stage: build
+  before_script:
+    - apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*
+    - python -m pip install --upgrade pip
+    - python -m pip install build twine
+  script:
+    - make build
+  artifacts:
+    paths:
+      - dist/

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,56 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: help test test-pbs-samples test-slurm-samples sample-gate lint lint-fix format-check format-fix coverage fortify build clean
 
 PYTHON ?= python3
+BASE_REF ?= origin/develop
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+SAMPLE_SCHEDULERS ?= slurm,pbs,sge
+SAMPLE_LIMIT ?= 6
+SAMPLE_MAX_FAILURES ?= 0
+SAMPLE_OUTPUT_DIR ?= artifacts/sample-gate
 
-test:
+.DEFAULT_GOAL := help
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_.-]+:.*## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test: ## Run the pytest suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
+test-pbs-samples: ## Validate external PBS sample renders
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Validate bundled Slurm sample renders
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+
+sample-gate: ## Run the fast scheduler sample gate used by GitHub and GitLab CI
+	$(PYTHON) tools/validate_samples.py --schedulers $(SAMPLE_SCHEDULERS) --limit $(SAMPLE_LIMIT) --max-failures $(SAMPLE_MAX_FAILURES) --output $(SAMPLE_OUTPUT_DIR) --pbs-samples-dir $(PBS_SAMPLES_DIR) --slurm-samples-dir $(SLURM_SAMPLES_DIR)
+
+lint: ## Run ruff checks without modifying files
+	$(PYTHON) -m ruff check .
+
+lint-fix: ## Apply safe ruff fixes
+	$(PYTHON) -m ruff check --fix .
+
+format-check: ## Show ruff fixes that would be applied
+	$(PYTHON) -m ruff check --diff .
+
+format-fix: ## Apply safe formatting-style fixes
+	$(PYTHON) -m ruff check --fix .
+
+coverage: ## Run tests and print a coverage report
+	$(PYTHON) -m coverage run -m pytest
+	$(PYTHON) -m coverage report
+
+fortify: ## Check the branch diff for accidental artifacts and suspicious text
+	$(PYTHON) tools/fortify_diff.py --base $(BASE_REF)
+
+build: ## Build source and wheel distributions
+	$(PYTHON) -m build
+
+clean: ## Remove local build and test outputs
+	rm -rf build dist qtop.egg-info .coverage .pytest_cache artifacts

--- a/docs/ci-sample-gate.md
+++ b/docs/ci-sample-gate.md
@@ -1,0 +1,39 @@
+# CI sample gate
+
+`make sample-gate` is the shared fast validation entry point for local runs,
+GitHub Actions, and GitLab CI. It renders scheduler command traces through qtop
+and stores a JSON manifest plus rendered output under `artifacts/sample-gate`.
+
+## Sample sources
+
+- Slurm samples are bundled in `tests/plugins/slurm_samples`.
+- PBS samples can be supplied from `../qtop-test-repo/qtop5/results` or by
+  overriding `PBS_SAMPLES_DIR`.
+- SGE is wired into the same gate through `SAMPLE_SCHEDULERS`, but the current
+  repository does not bundle runnable SGE command traces.
+
+## Limits and failure policy
+
+The default gate validates up to six samples per scheduler and allows zero
+failures:
+
+```sh
+make sample-gate
+```
+
+CI can tune the same command without duplicating shell logic:
+
+```sh
+make sample-gate SAMPLE_LIMIT=12 SAMPLE_MAX_FAILURES=0
+```
+
+Missing optional external sample directories are recorded as `skipped` in the
+manifest. Render failures are recorded as `failed`; CI fails when failures exceed
+`SAMPLE_MAX_FAILURES`.
+
+## CI shape
+
+GitHub Actions and GitLab CI both call the Makefile target. This keeps the CI
+definition thin and makes the same check available to contributors before they
+push. The local proof of concept is `tools/validate_samples.py`, which uses only
+the Python standard library so it can run in early cluster-like environments.

--- a/docs/ci-sample-gate.md
+++ b/docs/ci-sample-gate.md
@@ -37,3 +37,16 @@ GitHub Actions and GitLab CI both call the Makefile target. This keeps the CI
 definition thin and makes the same check available to contributors before they
 push. The local proof of concept is `tools/validate_samples.py`, which uses only
 the Python standard library so it can run in early cluster-like environments.
+
+## Independent pattern reference
+
+This gate follows the same portable CI shape used by other open source projects:
+keep provider-specific YAML small, then delegate real validation to a checked-in
+command that contributors can run locally.
+
+- `neil-lindquist/ci-utils` is an OSS utility/example set for multiple CI
+  providers, including GitHub Actions and GitLab CI:
+  https://github.com/neil-lindquist/ci-utils
+- The Common Lisp Cookbook's CI guide shows GitLab CI jobs delegating to
+  `make test`, matching the same local-command-first structure used here:
+  https://lispcookbook.github.io/cl-cookbook/testing.html#continuous-integration

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -15,6 +15,7 @@ except ImportError:
 import logging
 import re
 from qtop_py.serialiser import StatExtractor, GenericBatchSystem
+from qtop_py import utils
 import qtop_py.fileutils as fileutils
 import itertools
 
@@ -317,7 +318,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return utils.safe_int(total_running_jobs), utils.safe_int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -6,6 +6,7 @@ except ImportError:
 import logging
 import sys
 from qtop_py.serialiser import StatExtractor, GenericBatchSystem
+from qtop_py import utils
 from xml.etree import ElementTree as etree
 import qtop_py.fileutils as fileutils
 
@@ -132,7 +133,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, utils.safe_int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -772,7 +772,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = utils.parse_boolish(val)
         config[key] = val
 
     if args.TRANSPOSE:

--- a/qtop_py/utils.py
+++ b/qtop_py/utils.py
@@ -10,10 +10,33 @@
 
 import logging
 import sys
+from ast import literal_eval
 from argparse import ArgumentParser
 from qtop_py import fileutils
 from qtop_py.colormap import *  # noqa: F403  ## FIXME: this is a code-smell, because it can be tightened
 from qtop_py.constants import QTOP_LOGFILE
+
+
+def safe_int(value):
+    """Convert scheduler totals without evaluating arbitrary expressions."""
+    if isinstance(value, int):
+        return value
+    parsed = literal_eval(str(value))
+    if isinstance(parsed, bool):
+        raise ValueError("boolean is not a valid integer total")
+    return int(parsed)
+
+
+def parse_boolish(value):
+    """Parse command-line config overrides for booleans without eval()."""
+    if isinstance(value, bool):
+        return value
+    lowered = str(value).strip().lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return value
 
 
 def init_logging(options):

--- a/tests/test_fortify_diff.py
+++ b/tests/test_fortify_diff.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_fortify_diff():
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "fortify_diff.py"
+    spec = importlib.util.spec_from_file_location("fortify_diff", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fortify_diff = load_fortify_diff()
+
+
+def test_artifact_paths_flags_generated_outputs():
+    paths = [
+        "dist/qtop-1.0.tar.gz",
+        "qtop.egg-info/PKG-INFO",
+        "build/lib/qtop.py",
+        "qtop_py/plugins/slurm.py",
+    ]
+
+    assert fortify_diff.artifact_paths(paths) == paths[:3]
+
+
+def test_suspicious_added_lines_flags_non_ascii_and_controls():
+    diff = "\n".join(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "+plain ascii",
+            "+unicode caf\u00e9",
+            "+bidi \u202e marker",
+            "+control \x01 marker",
+        ]
+    )
+
+    findings = fortify_diff.suspicious_added_lines(diff)
+
+    assert [finding.reason for finding in findings] == [
+        "non-ascii character",
+        "bidirectional unicode control",
+        "control character",
+    ]
+
+
+def test_suspicious_added_lines_can_allow_non_ascii_text():
+    diff = "+unicode caf\u00e9\n+bidi \u202e marker"
+
+    findings = fortify_diff.suspicious_added_lines(diff, allow_non_ascii=True)
+
+    assert [finding.reason for finding in findings] == ["bidirectional unicode control"]

--- a/tools/fortify_diff.py
+++ b/tools/fortify_diff.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Lightweight PR diff checks for qtop contributors.
+
+The checks intentionally use only the Python standard library so they can run
+in early cluster-like environments where optional developer tools may be absent.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from typing import Iterable, List, NamedTuple, Optional, Sequence, Set
+
+
+BIDI_CODEPOINTS = {
+    0x202A,
+    0x202B,
+    0x202C,
+    0x202D,
+    0x202E,
+    0x2066,
+    0x2067,
+    0x2068,
+    0x2069,
+}
+
+ARTIFACT_RE = re.compile(
+    r"(^|/)(build|dist|\.eggs|qtop\.egg-info|htmlcov|\.pytest_cache|__pycache__)(/|$)"
+    r"|(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/"
+    r"|\.(xz|lzma|gz|bin|dat|pyc|pyo|so|whl|egg)$",
+    re.IGNORECASE,
+)
+
+
+class SuspiciousText(NamedTuple):
+    line_no: int
+    reason: str
+    text: str
+
+
+def run_git(args: Sequence[str], check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        universal_newlines=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def ref_exists(ref: str) -> bool:
+    return run_git(["rev-parse", "--verify", "--quiet", ref], check=False).returncode == 0
+
+
+def diff_args(base: Optional[str]) -> List[str]:
+    if base and ref_exists(base):
+        return [f"{base}...HEAD"]
+    return []
+
+
+def unique_lines(lines: Iterable[str]) -> List[str]:
+    seen: Set[str] = set()
+    unique: List[str] = []
+    for line in lines:
+        if line and line not in seen:
+            seen.add(line)
+            unique.append(line)
+    return unique
+
+
+def changed_files(base: Optional[str]) -> List[str]:
+    outputs = [
+        run_git(["diff", "--name-only", "--diff-filter=ACMRT", *diff_args(base)]).stdout,
+        run_git(["diff", "--name-only", "--diff-filter=ACMRT"]).stdout,
+        run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMRT"]).stdout,
+        run_git(["ls-files", "--others", "--exclude-standard"]).stdout,
+    ]
+    return unique_lines(line for output in outputs for line in output.splitlines())
+
+
+def artifact_paths(paths: Iterable[str]) -> List[str]:
+    return [path for path in paths if ARTIFACT_RE.search(path)]
+
+
+def classify_suspicious_char(ch: str, allow_non_ascii: bool) -> Optional[str]:
+    codepoint = ord(ch)
+    if codepoint in BIDI_CODEPOINTS:
+        return "bidirectional unicode control"
+    if ch not in "\t\n\r" and codepoint < 32:
+        return "control character"
+    if not allow_non_ascii and codepoint > 126:
+        return "non-ascii character"
+    return None
+
+
+def suspicious_added_lines(diff_text: str, allow_non_ascii: bool = False) -> List[SuspiciousText]:
+    findings: List[SuspiciousText] = []
+    for line_no, line in enumerate(diff_text.splitlines(), start=1):
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        text = line[1:]
+        for ch in text:
+            reason = classify_suspicious_char(ch, allow_non_ascii)
+            if reason:
+                findings.append(SuspiciousText(line_no, reason, text))
+                break
+    return findings
+
+
+def branch_diff(base: Optional[str]) -> str:
+    outputs = [
+        run_git(["diff", "--unified=0", "--no-ext-diff", *diff_args(base)]).stdout,
+        run_git(["diff", "--unified=0", "--no-ext-diff"]).stdout,
+        run_git(["diff", "--cached", "--unified=0", "--no-ext-diff"]).stdout,
+    ]
+    return "\n".join(output for output in outputs if output)
+
+
+def diff_check(base: Optional[str]) -> str:
+    outputs: List[str] = []
+    for args in (["diff", "--check", *diff_args(base)], ["diff", "--check"], ["diff", "--cached", "--check"]):
+        result = run_git(args, check=False)
+        if result.returncode:
+            outputs.append(result.stdout.rstrip())
+    return "\n".join(output for output in outputs if output)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/develop", help="base ref for branch diff checks")
+    parser.add_argument(
+        "--allow-non-ascii",
+        action="store_true",
+        help="allow non-ASCII additions while still checking control and bidi characters",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    failures: List[str] = []
+
+    whitespace_errors = diff_check(args.base)
+    if whitespace_errors:
+        failures.append("git diff --check reported whitespace errors:\n" + whitespace_errors.rstrip())
+
+    artifacts = artifact_paths(changed_files(args.base))
+    if artifacts:
+        failures.append("unexpected generated or binary-looking paths:\n" + "\n".join(f"  {path}" for path in artifacts))
+
+    suspicious = suspicious_added_lines(branch_diff(args.base), allow_non_ascii=args.allow_non_ascii)
+    if suspicious:
+        rendered = "\n".join(f"  diff line {item.line_no}: {item.reason}: {item.text!r}" for item in suspicious[:20])
+        extra = "" if len(suspicious) <= 20 else f"\n  ... {len(suspicious) - 20} more"
+        failures.append("suspicious text in added lines:\n" + rendered + extra)
+
+    if failures:
+        print("\n\n".join(failures), file=sys.stderr)
+        return 1
+
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -28,8 +28,9 @@ GOLDEN_PBS_SAMPLES = (
 def render_sample(sample_dir, output_dir):
     proc = subprocess.run(
         ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
-        text=True,
-        capture_output=True,
+        universal_newlines=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         timeout=8,
     )
     if proc.returncode != 0 or not proc.stdout.strip():

--- a/tools/validate_samples.py
+++ b/tools/validate_samples.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Fast scheduler sample gate shared by local, GitHub, and GitLab CI."""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def ensure_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+def write_text(path, text):
+    with open(path, "w") as handle:
+        handle.write(text)
+
+
+def run_command(command, env=None, timeout=12):
+    return subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        universal_newlines=True,
+        timeout=timeout,
+    )
+
+
+def record(scheduler, sample, status, output=None, stdout=None, stderr=None, reason=None):
+    return {
+        "scheduler": scheduler,
+        "sample": sample,
+        "status": status,
+        "output": output,
+        "stdout_tail": (stdout or "").splitlines()[-8:],
+        "stderr_tail": (stderr or "").splitlines()[-8:],
+        "reason": reason,
+    }
+
+
+def iter_dirs(root):
+    if not root or not os.path.isdir(root):
+        return
+    for name in sorted(os.listdir(root)):
+        path = os.path.join(root, name)
+        if os.path.isdir(path):
+            yield name, path
+
+
+def validate_slurm(args, output_root):
+    scheduler_output = os.path.join(output_root, "slurm")
+    ensure_dir(scheduler_output)
+    entries = []
+    sample_dirs = [
+        (name, path)
+        for name, path in iter_dirs(args.slurm_samples_dir)
+        if os.path.isfile(os.path.join(path, "squeue.txt")) and os.path.isfile(os.path.join(path, "sinfo.txt"))
+    ]
+    if not sample_dirs:
+        return [record("slurm", None, "skipped", reason="no bundled Slurm samples found")]
+
+    for name, path in sample_dirs[: args.limit]:
+        sample_output = os.path.join(scheduler_output, name)
+        ensure_dir(sample_output)
+        env = os.environ.copy()
+        env["QTOP_SCHEDULER"] = "slurm"
+        proc = run_command([sys.executable, "-m", "qtop_py.cli", "-b", "slurm", "-s", path, "-O", "-o", "savepath=%s" % sample_output], env=env)
+        status = "passed" if proc.returncode == 0 else "failed"
+        entries.append(record("slurm", name, status, output=sample_output, stdout=proc.stdout, stderr=proc.stderr))
+    return entries
+
+
+def validate_pbs(args, output_root):
+    scheduler_output = os.path.join(output_root, "pbs")
+    ensure_dir(scheduler_output)
+    if not args.pbs_samples_dir or not os.path.isdir(args.pbs_samples_dir):
+        return [record("pbs", None, "skipped", reason="external PBS sample directory not available")]
+
+    entries = []
+    for name, path in list(iter_dirs(args.pbs_samples_dir))[: args.limit]:
+        proc = run_command(["./qtop", "-b", "pbs", "-s", path, "-c", "ON"])
+        output_file = os.path.join(scheduler_output, "%s.ans" % name)
+        if proc.returncode == 0 and proc.stdout.strip():
+            write_text(output_file, proc.stdout)
+            entries.append(record("pbs", name, "passed", output=output_file, stdout=proc.stdout, stderr=proc.stderr))
+        else:
+            entries.append(record("pbs", name, "failed", stdout=proc.stdout, stderr=proc.stderr))
+    return entries or [record("pbs", None, "skipped", reason="no PBS samples found")]
+
+
+def validate_sge(args, output_root):
+    if not args.sge_samples_dir or not os.path.isdir(args.sge_samples_dir):
+        return [record("sge", None, "skipped", reason="SGE sample directory not available")]
+
+    # SGE archived command traces are not bundled in this repository yet. This
+    # hook keeps the shared gate ready for the qtop-test-repo samples once they
+    # are mirrored, while keeping today's CI deterministic.
+    return [record("sge", None, "skipped", reason="SGE sample hook configured; no runnable bundled samples yet")]
+
+
+VALIDATORS = {
+    "slurm": validate_slurm,
+    "pbs": validate_pbs,
+    "sge": validate_sge,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schedulers", default="slurm,pbs,sge", help="comma-separated schedulers to validate")
+    parser.add_argument("--limit", type=int, default=6, help="maximum samples per scheduler")
+    parser.add_argument("--max-failures", type=int, default=0, help="maximum failed samples allowed")
+    parser.add_argument("--output", default="artifacts/sample-gate", help="directory for rendered outputs and manifest")
+    parser.add_argument("--pbs-samples-dir", default="../qtop-test-repo/qtop5/results")
+    parser.add_argument("--slurm-samples-dir", default="tests/plugins/slurm_samples")
+    parser.add_argument("--sge-samples-dir", default="")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    ensure_dir(args.output)
+    schedulers = [item.strip().lower() for item in args.schedulers.split(",") if item.strip()]
+    entries = []
+
+    for scheduler in schedulers:
+        if scheduler not in VALIDATORS:
+            entries.append(record(scheduler, None, "failed", reason="unknown scheduler"))
+            continue
+        entries.extend(VALIDATORS[scheduler](args, args.output))
+
+    manifest_path = os.path.join(args.output, "manifest.json")
+    write_text(manifest_path, json.dumps(entries, indent=2, sort_keys=True))
+
+    failures = [entry for entry in entries if entry["status"] == "failed"]
+    passed = [entry for entry in entries if entry["status"] == "passed"]
+    skipped = [entry for entry in entries if entry["status"] == "skipped"]
+    print("sample-gate passed=%s failed=%s skipped=%s manifest=%s" % (len(passed), len(failures), len(skipped), manifest_path))
+    if len(failures) > args.max_failures:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #433

## Summary
- add a shared sample-gate workflow that both GitHub Actions and GitLab CI can call
- add Makefile targets for fortification, linting, sample validation, tests, coverage, and build checks
- replace executable config/runtime evaluation paths with safer parsing helpers
- document the sample-gate policy and point to independent CI/sample-gate patterns outside qtop

## Validation
- `make PYTHON=/tmp/qtop-venv/bin/python fortify`
- `make PYTHON=/tmp/qtop-venv/bin/python lint`
- `make PYTHON=/tmp/qtop-venv/bin/python sample-gate SAMPLE_OUTPUT_DIR=/tmp/qtop-sample-gate2 SAMPLE_MAX_FAILURES=0` -> sample-gate passed=6 failed=0 skipped=2
- `make PYTHON=/tmp/qtop-venv/bin/python test` -> 116 passed
- `make PYTHON=/tmp/qtop-venv/bin/python coverage`
- `make PYTHON=/tmp/qtop-venv/bin/python build`

No secrets, payout details, or private data are included. Commits include Signed-off-by lines.