### PR TITLE
Add shared CI sample gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,22 +4,28 @@ on:
   push:
     branches:
       - master
+      - main
       - 'releases/**'
   pull_request:
-    branches:    
+    branches:
       - master
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
-      - run: pip install build twine
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install build twine
       - run: pyproject-build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,25 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pytest pytest-cov
+      - run: make ci
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: qtop-sample-gate
+          path: artifacts/qtop-sample-gate/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+artifacts/
 
 # Translations
 *.mo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+image: python:3.10
+
+stages:
+  - test
+
+qtop-ci:
+  stage: test
+  variables:
+    MAX_FAILURES: "0"
+  before_script:
+    - python -m pip install --upgrade pip
+    - python -m pip install pytest pytest-cov
+  script:
+    - make ci
+  artifacts:
+    when: always
+    paths:
+      - artifacts/qtop-sample-gate/
+      - coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.DEFAULT_GOAL := help
+
+PYTHON ?= python
+PYTEST ?= $(PYTHON) -m pytest
+ARTIFACT_DIR ?= artifacts/qtop-sample-gate
+MAX_FAILURES ?= 0
+
+.PHONY: help test coverage sample-gate fortifications ci confirm
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the unit test suite
+	$(PYTEST)
+
+coverage: ## Run tests with coverage output for CI
+	$(PYTEST) --cov=qtop_py --cov-report=term-missing --cov-report=xml
+
+sample-gate: ## Run the fast sample validation gate and write review artifacts
+	$(PYTHON) scripts/sample_gate.py --max-failures $(MAX_FAILURES) --artifact-dir "$(ARTIFACT_DIR)"
+
+fortifications: ## Inspect codebase health and CI-sensitive changes
+	$(PYTHON) scripts/fortifications.py
+
+ci: fortifications sample-gate coverage ## Shared CI entry point for GitHub and GitLab
+
+confirm: ## Ask for human confirmation before destructive release steps
+	@echo "Are you sure? [y/N]" && read ans && [ $${ans:-N} = y ]

--- a/docs/ci-sample-gate.md
+++ b/docs/ci-sample-gate.md
@@ -1,0 +1,29 @@
+# CI sample gate
+
+Issue #433 asks GitHub and GitLab to avoid drifting on sample validation. The shared entry point is:
+
+```bash
+make ci
+```
+
+For a faster local signal while iterating:
+
+```bash
+make sample-gate MAX_FAILURES=0
+```
+
+The sample gate uses the committed fixtures in `qtop_py/contrib` and runs focused PBS parser tests:
+
+- `tests/plugins/test_pbs.py`
+
+The committed sample inventory currently covers PBS, OAR, and SGE-style fixtures. SLURM is documented in `ROADMAP.rst`,
+so this gate does not invent an unverified SLURM fixture.
+
+Artifacts are written to `artifacts/qtop-sample-gate/`:
+
+- `summary.txt`
+- `pytest.log`
+
+The failure policy is explicit: with `MAX_FAILURES=0`, missing sample files or failing focused tests fail the job.
+
+The `fortifications` target also runs in `make ci`. It checks for unexpected generated/binary file changes, unusual Unicode/control characters in changed text files, and reports the current `eval(` inventory. Existing `eval(` usage is reported but does not fail by default; set `FORTIFY_FAIL_ON_EVAL=1` when the project is ready to make that check strict.

--- a/scripts/fortifications.py
+++ b/scripts/fortifications.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Lightweight repository health checks for CI review gates."""
+
+from __future__ import print_function
+
+import os
+import re
+import subprocess
+import sys
+
+
+GENERATED_OR_BINARY = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/"
+    r"|(\.xz|\.lzma|\.gz|\.bin|\.dat)$",
+    re.IGNORECASE,
+)
+BIDI_OR_CONTROL = re.compile(
+    u"[\u202A\u202B\u202C\u202D\u202E\u2066\u2067\u2068\u2069]"
+    u"|[^\x09\x0A\x0D\x20-\x7E]"
+)
+
+
+def run_git(args):
+    try:
+        output = subprocess.check_output(["git"] + args, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return output.decode("utf-8", "replace").splitlines()
+
+
+def changed_files():
+    files = run_git(["diff", "--name-only", "origin/main...HEAD"])
+    if files:
+        return files
+    return run_git(["ls-files"])
+
+
+def is_text_file(path):
+    try:
+        with open(path, "rb") as handle:
+            chunk = handle.read(4096)
+    except IOError:
+        return False
+    return b"\0" not in chunk
+
+
+def scan_unicode(paths):
+    print("== weird unicode/control chars ==")
+    findings = []
+    for path in paths:
+        if not os.path.isfile(path) or not is_text_file(path):
+            continue
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for line_number, line in enumerate(handle, 1):
+                if BIDI_OR_CONTROL.search(line):
+                    findings.append("{}:{}".format(path, line_number))
+    if findings:
+        for finding in findings:
+            print(finding)
+        return 1
+    print("OK")
+    return 0
+
+
+def scan_generated(paths):
+    print("== unexpected binary/generated/build changes ==")
+    findings = [path for path in paths if GENERATED_OR_BINARY.search(path.replace(os.sep, "/"))]
+    if findings:
+        for finding in findings:
+            print(finding)
+        print("Manual review required")
+        return 1
+    print("OK")
+    return 0
+
+
+def scan_eval_inventory():
+    print("== eval inventory ==")
+    matches = []
+    for root, _, files in os.walk("qtop_py"):
+        for filename in files:
+            if not filename.endswith(".py"):
+                continue
+            path = os.path.join(root, filename)
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                for line_number, line in enumerate(handle, 1):
+                    if "eval(" in line and not line.lstrip().startswith("#"):
+                        matches.append("{}:{}".format(path, line_number))
+    if matches:
+        for match in matches:
+            print(match)
+        if os.environ.get("FORTIFY_FAIL_ON_EVAL") == "1":
+            return 1
+        print("Existing eval usage is reported but not failed by default.")
+    else:
+        print("OK")
+    return 0
+
+
+def main():
+    paths = changed_files()
+    status = 0
+    status |= scan_unicode(paths)
+    status |= scan_generated(paths)
+    status |= scan_eval_inventory()
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sample_gate.py
+++ b/scripts/sample_gate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fast sample validation gate for CI systems.
+
+The gate intentionally uses existing sample fixtures and focused tests so GitHub
+and GitLab can fail on the same small, reproducible signal.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+SAMPLE_FILES = [
+    "qtop_py/contrib/pbsnodes_a.txt",
+    "qtop_py/contrib/pbs_dvv_out.ref",
+    "qtop_py/contrib/qstat.txt",
+    "qtop_py/contrib/qstat_q.txt",
+    "qtop_py/contrib/oarstat.txt",
+    "qtop_py/contrib/oarnodes_s_Y.txt",
+    "qtop_py/contrib/sger_dvv_out.ref",
+    "qtop_py/contrib/qstat.F.xml.stdout",
+]
+
+FOCUSED_TESTS = [
+    "tests/plugins/test_pbs.py",
+]
+
+
+def write_artifact(path, lines):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-failures", type=int, default=0)
+    parser.add_argument("--artifact-dir", default="artifacts/qtop-sample-gate")
+    args = parser.parse_args()
+
+    os.makedirs(args.artifact_dir, exist_ok=True)
+    summary_path = os.path.join(args.artifact_dir, "summary.txt")
+    pytest_log_path = os.path.join(args.artifact_dir, "pytest.log")
+
+    lines = [
+        "qtop sample validation gate",
+        "max_failures={}".format(args.max_failures),
+        "sample_source=qtop_py/contrib",
+        "tests={}".format(" ".join(FOCUSED_TESTS)),
+        "",
+        "sample files:",
+    ]
+
+    failures = 0
+    for sample in SAMPLE_FILES:
+        exists = os.path.exists(sample)
+        lines.append("- {}: {}".format(sample, "present" if exists else "missing"))
+        if not exists:
+            failures += 1
+
+    cmd = [sys.executable, "-m", "pytest", "-q"] + FOCUSED_TESTS
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    write_artifact(pytest_log_path, proc.stdout.splitlines())
+    lines.extend(["", "pytest_exit={}".format(proc.returncode), "pytest_log={}".format(pytest_log_path)])
+
+    if proc.returncode != 0:
+        failures += 1
+
+    lines.extend(["", "failures={}".format(failures)])
+    write_artifact(summary_path, lines)
+    print("\n".join(lines))
+
+    if failures > args.max_failures:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a shared CI entry point for qtop sample validation so GitHub and GitLab run the same checks instead of drifting.

## Changes

- Add `Makefile` targets for `ci`, `sample-gate`, `fortifications`, `coverage`, and `test`.
- Add `scripts/sample_gate.py` with explicit `MAX_FAILURES=0` policy, fixture inventory, focused PBS parser tests, and artifact output.
- Add `scripts/fortifications.py` for changed-file Unicode/control character checks, generated/binary change checks, and `eval(` inventory reporting.
- Add `.gitlab-ci.yml` that calls the same `make ci` entrypoint as GitHub Actions.
- Update GitHub Actions with `permissions: contents: read` and action refs pinned to full commit SHAs.
- Document the sample source, limits, artifacts, and failure policy in `docs/ci-sample-gate.md`.

## Verification

```text
python scripts/fortifications.py
python scripts/sample_gate.py --max-failures 0 --artifact-dir artifacts/qtop-sample-gate
```

Observed result:

```text
fortifications -> exit 0
sample gate -> exit 0
focused pytest -> exit 0
failures=0
```

## Notes

The gate uses committed PBS/OAR/SGE fixtures in `qtop_py/contrib`. SLURM remains a roadmap item, so this PR does not invent an unverified SLURM sample.

Existing `eval(` calls are reported by `fortifications` but do not fail by default. Set `FORTIFY_FAIL_ON_EVAL=1` once the project is ready to make that strict.
