### PR TITLE
20260531: (LI) fix: include test fixture text files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,4 @@ recursive-include docs *.md *.rst *.png
 recursive-include tools *.py
 
 recursive-include qtop_py *.py *.sh *.jdl *.html *.txt *.ref *.gif *.stdout
-recursive-include tests *.py
-recursive-include tests/plugins/slurm_samples *.txt
+recursive-include tests *.py *.txt


### PR DESCRIPTION
Refs #245.

## Summary

This is a small MANIFEST cleanup for the current `develop` source distribution.

- include test fixture `.txt` files under `tests/` in the sdist
- keep the existing recursive MANIFEST style
- avoid touching runtime code, generated artifacts, CI, or dependencies

## Why

On current `origin/develop`, `tests/plugins/test_slurm.py` is included in the source distribution, but its `tests/plugins/slurm_samples/*/*.txt` fixture files are not. Running the Slurm plugin tests from an extracted sdist therefore fails with `FileNotFoundError` for the missing sample files.

## Validation

```text
# before this change, from an extracted origin/develop sdist:
PYTHONPATH=. uvx --with pytest pytest tests/plugins/test_slurm.py -q
# 6 failed, 13 passed; missing tests/plugins/slurm_samples/.../*.txt

# after this change, from an extracted sdist built from this branch:
PYTHONPATH=. uvx --with pytest pytest tests/plugins/test_slurm.py -q
# 19 passed

PYTHONPATH=. uvx --with pytest pytest -q
# 113 passed, 7 warnings

git diff --check
# passed
```

## qtop contribution alignment

[2026-05-31 CONTRIBUTING alignment] I rechecked `origin/develop:CONTRIBUTING.md` before opening this PR. This PR targets `develop`, uses a DCO-signed commit, adds no runtime dependencies, stores no generated artifacts in the repo, and keeps the change to one packaging manifest line.

No screenshot is included because this is packaging metadata only; the extracted-sdist test result above is the relevant proof.

## AI assistance disclosure

OpenAI Codex based on GPT-5 assisted with issue inspection, verification planning, and PR text. I reviewed the final one-line diff, reproduced the pre-fix sdist failure, ran the validation above, and remain responsible for the contribution.
