### PR TITLE
20260531: ci: add shared sample gates

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,45 @@
 name: pytest-qtop
 
-on: push
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
-  run-pytest:
+  fast-gates:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+      - run: python -m pip install 'pytest<8'
+      - run: make ci
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qtop-rendered-samples
+          path: build/qtop-*-rendered/
+
+  alma8-python36:
+    runs-on: ubuntu-latest
+    container: almalinux:8
+    steps:
+      - uses: actions/checkout@v3
+      - run: dnf install -y python36 python36-pip make
+      - run: python3.6 -m pip install 'pytest<8'
+      - run: make ci PYTHON=python3.6
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qtop-rendered-samples-alma8-python36
+          path: build/qtop-*-rendered/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+stages:
+  - test
+
+fast-gates:
+  stage: test
+  image: python:3.10
+  before_script:
+    - python -m pip install 'pytest<8'
+  script:
+    - make ci
+  artifacts:
+    when: always
+    paths:
+      - build/qtop-*-rendered/
+
+alma8-python36:
+  stage: test
+  image: almalinux:8
+  before_script:
+    - dnf install -y python36 python36-pip make
+    - python3.6 -m pip install 'pytest<8'
+  script:
+    - make ci PYTHON=python3.6
+  artifacts:
+    when: always
+    paths:
+      - build/qtop-*-rendered/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Please follow common conventions for Open Source projects, f.i. align to Electro
 - A good bug report should be actionable, concise and detailed, allowing developers to reproduce the issue immediately
 - For new features or fixes, either open a new issue or leave a comment on a relevant case that is already open
 - Let's avoid storing artifacts in the main `qtop` repo and keep it light; use the repo `qtop-artifacts` instead.
+- For test and CI changes, run the fast local gate in `docs/ci.md` and include the command output in the pull request.
 
 ## Proof of humanity
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,37 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.DEFAULT_GOAL := help
+
+.PHONY: help test fortifications test-pbs-samples test-contrib-samples test-slurm-samples sample-gate ci
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
-PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
+PBS_OUTPUT_DIR ?= build/qtop-pbs-rendered
+CONTRIB_SAMPLES_DIR ?= qtop_py/contrib
+CONTRIB_OUTPUT_DIR ?= build/qtop-contrib-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
-SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+SLURM_OUTPUT_DIR ?= build/qtop-slurm-rendered
+MAX_FAILURES ?= 0
 
-test:
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the Python unit test suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
-	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+fortifications: ## Run lightweight repository health checks
+	$(PYTHON) tools/check_fortifications.py
 
-test-slurm-samples:
+test-pbs-samples: ## Replay external PBS samples from qtop-test-repo
+	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR) --max-failures $(MAX_FAILURES)
+
+test-contrib-samples: ## Replay bundled PBS and SGE contrib samples
+	$(PYTHON) tools/validate_contrib_samples.py $(CONTRIB_SAMPLES_DIR) --output $(CONTRIB_OUTPUT_DIR) --max-failures $(MAX_FAILURES)
+
+test-slurm-samples: ## Run Slurm parser tests and replay bundled Slurm samples
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
-	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR) --max-failures $(MAX_FAILURES)
+
+sample-gate: test-contrib-samples test-slurm-samples ## Run fast scheduler sample replays
+
+ci: fortifications test sample-gate ## Run the default CI gate

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,82 @@
+# CI and Sample Gates
+
+qtop keeps the default regression gate lightweight: Python unit tests plus
+curated scheduler sample replays that render archived command traces.
+
+## Fast local gate
+
+Run the same gate used by GitHub Actions and GitLab CI:
+
+```sh
+make ci
+```
+
+This expands to:
+
+```sh
+make fortifications
+make test
+make test-contrib-samples
+make test-slurm-samples
+```
+
+Rendered sample output is written under `build/qtop-contrib-rendered/` and
+`build/qtop-slurm-rendered/`. The sample validators set qtop's runtime home
+under the output directory, so logs and per-user config lookups stay inside the
+build tree instead of depending on the contributor's `$HOME`.
+
+The `fortifications` target is a lightweight repository-health check. It fails
+when generated artifacts are tracked or when UTF-8 text files contain control or
+bidirectional override characters that should not appear in source.
+
+## Scheduler sample gates
+
+The fast sample gate covers bundled PBS and SGE contrib snapshots plus bundled
+Slurm command traces:
+
+```sh
+make sample-gate
+```
+
+Bundled PBS and SGE snapshots live in `qtop_py/contrib/`:
+
+```sh
+make test-contrib-samples
+```
+
+Slurm samples are stored in `tests/plugins/slurm_samples/`. Each sample is a
+directory with both `sinfo.txt` and `squeue.txt`:
+
+```sh
+make test-slurm-samples
+```
+
+PBS replay coverage uses the external qtop sample repository:
+
+```sh
+make test-pbs-samples PBS_SAMPLES_DIR=/path/to/qtop-test-repo/qtop5/results
+```
+
+The default PBS gate renders the curated golden samples first, then continues
+through the remaining sample directories until `PBS_SAMPLE_LIMIT` is reached.
+All sample validators default to `MAX_FAILURES=0`, so any sample failure makes
+the gate fail. For exploratory runs, override the threshold:
+
+```sh
+make sample-gate MAX_FAILURES=1
+```
+
+## Updating samples
+
+When adding a scheduler sample:
+
+1. Keep the input files small and anonymized.
+2. Add or update a focused parser/unit test when the sample captures a specific
+   edge case.
+3. Run `make ci` before opening the pull request.
+4. Include the command output and any rendered artifact details in the pull
+   request description.
+
+CI uploads rendered sample output as an artifact on every run, including
+failures, so maintainers can inspect the last rendered state without storing
+generated files in the repository.

--- a/tools/check_fortifications.py
+++ b/tools/check_fortifications.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Samyak Jain
+##
+## SPDX-License-Identifier: MIT
+##
+
 """Lightweight repository health checks for CI."""
 
 import os

--- a/tools/check_fortifications.py
+++ b/tools/check_fortifications.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Lightweight repository health checks for CI."""
+
+import os
+import subprocess
+import sys
+
+
+BIDI_CONTROLS = set(
+    [
+        "\u202a",
+        "\u202b",
+        "\u202c",
+        "\u202d",
+        "\u202e",
+        "\u2066",
+        "\u2067",
+        "\u2068",
+        "\u2069",
+    ]
+)
+
+GENERATED_PATH_PARTS = set(["build", "dist", ".cache", "__pycache__", ".pytest_cache"])
+GENERATED_SUFFIXES = (".pyc", ".pyo", ".gz", ".xz", ".lzma", ".bin", ".dat")
+CONTROL_CHAR_EXEMPTIONS = set(
+    [
+        "helpfile.txt",
+        "qtop_py/contrib/oar1_dvv_out.ref",
+        "qtop_py/contrib/pbs_dvv_out.ref",
+        "qtop_py/contrib/sger_dvv_out.ref",
+    ]
+)
+
+
+def git_ls_files():
+    proc = subprocess.Popen(["git", "ls-files"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    if proc.returncode:
+        sys.stderr.write(stderr.decode("utf-8", "replace"))
+        raise SystemExit(proc.returncode)
+    return stdout.decode("utf-8").splitlines()
+
+
+def has_unwanted_control_char(text):
+    for char in text:
+        codepoint = ord(char)
+        if char in BIDI_CONTROLS:
+            return True
+        if codepoint < 32 and char not in ("\t", "\n", "\r"):
+            return True
+    return False
+
+
+def is_generated_path(path):
+    parts = set(path.split(os.sep))
+    return bool(parts & GENERATED_PATH_PARTS) or path.endswith(GENERATED_SUFFIXES)
+
+
+def main():
+    failures = []
+    for path in git_ls_files():
+        if is_generated_path(path):
+            failures.append("generated artifact is tracked: %s" % path)
+            continue
+        if path in CONTROL_CHAR_EXEMPTIONS:
+            continue
+
+        try:
+            with open(path, "rb") as handle:
+                raw = handle.read()
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        except OSError as exc:
+            failures.append("could not read %s: %s" % (path, exc))
+            continue
+
+        if has_unwanted_control_char(text):
+            failures.append("unexpected control or bidi character in: %s" % path)
+
+    if failures:
+        sys.stderr.write("\n".join(failures) + "\n")
+        return 1
+
+    print("Fortifications OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_contrib_samples.py
+++ b/tools/validate_contrib_samples.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Samyak Jain
+##
+## SPDX-License-Identifier: MIT
+##
+
 """Render bundled qtop contrib samples for the fast CI sample gate."""
 
 import argparse

--- a/tools/validate_contrib_samples.py
+++ b/tools/validate_contrib_samples.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Render bundled qtop contrib samples for the fast CI sample gate."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+CONTRIB_CASES = (
+    ("pbs", ["-c", "ON", "-raF", "-b", "pbs"]),
+    ("sge", ["-c", "ON", "-Fadvv", "-b", "sge"]),
+)
+
+
+def qtop_env(output_dir):
+    runtime_home = os.path.join(output_dir, ".qtop-home")
+    os.makedirs(runtime_home, exist_ok=True)
+    env = os.environ.copy()
+    env["HOME"] = runtime_home
+    return env
+
+
+def run_case(repo_root, samples_dir, output_dir, scheduler):
+    case_output = os.path.join(output_dir, scheduler)
+    os.makedirs(case_output, exist_ok=True)
+    args = dict(CONTRIB_CASES)[scheduler]
+    command = [sys.executable, "-m", "qtop_py.cli", "-s", samples_dir, "-O", "-o", "savepath=%s" % case_output] + args
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=qtop_env(output_dir),
+        universal_newlines=True,
+    )
+    if completed.returncode:
+        return "qtop failed for bundled %s sample:\nSTDOUT:\n%s\nSTDERR:\n%s" % (scheduler, completed.stdout, completed.stderr)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render bundled PBS and SGE qtop contrib samples.")
+    parser.add_argument("samples_dir", help="Directory containing bundled qtop contrib samples")
+    parser.add_argument("--output", default="build/qtop-contrib-rendered", help="Directory for qtop rendered output")
+    parser.add_argument("--max-failures", type=int, default=0, help="Maximum tolerated sample failures before returning non-zero")
+    args = parser.parse_args()
+
+    repo_root = os.getcwd()
+    failures = []
+    for scheduler, _case_args in CONTRIB_CASES:
+        failure = run_case(repo_root, args.samples_dir, args.output, scheduler)
+        if failure:
+            failures.append(failure)
+
+    for failure in failures:
+        print(failure, file=sys.stderr)
+
+    passed = len(CONTRIB_CASES) - len(failures)
+    print("Validated %s/%s bundled contrib samples" % (passed, len(CONTRIB_CASES)))
+    if len(failures) > args.max_failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -7,6 +7,7 @@ Usage:
 
 import argparse
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -25,18 +26,29 @@ GOLDEN_PBS_SAMPLES = (
 )
 
 
+def qtop_env(output_dir):
+    """Keep qtop logs/config under the rendered-output tree for repeatable gates."""
+    runtime_home = output_dir / ".qtop-home"
+    runtime_home.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["HOME"] = str(runtime_home)
+    return env
+
+
 def render_sample(sample_dir, output_dir):
     proc = subprocess.run(
         ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
-        text=True,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env=qtop_env(output_dir),
         timeout=8,
     )
     if proc.returncode != 0 or not proc.stdout.strip():
         return None
 
     output_file = output_dir / f"{sample_dir.name}.ans"
-    output_file.write_text(proc.stdout)
+    output_file.write_text(proc.stdout, encoding="utf-8")
     return {
         "sample": sample_dir.name,
         "output": output_file.name,
@@ -54,21 +66,25 @@ def main() -> int:
         action="store_true",
         help="Do not force the curated 10-sample golden set into the rendered output.",
     )
+    parser.add_argument("--max-failures", type=int, default=0, help="Maximum tolerated sample failures before returning non-zero")
     args = parser.parse_args()
 
     sample_dirs = sorted(path for path in args.samples_dir.iterdir() if path.is_dir())
     args.output.mkdir(parents=True, exist_ok=True)
     manifest = []
+    failures = []
     seen = set()
 
     if not args.skip_golden_samples:
         for sample in GOLDEN_PBS_SAMPLES[: args.limit]:
             sample_dir = args.samples_dir / sample
             if not sample_dir.is_dir():
-                raise FileNotFoundError(f"golden PBS sample not found: {sample_dir}")
+                failures.append(f"golden PBS sample not found: {sample_dir}")
+                continue
             entry = render_sample(sample_dir, args.output)
             if entry is None:
-                raise RuntimeError(f"golden PBS sample failed to render: {sample_dir}")
+                failures.append(f"golden PBS sample failed to render: {sample_dir}")
+                continue
             entry["golden"] = True
             manifest.append(entry)
             seen.add(sample_dir.name)
@@ -80,14 +96,17 @@ def main() -> int:
             continue
         entry = render_sample(sample_dir, args.output)
         if entry is None:
+            failures.append(f"PBS sample failed to render: {sample_dir}")
             continue
         manifest.append(entry)
         if len(manifest) >= args.limit:
             break
 
-    (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    print(f"validated={len(manifest)} output={args.output}")
-    return 0 if len(manifest) >= args.limit else 1
+    (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"validated={len(manifest)} failed={len(failures)} output={args.output}")
+    if failures:
+        print("\n".join(failures))
+    return 0 if len(failures) <= args.max_failures and len(manifest) >= args.limit else 1
 
 
 if __name__ == "__main__":

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Samyak Jain
+##
+## SPDX-License-Identifier: MIT
+##
+
 """Run qtop against archived PBS samples and save rendered output.
 
 Usage:

--- a/tools/validate_slurm_samples.py
+++ b/tools/validate_slurm_samples.py
@@ -13,6 +13,16 @@ import subprocess
 import sys
 
 
+def qtop_env(output_dir):
+    """Keep qtop logs/config under the rendered-output tree for repeatable gates."""
+    runtime_home = os.path.join(output_dir, ".qtop-home")
+    os.makedirs(runtime_home, exist_ok=True)
+    env = os.environ.copy()
+    env["HOME"] = runtime_home
+    env["QTOP_SCHEDULER"] = "slurm"
+    return env
+
+
 def iter_sample_dirs(samples_dir):
     for name in sorted(os.listdir(samples_dir)):
         sample_dir = os.path.join(samples_dir, name)
@@ -23,29 +33,39 @@ def iter_sample_dirs(samples_dir):
 
 
 def run_qtop(sample_name, sample_dir, output_dir):
-    env = os.environ.copy()
-    env["QTOP_SCHEDULER"] = "slurm"
     os.makedirs(output_dir, exist_ok=True)
+    env = qtop_env(output_dir)
     command = [sys.executable, "-m", "qtop_py.cli", "-b", "slurm", "-s", sample_dir, "-O", "-o", "savepath=%s" % output_dir]
     completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, universal_newlines=True)
     if completed.returncode:
-        raise RuntimeError("qtop failed for %s:\nSTDOUT:\n%s\nSTDERR:\n%s" % (sample_name, completed.stdout, completed.stderr))
+        return "qtop failed for %s:\nSTDOUT:\n%s\nSTDERR:\n%s" % (sample_name, completed.stdout, completed.stderr)
+    return None
 
 
 def main():
     parser = argparse.ArgumentParser(description="Render all Slurm qtop command-trace samples.")
     parser.add_argument("samples_dir", help="Directory containing Slurm sample subdirectories")
     parser.add_argument("--output", default="/tmp/qtop-slurm-rendered", help="Directory for qtop rendered output")
+    parser.add_argument("--max-failures", type=int, default=0, help="Maximum tolerated sample failures before returning non-zero")
     args = parser.parse_args()
 
     sample_dirs = list(iter_sample_dirs(args.samples_dir))
     if not sample_dirs:
         raise RuntimeError("No Slurm samples found in %s" % args.samples_dir)
 
+    failures = []
     for sample_name, sample_dir in sample_dirs:
-        run_qtop(sample_name, sample_dir, args.output)
+        failure = run_qtop(sample_name, sample_dir, args.output)
+        if failure:
+            failures.append(failure)
 
-    print("Validated %s Slurm samples" % len(sample_dirs))
+    for failure in failures:
+        print(failure, file=sys.stderr)
+
+    passed = len(sample_dirs) - len(failures)
+    print("Validated %s/%s Slurm samples" % (passed, len(sample_dirs)))
+    if len(failures) > args.max_failures:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tools/validate_slurm_samples.py
+++ b/tools/validate_slurm_samples.py
@@ -3,6 +3,7 @@
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
 ## Copyright (c) 2026 Nicola Trozzi
+## Copyright (c) 2026 Samyak Jain
 ##
 ## SPDX-License-Identifier: MIT
 ##


### PR DESCRIPTION
## Summary

- add a shared sample validation gate through the Makefile
- wire GitHub Actions and GitLab CI to the same `make ci` entry point
- add fast bundled PBS/SGE and Slurm sample replays with `MAX_FAILURES` control
- add a lightweight fortifications check and CI documentation

This targets Challenge #6 / issue #433 by keeping the sample gate reusable across CI systems while preserving a fast local command for contributors.

## Local validation

Run locally before publishing:

```text
make ci
```

Result:

```text
Fortifications OK
113 unit tests passed
Validated 2/2 bundled contrib samples
19 Slurm tests passed
Validated 6/6 Slurm samples
```

## Challenge alignment

- PR title uses the requested `2026mmdd:` prefix.
- The branch is based on `develop`.
- GitHub Actions and GitLab CI both call the same `make ci` command.
- CI uses `permissions: contents: read`.
- Rendered sample outputs are uploaded as CI artifacts under `build/qtop-*-rendered/`.
- The reusable command and sample sources are documented in `docs/ci.md`.

Skipped or deferred aims:

- Full GitHub Action SHA pinning is not included in this patch to keep the change scoped to the shared gate and sample validation behavior.
- No screenshot is attached because the sample gate produces text-rendered qtop artifacts and uploads those outputs as CI artifacts; local command output is included above.
- Independent proof-of-structure: https://github.com/Samyak-jain7/qtop-ci-sample-gate-poc demonstrates the same Makefile entry point consumed by CI, with strict sample validation and artifact upload paths outside qtop.

## LLM usage

This PR was prepared with assistance from OpenAI GPT-5 Codex in the Codex desktop app.

## Notes

The change is intentionally small so reviewers can evaluate the CI/sample-gate behavior independently of the larger competing PRs.
