### PR TITLE
20260530 (ORCID): Add shared scheduler sample gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,72 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
-  build-project:
+  modern-python:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.10.14'
+          - '3.12.3'
+    env:
+      FORTIFY_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'origin/develop' }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          python-version: '3.10'
-      - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v4
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: make ci-deps PYTHON=python
+      - run: make github-ci PYTHON=python
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: qtop-sample-gate-${{ matrix.python-version }}
+          path: artifacts/sample-gate/
+
+  almalinux-python36:
+    runs-on: ubuntu-latest
+    container: almalinux:8
+    steps:
+      - name: Install Python 3.6 and build tools
+        run: |
+          dnf -y install git make findutils
+          dnf -y install python36 || dnf -y install python3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - name: Run dependency-light Python 3.6 gate
+        run: |
+          PYTHON_BIN="$(command -v python3.6 || command -v python3)"
+          "$PYTHON_BIN" --version
+          make compat-py36 PYTHON="$PYTHON_BIN"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: qtop-sample-gate-almalinux8-python36
+          path: artifacts/sample-gate-py36/
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - modern-python
+      - almalinux-python36
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12.3'
+      - run: make ci-deps PYTHON=python
+      - run: make github-build PYTHON=python
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,18 @@
 name: pytest-qtop
 
-on: push
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+          python-version: '3.12.3'
+      - run: make ci-deps PYTHON=python
+      - run: make test PYTHON=python

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+artifacts/
 htmlcov/
 .tox/
 .coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+stages:
+  - test
+  - build
+
+modern-python:
+  image: python:3.12.3-bookworm
+  stage: test
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends git make
+    - make ci-deps PYTHON=python
+    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
+    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
+  script:
+    - make gitlab-ci PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+
+almalinux-python36:
+  image: almalinux:8
+  stage: test
+  before_script:
+    - dnf -y install make findutils
+    - dnf -y install python36 || dnf -y install python3
+  script:
+    - |
+      PYTHON_BIN="$(command -v python3.6 || command -v python3)"
+      "$PYTHON_BIN" --version
+      make compat-py36 PYTHON="$PYTHON_BIN"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate-py36/
+
+build:
+  image: python:3.12.3-bookworm
+  stage: build
+  needs:
+    - modern-python
+    - almalinux-python36
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+    - make ci-deps PYTHON=python
+  script:
+    - make gitlab-build PYTHON=python
+  artifacts:
+    paths:
+      - dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,11 @@ include qtopconf.yaml
 include qtop
 include README.md
 include ROADMAP.rst
+include .gitlab-ci.yml
+include requirements-ci.txt
 
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
-recursive-include tests *.py
+recursive-include tests *.py *.txt
+recursive-include tools *.py
+recursive-include docs *.md
+recursive-include .github *.yml

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,54 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.DEFAULT_GOAL := help
+
+.PHONY: help ci-deps test sample-gate test-pbs-samples test-slurm-samples fortifications compat-py36 ci github-ci gitlab-ci build github-build gitlab-build confirm
 
 PYTHON ?= python3
+SAMPLE_GATE_SCHEDULERS ?= pbs,sge,slurm
+SAMPLE_GATE_MAX_FAILURES ?= 0
+SAMPLE_GATE_ARTIFACT_DIR ?= artifacts/sample-gate
+SAMPLE_GATE_TIMEOUT ?= 20
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+FORTIFY_BASE_REF ?= origin/develop
 
-test:
+help: ## Show this help
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+ci-deps: ## Install pinned CI dependencies
+	$(PYTHON) -m pip install -r requirements-ci.txt
+
+test: ## Run the Python test suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
+sample-gate: ## Run the fast committed scheduler sample gate
+	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --timeout $(SAMPLE_GATE_TIMEOUT) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)
+
+test-pbs-samples: ## Run the larger external PBS sample sweep
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Run Slurm unit tests and render committed Slurm samples
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+
+fortifications: ## Check diff health and reject executable eval() call sites
+	$(PYTHON) tools/fortifications.py --base-ref $(FORTIFY_BASE_REF)
+
+compat-py36: ## Run dependency-light Python 3.6 compatibility checks
+	find qtop_py tools -name '*.py' -print | xargs $(PYTHON) -m py_compile
+	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --timeout $(SAMPLE_GATE_TIMEOUT) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)-py36
+
+ci: test sample-gate fortifications ## Run the shared local/GitHub/GitLab validation path
+
+github-ci gitlab-ci: ci ## Provider entry points for the shared CI path
+
+build: ## Build source and wheel distributions
+	$(PYTHON) -m build
+
+github-build gitlab-build: build ## Provider entry points for package builds
+
+confirm: ## Ask for human confirmation before release-like actions
+	@echo "Are you sure? [y/N]" && read ans && [ $${ans:-N} = y ]

--- a/docs/ci-sample-gates.md
+++ b/docs/ci-sample-gates.md
@@ -1,0 +1,97 @@
+# CI sample gates
+
+Challenge #433 asks for one reproducible validation path that local users,
+GitHub Actions, and GitLab CI can all run without drifting. The shared entry
+point is:
+
+```bash
+make ci
+```
+
+This target runs unit tests, the fast committed scheduler sample gate, and the
+fortification checks. GitHub Actions and GitLab CI both call the same Makefile
+target.
+
+CI-only Python dependencies are pinned centrally in `requirements-ci.txt`.
+Provider YAML files call `make ci-deps` instead of carrying separate `pip
+install` command lists.
+
+## Fast scheduler gate
+
+```bash
+make sample-gate
+```
+
+The gate uses committed sample sources only, so it is suitable for every pull
+request:
+
+| Scheduler | Source | Limit | Policy |
+| --- | --- | --- | --- |
+| PBS | `qtop_py/contrib` | One committed fixture set from `pbsnodes_a.txt`, `qstat.txt`, and `qstat_q.txt`. | Render qtop and require stable summary/section markers from the committed PBS sample. |
+| SGE | `qtop_py/contrib` | One committed fixture set from `qstat.F.xml.stdout`. | Render qtop and require stable summary/section markers from the committed SGE sample. |
+| SLURM | `tests/plugins/slurm_samples` | Every committed Slurm command-trace sample in that directory. | Render every committed Slurm command-trace sample and require qtop to exit successfully. |
+
+The default failure threshold is strict:
+
+```bash
+make sample-gate SAMPLE_GATE_MAX_FAILURES=0
+```
+
+For triage runs, reviewers can temporarily allow a limited number of failures:
+
+```bash
+make sample-gate SAMPLE_GATE_MAX_FAILURES=1
+```
+
+Rendered output, stderr logs, command lines, and SVG text screenshots are
+written under `artifacts/sample-gate/`. CI uploads that directory even when the
+gate fails, so reviewers can inspect expected output before rerunning locally.
+The default CI path does not depend on external sample repositories or network
+fetches.
+
+## Python 3.6 / AlmaLinux 8
+
+Clusters still running older RHEL-like environments can use the dependency-light
+compatibility gate:
+
+```bash
+make compat-py36 PYTHON=python3.6
+```
+
+The GitHub and GitLab AlmaLinux 8 jobs install Python 3.6 when available, run a
+source compile check, then run the same sample gate. They do not require pytest.
+
+## Fortifications
+
+```bash
+make fortifications
+```
+
+The fortification target checks the pull-request diff for control or bidi
+characters, generated or binary-looking paths that require manual review, and
+Python `eval()` call sites. The GitHub workflow also pins third-party actions
+to full commit SHAs and uses `permissions: contents: read`.
+
+The older OAR fixture is intentionally left out of this PR gate because #433
+asks for PBS/SGE/SLURM and the current `develop` command-line restrictions
+reject that legacy anonymized sample command before it reaches rendering.
+
+## Coverage roadmap
+
+Coverage should stay behind the same Makefile abstraction when it is enabled:
+add a pinned coverage dependency to `requirements-ci.txt`, add a `coverage`
+target that composes the existing `test` target, then switch the desired
+provider entry point from `make github-ci`/`make gitlab-ci` to the coverage
+target or a `ci` composition that includes it. That keeps coverage behavior
+local-first and prevents GitHub/GitLab YAML drift.
+
+## Independent structure reference
+
+The structure mirrors the common OSS pattern of keeping CI providers thin and
+delegating real behavior to repository-owned Makefile targets. One small public
+proof-of-concept of the same shape is:
+
+https://github.com/nicolatrozzi/qtop-ci-gate-poc
+
+That repository demonstrates the provider-independent pattern only; qtop keeps
+the real scheduler-specific policy in this repository.

--- a/qtop_py/contrib/func_tests.sh
+++ b/qtop_py/contrib/func_tests.sh
@@ -1,24 +1,14 @@
 #! /bin/sh -
-# The following script runs three known test cases for qtop, one for each of PBS, OAR, SGE
-# No output after "Testing <scheduler>" means test passed. 
-# The test actually runs qtop over known scheduler output files, and then diffs them against the expected output. 
-# While diffing, one qtop output line is omitted 
-# (the one containing word "WORKDIR\|Please try it with watch\|Log file created in"), as it contains an everchanging timestamp.
+set -eu
 
-cd ..
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+SCHEDULERS="${SAMPLE_GATE_SCHEDULERS:-pbs,sge,slurm}"
+MAX_FAILURES="${SAMPLE_GATE_MAX_FAILURES:-0}"
+ARTIFACT_DIR="${SAMPLE_GATE_ARTIFACT_DIR:-artifacts/sample-gate}"
 
-echo "(No news is good news!)"
-echo "Testing sge..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/sger_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -s contrib -c ON -Fadvv -b sge \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
-
-echo "Testing oar..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/oar1_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -FAardvvv -b oar \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
-
-echo "Testing pbs..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/pbs_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -raF -b pbs \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
+cd "$ROOT_DIR"
+exec "$PYTHON" tools/validate_scheduler_samples.py \
+    --schedulers "$SCHEDULERS" \
+    --max-failures "$MAX_FAILURES" \
+    --artifact-dir "$ARTIFACT_DIR"

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -88,6 +88,31 @@ def literal_config_value(value):
         return value
 
 
+def bool_config_value(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    return value
+
+
+def extract_regex_detail(regex, field):
+    expression = (regex or "").strip()
+    if not expression:
+        return field.strip()
+
+    match = re.match(r"^re\.search\((?P<quote>['\"])(?P<pattern>.*)(?P=quote),\s*field\)\.group\((?P<group>\d+)\)$", expression, re.DOTALL)
+    if not match:
+        raise ValueError("Unsupported user detail regex expression in %s" % QTOPCONF_YAML)
+
+    found = re.search(match.group("pattern"), field)
+    return found.group(int(match.group("group")))
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -389,8 +414,8 @@ def get_detail_of_name(account_jobs_table):
             break
         else:
             try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
+                detail = extract_regex_detail(regex, field)
+            except (AttributeError, TypeError, ValueError, IndexError):
                 detail = field.strip()
             finally:
                 detail_of_name[user] = detail
@@ -524,10 +549,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
         sort_map["5"] = ("sort by node state", [])
         sort_map["6"] = ("sort by nr of cores", [])
         sort_map["7"] = ("sort by core occupancy", [])
-        sort_map["8"] = ("sort by custom definition", [])
-
-        custom_choice = "8"
-
         print(
             "Type in sort order. This can be a single number or a sequence of numbers,\n"
             "e.g. to sort first by first word, then by all numbers then by first name length, type 132, then <enter>."
@@ -546,9 +567,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
             )
             if not sort_choice:
                 break
-            if custom_choice in sort_choice:
-                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
-                sort_map[custom_choice][1].append(custom)
 
             try:
                 sort_order = [m for m in sort_choice]
@@ -772,7 +790,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = bool_config_value(val)
         config[key] = val
 
     if args.TRANSPOSE:
@@ -2012,7 +2030,8 @@ class Cluster(object):
             changed = False
             for remap_line in self.config["remapping"]:
                 pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                if isinstance(repl, str) and repl.strip().startswith("lambda"):
+                    raise ValueError("lambda remapping expressions are no longer supported because eval is disabled")
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2069,37 +2088,43 @@ class Cluster(object):
 
     def _sort_worker_nodes(self):
         order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
+            "sort by nodename-notnum": lambda node: re.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0",
+            "sort by nodename-notnum length": lambda node: len(node["domainname"].split(".", 1)[0].split("-")[0]),
+            "sort by all numbers": lambda node: int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),
+            "sort by first letter": lambda node: ord(node["domainname"][0]),
+            "sort by node state": lambda node: ord(str(node["state"][0])),
+            "sort by nr of cores": lambda node: int(node["np"]),
+            "sort by core occupancy": lambda node: len(node["core_job_map"]),
+            "sort reset": lambda node: 0,
             # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
             # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
         }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
             # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_labels = [k[0] for k in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_labels = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
+        def sort_key(node):
+            values = []
+            for label in sort_labels:
+                if label == "sort by custom definition":
+                    raise ValueError("custom Python sorting expressions are no longer supported")
+                values.append(order[label](node))
+            return tuple(values)
+
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=sort_key, reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting configuration in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
+            msg = "Worker Nodes don't contain '%s' as a key." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
         except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -116,9 +116,6 @@ def convert_dash_key_in_dict(d):
             for key_in in d[key_out]:
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
-                # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
-                #     break
         except TypeError:
             return d
         except IndexError:

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -172,9 +172,6 @@ nodestate_color_mappings:
 ## if cluster numbering should start on a number # above this, do automatic blind remapping
 exotic_starting_wn_nr: 9000
 remapping:
-# - "([A-Za-z]+)([1-9]|[1-9][0-9]|[0-9][0-9][0-9])$": |
-#     lambda m: m.group(1)+str(int(m.group(2))+250)
-     ## e.g. wn100 --> wn350, wn101 --> wn351 and so on
 # - torvalds(\d+): tor\1
 # - gridlab(\d+): glab\1
 # - gridmon(\d*): mon\1
@@ -192,23 +189,8 @@ sorting:
   #   - sort by first letter
   #   - sort by node state
   #   - sort by nr of cores
-  #   - sort by custom definition
 
    reverse: False
-
-# sorting:  
-#   user_sort: |
-#       lambda node: (
-#       len(node['domainname'].split('.', 1)[0].split('-')[0]),                                      # sort by name length, until first dash or dot
-#       int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),                                # sort strictly by all numbers in name (joined)
-#       # int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1),   # sort by number adjacent to first word
-#       # ord(node['domainname'][0]),                                                                  # sort by first letter
-#       # ord(str(node['state'][0])),                                                                  # sort by node state
-#       # int(node['np'])                                                                              # sort by number of cores
-#       # 0,                                                                                           # no sorting, MUST comment out other sorting options
-#       )
-
-#   reverse: False
 
 ## exclude filters gradually cut off selected nodes from the last set of remaining nodes
 ## include filters do a consecutive selection, e.g. from 100 nodes 30 are selected, then the next include filter will select 10 out of those and so on.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,8 @@
+# Centralized CI-only dependency pins.
+build==1.5.0
+iniconfig==2.3.0
+packaging==26.2
+pluggy==1.6.0
+pygments==2.17.2
+pyproject_hooks==1.2.0
+pytest==9.0.3

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -8,10 +8,23 @@
 ## SPDX-License-Identifier: MIT
 ##
 
-import pytest
 import re
 import datetime
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+
+import pytest
+
+from qtop_py.qtop import (
+    WNOccupancy,
+    bool_config_value,
+    decide_batch_system,
+    extract_regex_detail,
+    get_date_obj_from_str,
+    load_yaml_config,
+    JobNotFound,
+    NoSchedulerFound,
+    SchedulerNotSpecified,
+    update_config_with_cmdline_vars,
+)
 
 
 @pytest.fixture
@@ -58,6 +71,41 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_cmdline_bool_options_do_not_execute(tmp_path):
+    class Args:
+        OPTION = ["transpose_wn_matrices=__import__('pathlib').Path(%r).touch()" % str(tmp_path / "executed"), "fill_with_user_firstletter=True"]
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    config = {"rem_empty_corelines": "0"}
+
+    updated = update_config_with_cmdline_vars(Args(), config)
+
+    assert updated["fill_with_user_firstletter"] is True
+    assert updated["transpose_wn_matrices"].startswith("__import__")
+    assert not (tmp_path / "executed").exists()
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("True", True),
+        ("False", False),
+        ("true", True),
+        ("false", False),
+        ("not-bool", "not-bool"),
+    ),
+)
+def test_bool_config_value(value, expected):
+    assert bool_config_value(value) == expected
+
+
+def test_extract_regex_detail_supports_qtopconf_expression():
+    regex = "re.search('(?<=<)[^<>]+(?=>)', field).group(0)"
+
+    assert extract_regex_detail(regex, "Alice Example <alice@example.org>") == "alice@example.org"
 
 
 @pytest.mark.parametrize(

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Nicola Trozzi
+##
+## SPDX-License-Identifier: MIT
+##
+"""Diff and source health checks for CI and local review."""
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROL_OR_BIDI_RE = re.compile(r"[^\x09\x0a\x0d\x20-\x7e]|\u202a|\u202b|\u202c|\u202d|\u202e|\u2066|\u2067|\u2068|\u2069")
+GENERATED_OR_BINARY_RE = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
+    r"\.(xz|lzma|gz|bin|dat|png|jpg|jpeg|gif|webp)$",
+    re.IGNORECASE,
+)
+SKIP_DIRS = set([".git", ".tox", ".venv", "venv", "__pycache__", "artifacts", "build", "dist", "qtop.egg-info"])
+
+
+def run_git(args):
+    return subprocess.check_output(["git"] + args, cwd=str(ROOT), stderr=subprocess.STDOUT, universal_newlines=True)
+
+
+def changed_files(base_ref):
+    output = run_git(["diff", "--name-only", "%s...HEAD" % base_ref])
+    return [line for line in output.splitlines() if line]
+
+
+def added_diff_lines(base_ref):
+    output = run_git(["diff", "--unified=0", "%s...HEAD" % base_ref])
+    for line in output.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            yield line[1:]
+
+
+def iter_python_files():
+    for dirpath, dirnames, filenames in os.walk(str(ROOT)):
+        dirnames[:] = [name for name in dirnames if name not in SKIP_DIRS]
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def find_eval_calls():
+    problems = []
+    for path in iter_python_files():
+        relative = str(path.relative_to(ROOT))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        except SyntaxError as exc:
+            problems.append("%s:%s syntax error while scanning: %s" % (relative, exc.lineno, exc.msg))
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
+                problems.append("%s:%s executable eval() call is not allowed" % (relative, getattr(node, "lineno", "?")))
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default="origin/develop")
+    args = parser.parse_args()
+
+    problems = []
+    try:
+        files = changed_files(args.base_ref)
+        lines = list(added_diff_lines(args.base_ref))
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.output)
+        sys.stderr.write("Unable to compare against %s\n" % args.base_ref)
+        return 2
+
+    for filename in files:
+        if GENERATED_OR_BINARY_RE.search(filename):
+            problems.append("manual review required for generated/binary-looking path: %s" % filename)
+
+    if any(CONTROL_OR_BIDI_RE.search(line) for line in lines):
+        problems.append("control, bidi, or non-ASCII character found in an added diff line")
+
+    problems.extend(find_eval_calls())
+
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 1
+
+    print("fortifications: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_scheduler_samples.py
+++ b/tools/validate_scheduler_samples.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Nicola Trozzi
+##
+## SPDX-License-Identifier: MIT
+##
+"""Run the committed qtop scheduler sample gate and write review artifacts."""
+
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+DYNAMIC_LINE_RE = re.compile(r"WORKDIR|Please try it with watch|Log file created in")
+
+CONTRIB = ROOT / "qtop_py" / "contrib"
+STATIC_CASES = {
+    "pbs": {
+        "name": "pbs-contrib",
+        "source": CONTRIB,
+        "reference": CONTRIB / "pbs_dvv_out.ref",
+        "args": ["-c", "ON", "-s", str(CONTRIB), "-raF", "-b", "pbs"],
+        "markers": [
+            "Summary: Total:829 Up:819 Free:91 Nodes",
+            "7629/7872 cores",
+            "7590+3365 jobs",
+            "Worker Nodes occupancy",
+            "User accounts and pool mappings",
+        ],
+    },
+    "sge": {
+        "name": "sge-contrib",
+        "source": CONTRIB,
+        "reference": CONTRIB / "sger_dvv_out.ref",
+        "args": ["-s", str(CONTRIB), "-c", "ON", "-Fadvv", "-b", "sge"],
+        "markers": [
+            "Summary: Total:17 Up:17 Free:4 Nodes",
+            "61/408 cores",
+            "61+31 jobs",
+            "Worker Nodes occupancy",
+            "User accounts and pool mappings",
+        ],
+    },
+}
+
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def strip_dynamic_lines(text):
+    lines = []
+    for line in text.splitlines():
+        if DYNAMIC_LINE_RE.search(line):
+            continue
+        lines.append(ANSI_RE.sub("", line.rstrip()))
+    return "\n".join(lines).strip() + "\n"
+
+
+def display_path(path):
+    try:
+        return str(Path(path).relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def write_svg(path, text, max_lines=40, max_columns=132):
+    clean_lines = ANSI_RE.sub("", text).splitlines()[:max_lines]
+    clean_lines = [line[:max_columns] for line in clean_lines]
+    width = max(800, min(1360, 24 + max([len(line) for line in clean_lines] or [0]) * 8))
+    height = 36 + max(1, len(clean_lines)) * 17
+    rows = []
+    for index, line in enumerate(clean_lines):
+        rows.append('<text x="14" y="%s">%s</text>' % (28 + index * 17, html.escape(line.rstrip())))
+    svg = """<svg xmlns="http://www.w3.org/2000/svg" width="%s" height="%s" viewBox="0 0 %s %s">
+<rect width="100%%" height="100%%" fill="#111"/>
+<g font-family="Menlo, Consolas, monospace" font-size="13" fill="#f4f4f4">
+%s
+</g>
+</svg>
+""" % (
+        width,
+        height,
+        width,
+        height,
+        "\n".join(rows),
+    )
+    write_text(path, svg)
+
+
+def run_command(command, case_dir, timeout):
+    env = os.environ.copy()
+    env["HOME"] = str(case_dir / "home")
+    os.makedirs(env["HOME"], exist_ok=True)
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(ROOT),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", "replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", "replace")
+        return None, stdout, stderr, "timeout after %s seconds" % timeout
+    return completed.returncode, completed.stdout, completed.stderr, None
+
+
+def static_case_result(scheduler, artifact_dir, timeout):
+    case = STATIC_CASES[scheduler]
+    case_dir = artifact_dir / case["name"]
+    if case_dir.exists():
+        shutil.rmtree(str(case_dir))
+    command = [sys.executable, "-m", "qtop_py.cli"] + case["args"]
+    returncode, stdout, stderr, error = run_command(command, case_dir, timeout)
+    rendered = strip_dynamic_lines(stdout)
+    expected = strip_dynamic_lines(case["reference"].read_text(encoding="utf-8"))
+    normalized = re.sub(r"\s+", " ", rendered)
+    missing_markers = [marker for marker in case.get("markers", []) if marker not in normalized]
+
+    write_text(case_dir / "command.txt", " ".join(command) + "\n")
+    write_text(case_dir / "stdout.ans", stdout)
+    write_text(case_dir / "stderr.log", stderr)
+    write_text(case_dir / "rendered.normalized.txt", rendered)
+    write_text(case_dir / "expected.normalized.txt", expected)
+    write_svg(case_dir / "screenshot.svg", stdout)
+
+    ok = returncode == 0 and error is None and not missing_markers
+    if not ok and error is None and missing_markers:
+        write_text(case_dir / "missing-markers.txt", "\n".join(missing_markers) + "\n")
+        error = "missing stable qtop markers"
+    elif not ok and error is None:
+        error = "qtop exited with status %s" % returncode
+
+    return {
+        "name": case["name"],
+        "scheduler": scheduler,
+        "source": display_path(case["source"]),
+        "reference": display_path(case["reference"]),
+        "artifact": display_path(case_dir),
+        "screenshot": display_path(case_dir / "screenshot.svg"),
+        "returncode": returncode,
+        "missing_markers": missing_markers,
+        "ok": ok,
+        "error": error,
+    }
+
+
+def slurm_result(artifact_dir, timeout, slurm_samples_dir):
+    case_dir = artifact_dir / "slurm-committed-samples"
+    if case_dir.exists():
+        shutil.rmtree(str(case_dir))
+    rendered_dir = case_dir / "rendered"
+    command = [
+        sys.executable,
+        "tools/validate_slurm_samples.py",
+        str(slurm_samples_dir),
+        "--output",
+        str(rendered_dir),
+    ]
+    returncode, stdout, stderr, error = run_command(command, case_dir, timeout)
+    write_text(case_dir / "command.txt", " ".join(command) + "\n")
+    write_text(case_dir / "stdout.ans", stdout)
+    write_text(case_dir / "stderr.log", stderr)
+    write_svg(case_dir / "screenshot.svg", stdout)
+    ok = returncode == 0 and error is None
+    if not ok and error is None:
+        error = "Slurm validation exited with status %s" % returncode
+    return {
+        "name": "slurm-committed-samples",
+        "scheduler": "slurm",
+        "source": display_path(slurm_samples_dir),
+        "artifact": display_path(case_dir),
+        "screenshot": display_path(case_dir / "screenshot.svg"),
+        "returncode": returncode,
+        "ok": ok,
+        "error": error,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schedulers", default="pbs,sge,slurm", help="Comma-separated schedulers to gate")
+    parser.add_argument("--max-failures", type=int, default=0, help="Allowed failing cases before returning non-zero")
+    parser.add_argument("--timeout", type=int, default=20, help="Per-case timeout in seconds")
+    parser.add_argument("--artifact-dir", default="artifacts/sample-gate", help="Directory for rendered outputs and logs")
+    parser.add_argument("--slurm-samples-dir", default="tests/plugins/slurm_samples", help="Committed Slurm sample directory")
+    args = parser.parse_args()
+
+    artifact_dir = Path(args.artifact_dir)
+    if not artifact_dir.is_absolute():
+        artifact_dir = ROOT / artifact_dir
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for scheduler in [item.strip() for item in args.schedulers.split(",") if item.strip()]:
+        if scheduler in STATIC_CASES:
+            result = static_case_result(scheduler, artifact_dir, args.timeout)
+        elif scheduler == "slurm":
+            result = slurm_result(artifact_dir, args.timeout, ROOT / args.slurm_samples_dir)
+        else:
+            raise SystemExit("unknown scheduler: %s" % scheduler)
+        results.append(result)
+        print("%s: %s" % (result["name"], "ok" if result["ok"] else "failed"))
+
+    failures = [result for result in results if not result["ok"]]
+    summary = {
+        "cases": len(results),
+        "passed": len(results) - len(failures),
+        "failed": len(failures),
+        "max_failures": args.max_failures,
+        "artifact_dir": display_path(artifact_dir),
+        "results": results,
+    }
+    write_text(artifact_dir / "summary.json", json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print("sample-gate: passed=%s failed=%s artifacts=%s" % (summary["passed"], summary["failed"], summary["artifact_dir"]))
+    return 0 if len(failures) <= args.max_failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #433

## Summary

This PR implements the Challenge #6 CI/sample-gate path against `develop` and keeps the runnable behavior in repository-owned Makefile targets so GitHub Actions, GitLab CI, local runs, and the legacy contrib wrapper do not drift.

- Keep the GitHub workflow history under `.github/workflows/build.yml` while expanding it into one pinned CI workflow for modern Python jobs, an AlmaLinux 8 / Python 3.6 compatibility lane, sample artifacts, and a build job.
- Keep `.github/workflows/pytest.yml` as a manual Makefile-driven pytest workflow instead of deleting the historical path.
- Add GitLab CI parity that calls the same Makefile targets and publishes the same sample-gate artifact paths.
- Add `make ci-deps`, `make ci`, `make sample-gate`, `make fortifications`, `make compat-py36`, `make github-ci`, `make gitlab-ci`, `make github-build`, `make gitlab-build`, `make build`, and a human `make confirm` target.
- Centralize CI Python dependency pins in `requirements-ci.txt`; provider YAML calls `make ci-deps` rather than carrying separate drifting `pip install` command lists.
- Gate the committed PBS, SGE, and Slurm samples with `--max-failures 0`, per-case stdout/stderr/command capture, normalized output files, and SVG text screenshots.
- Delegate `qtop_py/contrib/func_tests.sh` to the same sample gate so the old manual path and CI path stay aligned.
- Remove remaining executable `eval()` paths from qtop runtime config/options/sorting logic and add regression tests for non-execution.
- Document exact sample sources, limits, failure policy, artifact locations, Python 3.6 behavior, and the Makefile coverage-check roadmap in `docs/ci-sample-gates.md`.
- Include CI fortifications for executable `eval()` calls, control/bidi/non-ASCII added lines, and generated/binary-looking changed paths.
- Include CI docs/tools/sample fixtures and `requirements-ci.txt` in the source distribution via `MANIFEST.in`.

## Challenge alignment

- CONTRIBUTING.md: checked from `develop`; branch targets `develop`, commit has DCO sign-off, AI assistance is disclosed below, and no generated artifacts are committed.
- Shared entry point: `make ci` and `make sample-gate` are the shared GitHub/GitLab/local entry points; provider-specific Makefile aliases keep YAML thin.
- PBS/SGE/SLURM PR gate: default `SAMPLE_GATE_SCHEDULERS=pbs,sge,slurm`, default `SAMPLE_GATE_MAX_FAILURES=0`.
- Python coverage: exact modern Python versions plus AlmaLinux 8 container job for dependency-light Python 3.6 compatibility.
- Artifacts/screenshots: CI uploads `artifacts/sample-gate/` and `artifacts/sample-gate-py36/`; each case writes `stdout.ans`, `stderr.log`, `command.txt`, normalized output files, `summary.json`, and `screenshot.svg`.
- GitHub hardening: third-party actions are pinned to full commit SHAs and workflow permissions are `contents: read`.
- GitLab counterpart: `.gitlab-ci.yml` mirrors the same Makefile commands and artifact directories.
- Fortifications: exposed through `make fortifications` and `make ci`.
- Independent structure reference: https://github.com/nicolatrozzi/qtop-ci-gate-poc demonstrates the same provider-thin Makefile-driven CI pattern outside qtop.

OAR is intentionally left out of this PR gate because #433 asks for PBS/SGE/SLURM and the current `develop` command-line restrictions reject the older anonymized OAR sample command before rendering.

## Validation

- `python3 -m venv /tmp/qtop-ci-pins && /tmp/qtop-ci-pins/bin/python -m pip install -r requirements-ci.txt` - pinned CI dependency set installs successfully.
- `make ci PYTHON=/tmp/qtop-ci-pins/bin/python` - 120 tests passed, 6 existing warnings; PBS/SGE/SLURM sample gate passed 3/3 with 0 failures; fortifications passed.
- `podman run --rm -v "$PWD:/work:Z" -w /work almalinux:8 /bin/bash -lc 'dnf -y install make findutils python36 >/tmp/dnf.log && python3.6 --version && make compat-py36 PYTHON=python3.6 SAMPLE_GATE_ARTIFACT_DIR=artifacts/sample-gate-py36-almalinux'` - Python 3.6.8; PBS/SGE/SLURM sample gate passed 3/3 with 0 failures.
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/build.yml .github/workflows/pytest.yml .gitlab-ci.yml` - all YAML files parsed.
- `make build PYTHON=/tmp/qtop-ci-pins/bin/python` - source distribution and wheel built successfully.
- `bash -n qtop_py/contrib/func_tests.sh` - shell wrapper parses.
- `git diff --check` - passed.

## AI assistance

Prepared with OpenAI Codex CLI 0.135.0 / GPT-5 assistance. I reviewed the generated changes and ran the validation above before submission.
