### PR TITLE
ci: add scheduler sample gate and fortifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: help test sample-gate fortifications test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -6,13 +6,27 @@ PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+SAMPLE_GATE_OUTPUT_DIR ?= artifacts/sample-gate
+SAMPLE_GATE_MAX_FAILURES ?= 0
 
-test:
+.DEFAULT_GOAL := help
+
+help: ## Show available Makefile targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the complete pytest suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
+sample-gate: ## Run the fast PBS, SGE and Slurm PR sample gate
+	$(PYTHON) tools/sample_gate.py --output $(SAMPLE_GATE_OUTPUT_DIR) --max-failures $(SAMPLE_GATE_MAX_FAILURES)
+
+fortifications: ## Inspect changed files for unsafe control characters and generated artifacts
+	$(PYTHON) tools/fortifications.py
+
+test-pbs-samples: ## Render archived PBS samples from the external corpus
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Validate the bundled Slurm command-trace samples
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)

--- a/docs/sample-gate.md
+++ b/docs/sample-gate.md
@@ -1,0 +1,84 @@
+# Scheduler sample gate
+
+The fast scheduler sample gate gives local development, GitHub Actions, and
+GitLab CI one shared entry point:
+
+```bash
+make sample-gate SAMPLE_GATE_MAX_FAILURES=0
+```
+
+The gate runs:
+
+1. bundled PBS parser unit fixtures;
+2. the bundled SGE XML command-trace fixture;
+3. bundled Slurm parser fixtures;
+4. rendered output checks for bundled Slurm command traces.
+
+Logs, rendered Slurm output, and `manifest.json` are written under
+`artifacts/sample-gate/`. Hosted CI uploads that directory so reviewers can
+inspect output before rerunning locally.
+
+The qtop CLI renderer depends on POSIX `SIGPIPE`. On Windows, the shared gate
+records the Slurm render step as skipped while still running parser fixtures.
+The Linux CI jobs always execute the render step.
+
+## Failure policy
+
+`SAMPLE_GATE_MAX_FAILURES=0` makes every failed step fail the gate. The
+underlying Python entry point also accepts `--max-failures 0`, which is useful
+outside Make:
+
+```bash
+python3 tools/sample_gate.py --output artifacts/sample-gate --max-failures 0
+```
+
+## Archived PBS corpus
+
+The large PBS corpus stays outside this lightweight repository. When it is
+available locally, include a curated archived render sweep:
+
+```bash
+python3 tools/sample_gate.py \
+  --output artifacts/sample-gate \
+  --max-failures 0 \
+  --pbs-samples ../qtop-test-repo/qtop5/results \
+  --pbs-limit 10
+```
+
+The external sample source is `fgeorgatos/qtop-test-repo/qtop5/results`.
+`--pbs-limit 10` caps the archived sweep, while the bundled fixtures always run.
+
+## Fortifications
+
+The shared Makefile also exposes a lightweight changed-file check:
+
+```bash
+make fortifications
+```
+
+It rejects bidirectional Unicode control characters and requests manual review
+for generated, compressed, or binary-looking changed paths. In an extracted
+archive without git metadata, pass paths explicitly:
+
+```bash
+python3 tools/fortifications.py tools/sample_gate.py docs/sample-gate.md
+```
+
+## Scope
+
+This change intentionally does not remove the remaining inherited `eval`
+calls. Replacing those calls requires separate behavior-focused tests and
+review. Keeping that refactor separate makes this CI contribution easier to
+validate and backport.
+
+## Generic structure
+
+The reusable pattern is intentionally small:
+
+1. one dependency-light Python orchestrator;
+2. one Makefile target used locally and by both hosted CI systems;
+3. a machine-readable manifest plus plain-text logs;
+4. optional larger external corpora that do not burden ordinary PR checks.
+
+This structure can be copied into another Python OSS project without requiring
+qtop-specific CI plugins.

--- a/tests/plugins/sge_samples/basic/qstat.xml
+++ b/tests/plugins/sge_samples/basic/qstat.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<job_info>
+  <queue_info>
+    <Queue-List>
+      <name>compute.q@node001</name>
+      <resource name="qname">compute.q</resource>
+      <resource name="hostname">node001</resource>
+      <resource name="num_proc">4</resource>
+      <slots_used>1</slots_used>
+      <state>-</state>
+      <job_list state="running">
+        <JB_job_number>101</JB_job_number>
+        <JB_name>running-job</JB_name>
+        <JB_owner>alice</JB_owner>
+        <JAT_start_time>2026-05-31T00:00:00</JAT_start_time>
+        <state>r</state>
+      </job_list>
+    </Queue-List>
+  </queue_info>
+  <job_info>
+    <job_list state="pending">
+      <JB_job_number>102</JB_job_number>
+      <JB_name>queued-job</JB_name>
+      <JB_owner>bob</JB_owner>
+      <JB_submission_time>2026-05-31T00:01:00</JB_submission_time>
+      <state>qw</state>
+    </job_list>
+  </job_info>
+</job_info>

--- a/tests/plugins/test_sge.py
+++ b/tests/plugins/test_sge.py
@@ -1,0 +1,29 @@
+import os
+
+from qtop_py.plugins.sge import SGEBatchSystem
+
+
+class Options(object):
+    ANONYMIZE = False
+    SAMPLE = 0
+
+
+def scheduler_files(sample_name):
+    return {"sge_file": os.path.join(os.path.dirname(__file__), "sge_samples", sample_name, "qstat.xml")}
+
+
+def test_sge_command_trace_sample():
+    sge = SGEBatchSystem(scheduler_files("basic"), {}, Options())
+
+    assert sge.get_jobs_info() == (["101", "102"], ["alice", "bob"], ["r", "qw"], ["compute.q", "Pending"])
+    assert sge.get_queues_info() == (
+        1,
+        1,
+        [
+            {"queue_name": "compute.q", "run": "1", "queued": "0", "lm": 0, "state": "-"},
+            {"queue_name": "Pending", "run": "0", "queued": "1", "lm": "0", "state": "Q"},
+        ],
+    )
+    assert sge.get_worker_nodes(["101", "102"], ["compute.q", "Pending"], Options()) == [
+        {"domainname": "node001", "np": 4, "state": "-", "qname": ["compute.q"], "core_job_map": {0: "101"}, "existing_busy_cores": 1}
+    ]

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Inspect changed files for suspicious text and generated artifacts."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+CONTROL_CHARACTERS = re.compile(
+    "[\u202a-\u202e\u2066-\u2069]"
+)
+GENERATED_PATH = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
+    r"\.(xz|lzma|gz|bin|dat)$",
+    re.IGNORECASE,
+)
+
+
+def git_changed_files(base_ref):
+    commands = []
+    if base_ref:
+        commands.append(["git", "diff", "--name-only", "%s...HEAD" % base_ref])
+    commands.append(["git", "diff", "--name-only", "HEAD^", "HEAD"])
+    for command in commands:
+        try:
+            completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        except OSError:
+            break
+        if completed.returncode == 0:
+            return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return []
+
+
+def inspect(paths):
+    findings = []
+    for path in paths:
+        normalized = path.replace("\\", "/")
+        if GENERATED_PATH.search(normalized):
+            findings.append("%s: generated or binary-looking path requires manual review" % path)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle, 1):
+                    if CONTROL_CHARACTERS.search(line):
+                        findings.append("%s:%s: bidi control character found" % (path, line_number))
+        except (UnicodeDecodeError, OSError):
+            continue
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default=os.environ.get("QTOP_FORTIFICATIONS_BASE", "origin/develop"))
+    parser.add_argument("paths", nargs="*", help="Explicit paths for local checks without git metadata")
+    args = parser.parse_args()
+    paths = args.paths or git_changed_files(args.base_ref)
+    if not paths:
+        print("fortifications: no changed files detected; pass paths explicitly outside a git checkout")
+        return 0
+    findings = inspect(paths)
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+    print("fortifications: checked %s changed files" % len(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sample_gate.py
+++ b/tools/sample_gate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the small scheduler sample gate shared by local and hosted CI."""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+
+
+def run_step(name, command, output_dir):
+    print("== %s ==" % name)
+    completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    stdout_path = os.path.join(output_dir, "%s.stdout.log" % name)
+    stderr_path = os.path.join(output_dir, "%s.stderr.log" % name)
+    with open(stdout_path, "w") as handle:
+        handle.write(completed.stdout)
+    with open(stderr_path, "w") as handle:
+        handle.write(completed.stderr)
+    print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="")
+    return {
+        "name": name,
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": os.path.basename(stdout_path),
+        "stderr": os.path.basename(stderr_path),
+    }
+
+
+def skipped_step(name, reason):
+    print("== %s ==" % name)
+    print("SKIPPED: %s" % reason)
+    return {"name": name, "status": "skipped", "reason": reason}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="artifacts/sample-gate", help="Directory for logs and rendered scheduler output")
+    parser.add_argument("--max-failures", type=int, default=0, help="Maximum failed gate steps allowed")
+    parser.add_argument("--pbs-samples", help="Optional external archived PBS sample directory")
+    parser.add_argument("--pbs-limit", type=int, default=10, help="External PBS samples to render when --pbs-samples is set")
+    args = parser.parse_args()
+
+    os.makedirs(args.output, exist_ok=True)
+    slurm_output = os.path.join(args.output, "slurm-rendered")
+    steps = [
+        run_step(
+            "scheduler-unit-tests",
+            [sys.executable, "-m", "pytest", "tests/plugins/test_pbs.py", "tests/plugins/test_sge.py", "tests/plugins/test_slurm.py", "-q"],
+            args.output,
+        ),
+    ]
+    if hasattr(signal, "SIGPIPE"):
+        steps.append(
+            run_step(
+                "slurm-render",
+                [sys.executable, "tools/validate_slurm_samples.py", "tests/plugins/slurm_samples", "--output", slurm_output],
+                args.output,
+            )
+        )
+    else:
+        steps.append(skipped_step("slurm-render", "qtop CLI requires SIGPIPE; render remains mandatory on Linux CI"))
+
+    if args.pbs_samples:
+        steps.append(
+            run_step(
+                "pbs-archived-render",
+                [
+                    sys.executable,
+                    "tools/validate_pbs_samples.py",
+                    args.pbs_samples,
+                    "--limit",
+                    str(args.pbs_limit),
+                    "--output",
+                    os.path.join(args.output, "pbs-rendered"),
+                ],
+                args.output,
+            )
+        )
+
+    failures = sum(step.get("returncode", 0) != 0 for step in steps)
+    manifest = {
+        "failure_policy": {"max_failures": args.max_failures, "observed_failures": failures},
+        "pbs_archived_samples": args.pbs_samples or "not configured; bundled PBS parser fixtures still run",
+        "steps": steps,
+    }
+    with open(os.path.join(args.output, "manifest.json"), "w") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+    print("sample-gate failures=%s max_failures=%s output=%s" % (failures, args.max_failures, args.output))
+    return 0 if failures <= args.max_failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Refs #433

This PR adds a small scheduler sample gate shared by local development, GitHub
Actions, and GitLab CI.

## Included scope

- add `make sample-gate SAMPLE_GATE_MAX_FAILURES=0`;
- run bundled PBS, SGE, and Slurm parser fixtures on every gate execution;
- add a deterministic SGE XML command-trace fixture;
- render bundled Slurm traces on POSIX hosts and upload gate logs plus a JSON
  manifest as CI artifacts;
- add an AlmaLinux 8 / Python 3.6 GitHub Actions job with `pytest<7`;
- add a lightweight changed-file `fortifications` hook for bidi control
  characters and generated or binary-looking paths;
- set `contents: read` explicitly and pin official GitHub Actions dependencies
  to full current SHAs across existing and new workflows;
- document local reproduction, failure policy, external PBS corpus usage, and
  the generic CI pattern.

## Intentionally omitted

This PR does not replace inherited `eval` calls. Those changes need separate
behavior-focused tests and review. Keeping that refactor separate makes this CI
contribution easier to validate and backport.

## Validation

Executed locally on Windows:

```text
python tools/sample_gate.py --output artifacts/sample-gate --max-failures 0
29 passed
sample-gate failures=0 max_failures=0

python tools/fortifications.py <changed files>
fortifications: checked 11 changed files
```

The qtop CLI renderer depends on POSIX `SIGPIPE`, so the shared gate records the
Slurm render step as skipped on Windows. Both Linux CI jobs execute that step.

The full upstream pytest suite cannot collect on Windows because inherited
`qtop_py/qtop.py` imports `signal.SIGPIPE`. The new scheduler fixture suite does
not introduce that portability issue.

## AI assistance disclosure

GPT-5 Codex materially assisted with implementation and validation. The
contributor reviewed the change and remains responsible for the submitted
code.

/claim #433
