### PR TITLE
[2026-06-01 CONTRIBUTING alignment] ci: add scheduler sample validation gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-project:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,13 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
 
 jobs:
   run-pytest:
@@ -12,3 +19,12 @@ jobs:
           python-version: '3.10'
       - run: pip install pytest
       - run: python -m pytest
+
+  run-pytest-rhel8:
+    runs-on: ubuntu-latest
+    container: almalinux:8
+    steps:
+      - uses: actions/checkout@v3
+      - run: dnf install -y python36 python36-pip
+      - run: python3.6 -m pip install "pytest<7"
+      - run: python3.6 -m pytest

--- a/.github/workflows/sample-validation.yml
+++ b/.github/workflows/sample-validation.yml
@@ -16,10 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - run: pip install pytest
+      - run: make fortify FORTIFY_BASE=origin/develop
       - run: make test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=artifacts/qtop-slurm-rendered PBS_OUTPUT_DIR=artifacts/qtop-pbs-rendered
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/sample-validation.yml
+++ b/.github/workflows/sample-validation.yml
@@ -1,0 +1,32 @@
+name: sample-validation
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  sample-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: pip install pytest
+      - run: make test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=artifacts/qtop-slurm-rendered PBS_OUTPUT_DIR=artifacts/qtop-pbs-rendered
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qtop-sample-rendered-output
+          path: |
+            artifacts/qtop-contrib-rendered
+            artifacts/qtop-slurm-rendered
+            artifacts/qtop-pbs-rendered
+          if-no-files-found: ignore

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ sample-validation:
   before_script:
     - pip install pytest
   script:
+    - make fortify FORTIFY_BASE=origin/develop
     - make test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=artifacts/qtop-slurm-rendered PBS_OUTPUT_DIR=artifacts/qtop-pbs-rendered
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+stages:
+  - test
+
+sample-validation:
+  stage: test
+  image: python:3.10
+  before_script:
+    - pip install pytest
+  script:
+    - make test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=artifacts/qtop-slurm-rendered PBS_OUTPUT_DIR=artifacts/qtop-pbs-rendered
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - artifacts/qtop-contrib-rendered
+      - artifacts/qtop-slurm-rendered
+      - artifacts/qtop-pbs-rendered

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: test test-samples test-contrib-samples test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -6,13 +6,28 @@ PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+SAMPLE_MAX_FAILURES ?= 0
+SKIP_MISSING_PBS_SAMPLES ?= 1
 
 test:
 	$(PYTHON) -m pytest
+
+test-samples: test-contrib-samples test-slurm-samples
+	@if [ -d "$(PBS_SAMPLES_DIR)" ]; then \
+		$(MAKE) test-pbs-samples; \
+	elif [ "$(SKIP_MISSING_PBS_SAMPLES)" = "1" ]; then \
+		echo "Skipping PBS sample gate: $(PBS_SAMPLES_DIR) not found"; \
+	else \
+		echo "PBS sample gate required but $(PBS_SAMPLES_DIR) was not found"; \
+		exit 1; \
+	fi
+
+test-contrib-samples:
+	$(PYTHON) tools/validate_contrib_samples.py --output $(SLURM_OUTPUT_DIR)/../qtop-contrib-rendered
 
 test-pbs-samples:
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
 test-slurm-samples:
-	$(PYTHON) -m pytest tests/plugins/test_slurm.py
+	$(PYTHON) -m pytest tests/plugins/test_slurm.py --maxfail=$(SAMPLE_MAX_FAILURES)
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: test test-samples test-contrib-samples test-pbs-samples test-slurm-samples
+.PHONY: help test fortify test-samples test-contrib-samples test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
+FORTIFY_BASE ?= origin/develop
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
@@ -9,10 +10,17 @@ SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
 SAMPLE_MAX_FAILURES ?= 0
 SKIP_MISSING_PBS_SAMPLES ?= 1
 
-test:
+help: ## Show available Make targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the pytest suite.
 	$(PYTHON) -m pytest
 
-test-samples: test-contrib-samples test-slurm-samples
+fortify: ## Inspect the current diff for review hazards.
+	$(PYTHON) tools/fortify_diff.py --base $(FORTIFY_BASE)
+
+test-samples: test-contrib-samples test-slurm-samples ## Run fast scheduler sample gates.
 	@if [ -d "$(PBS_SAMPLES_DIR)" ]; then \
 		$(MAKE) test-pbs-samples; \
 	elif [ "$(SKIP_MISSING_PBS_SAMPLES)" = "1" ]; then \
@@ -22,12 +30,12 @@ test-samples: test-contrib-samples test-slurm-samples
 		exit 1; \
 	fi
 
-test-contrib-samples:
+test-contrib-samples: ## Render built-in PBS, SGE, and OAR samples.
 	$(PYTHON) tools/validate_contrib_samples.py --output $(SLURM_OUTPUT_DIR)/../qtop-contrib-rendered
 
-test-pbs-samples:
+test-pbs-samples: ## Render archived PBS samples when the archive is present.
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Run Slurm unit tests and render bundled Slurm samples.
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py --maxfail=$(SAMPLE_MAX_FAILURES)
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)

--- a/docs/sample-ci-gate.md
+++ b/docs/sample-ci-gate.md
@@ -1,0 +1,30 @@
+# Sample CI Gate
+
+`make test-samples` is the shared entry point for the lightweight scheduler
+sample gate. GitHub Actions and GitLab CI both call this target so the two CI
+systems do not drift.
+
+The gate always runs the built-in PBS, SGE, and OAR samples from
+`qtop_py/contrib`, then runs the in-repository Slurm command-trace samples from
+`tests/plugins/slurm_samples` and writes rendered output to `SLURM_OUTPUT_DIR`
+(`/tmp/qtop-slurm-rendered` by default). When the external PBS archive is
+available at `PBS_SAMPLES_DIR`, the same target also runs
+`tools/validate_pbs_samples.py` with `PBS_SAMPLE_LIMIT` and writes output to
+`PBS_OUTPUT_DIR` (`/tmp/qtop-pbs-rendered` by default).
+
+PBS samples are intentionally optional in the default CI job because the large
+historical trace archive is not vendored in this repository. Set
+`SKIP_MISSING_PBS_SAMPLES=0` in a CI job that mounts the archive to make PBS
+coverage mandatory.
+
+Failure policy:
+
+- `SAMPLE_MAX_FAILURES=0` is passed to the fast Slurm pytest gate.
+- Built-in PBS, SGE, and OAR samples fail the job when qtop cannot render them
+  or when they produce empty output.
+- Slurm rendering fails the job when no valid samples are found or qtop cannot
+  render a sample.
+- PBS rendering fails the job when the archive is required and missing, when a
+  golden sample is missing, or when fewer than `PBS_SAMPLE_LIMIT` samples render.
+- Rendered outputs are uploaded as CI artifacts instead of being committed to
+  this repository, keeping the repo aligned with `CONTRIBUTING.md`.

--- a/docs/sample-ci-gate.md
+++ b/docs/sample-ci-gate.md
@@ -4,6 +4,15 @@
 sample gate. GitHub Actions and GitLab CI both call this target so the two CI
 systems do not drift.
 
+`make fortify` is the shared pre-test review gate. It compares the current
+branch against `FORTIFY_BASE` (`origin/develop` by default) and fails on:
+
+- non-ASCII or control characters added by the contribution diff, including
+  bidirectional text controls;
+- new `eval()` calls added by the contribution diff;
+- changed generated, compressed, binary, or fixture-like paths that should be
+  reviewed manually instead of silently accepted by automation.
+
 The gate always runs the built-in PBS, SGE, and OAR samples from
 `qtop_py/contrib`, then runs the in-repository Slurm command-trace samples from
 `tests/plugins/slurm_samples` and writes rendered output to `SLURM_OUTPUT_DIR`
@@ -19,6 +28,7 @@ coverage mandatory.
 
 Failure policy:
 
+- `make fortify` runs before sample rendering in GitHub Actions and GitLab CI.
 - `SAMPLE_MAX_FAILURES=0` is passed to the fast Slurm pytest gate.
 - Built-in PBS, SGE, and OAR samples fail the job when qtop cannot render them
   or when they produce empty output.
@@ -28,3 +38,8 @@ Failure policy:
   golden sample is missing, or when fewer than `PBS_SAMPLE_LIMIT` samples render.
 - Rendered outputs are uploaded as CI artifacts instead of being committed to
   this repository, keeping the repo aligned with `CONTRIBUTING.md`.
+
+The structure mirrors a common CI pattern used by projects that keep one local
+command as the contract and call it from more than one CI system. For example,
+Ruff keeps contributor-facing commands in its repository automation and invokes
+them from GitHub workflows rather than duplicating all logic in workflow YAML.

--- a/tools/fortify_diff.py
+++ b/tools/fortify_diff.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 San Phan
+##
+## SPDX-License-Identifier: MIT
+##
+
+"""Inspect a contribution diff for review hazards before CI runs tests."""
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+BIDI_CONTROLS = set(range(0x202A, 0x202F)) | set(range(0x2066, 0x206A))
+GENERATED_OR_BINARY_PATH = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/"
+    r"|(\.xz|\.lzma|\.gz|\.bin|\.dat)$",
+    re.IGNORECASE,
+)
+EVAL_CALL = re.compile(r"\beval\s*\(")
+
+
+def git_output(args):
+    completed = subprocess.run(
+        ["git"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            "git %s failed:\n%s" % (" ".join(args), completed.stderr.strip())
+        )
+    return completed.stdout
+
+
+def resolve_base(preferred_base):
+    candidates = [preferred_base, "origin/develop", "upstream/develop", "HEAD~1"]
+    seen = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        completed = subprocess.run(
+            ["git", "rev-parse", "--verify", "%s^{commit}" % candidate],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        if completed.returncode == 0:
+            return candidate
+    raise RuntimeError("could not resolve a base ref for fortification checks")
+
+
+def has_control_or_non_ascii(text):
+    for char in text:
+        codepoint = ord(char)
+        if codepoint in (0x09, 0x0A, 0x0D):
+            continue
+        if 0x20 <= codepoint <= 0x7E and codepoint not in BIDI_CONTROLS:
+            continue
+        return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/develop")
+    args = parser.parse_args()
+
+    base = resolve_base(args.base)
+    changed_files = [
+        line
+        for line in git_output(["diff", "--name-only", "%s...HEAD" % base]).splitlines()
+        if line
+    ]
+    failures = []
+
+    for path in changed_files:
+        if GENERATED_OR_BINARY_PATH.search(path):
+            failures.append("manual review required for generated/binary path: %s" % path)
+
+    diff = git_output(["diff", "-U0", "%s...HEAD" % base])
+    for line_number, line in enumerate(diff.splitlines(), 1):
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if has_control_or_non_ascii(line):
+            failures.append("non-ASCII/control character in added diff line %s" % line_number)
+        if EVAL_CALL.search(line):
+            failures.append("new eval() call in added diff line %s" % line_number)
+
+    if failures:
+        print("== fortify failures ==")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("Fortify OK against %s (%s changed files)" % (base, len(changed_files)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_contrib_samples.py
+++ b/tools/validate_contrib_samples.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Render built-in qtop scheduler samples and save their output."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+SAMPLES = (
+    ("sge", ("-Fadvv", "-b", "sge")),
+    ("pbs", ("-raF", "-b", "pbs")),
+    ("oar", ("--experimental", "-FAardvvv", "-b", "oar")),
+)
+
+
+def run_sample(name, qtop_args, contrib_dir, output_dir):
+    command = [
+        sys.executable,
+        "-m",
+        "qtop_py.qtop",
+        "-s",
+        str(contrib_dir),
+        "-c",
+        "ON",
+    ] + list(qtop_args)
+    completed = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            "qtop failed for %s:\nSTDOUT:\n%s\nSTDERR:\n%s"
+            % (name, completed.stdout, completed.stderr)
+        )
+    if not completed.stdout.strip():
+        raise RuntimeError("qtop produced no output for %s" % name)
+    (output_dir / ("%s.ans" % name)).write_text(completed.stdout)
+    (output_dir / ("%s.stderr" % name)).write_text(completed.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render built-in PBS, SGE, and OAR qtop samples.")
+    parser.add_argument("--contrib-dir", type=Path, default=Path("qtop_py/contrib"))
+    parser.add_argument("--output", type=Path, default=Path("/tmp/qtop-contrib-rendered"))
+    args = parser.parse_args()
+
+    if not args.contrib_dir.is_dir():
+        raise RuntimeError("contrib sample directory not found: %s" % args.contrib_dir)
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    for name, qtop_args in SAMPLES:
+        run_sample(name, qtop_args, args.contrib_dir, args.output)
+
+    print("Validated %s contrib scheduler samples" % len(SAMPLES))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_contrib_samples.py
+++ b/tools/validate_contrib_samples.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 San Phan
+##
+## SPDX-License-Identifier: MIT
+##
+
 """Render built-in qtop scheduler samples and save their output."""
 
 import argparse


### PR DESCRIPTION
# [2026-06-01 CONTRIBUTING alignment] Add shared scheduler sample CI gate

## Summary

[2026-06-01 CONTRIBUTING alignment] Contributor: San Phan. This PR targets
`develop`, uses DCO-signed commits, keeps generated/rendered artifacts out of
the repository, avoids new runtime dependencies, adds copyright/SPDX headers to
new Python tools, and discloses AI assistance below.

Adds a shared `make test-samples` entry point for qtop scheduler sample
validation, a shared `make fortify` pre-test review gate, and wires both into
GitHub Actions plus GitLab CI.

This is intended to help with #433 by making the small sample gate repeatable
across CI systems without vendoring the larger PBS archive into the main repo.

Changes:

- Adds `tools/validate_contrib_samples.py` to render built-in PBS, SGE, and OAR
  samples from `qtop_py/contrib` with the active Python interpreter.
- Adds `tools/fortify_diff.py` to check the contribution diff for non-ASCII or
  control characters, new `eval()` calls, and generated/binary path changes.
- Extends `make test-samples` to run built-in scheduler samples, Slurm sample
  pytest coverage, Slurm rendering validation, and optional archived PBS sample
  validation.
- Adds `make help` and target descriptions so contributors can discover the
  local commands without reading workflow YAML.
- Adds GitHub Actions sample-validation workflow and GitLab CI job using the
  same Makefile target.
- Uploads rendered outputs as CI artifacts.
- Adds `permissions: contents: read` to GitHub workflows.
- Adds a RHEL8-style Python 3.6 pytest job using an AlmaLinux 8 container.
- Documents sample sources, output locations, limits, and failure policy.

Explicitly scoped out:

- Full removal of existing `eval()` calls is left for a separate source-code
  hardening PR; this PR prevents adding new `eval()` calls in its diff.
- Pinning GitHub Actions to full SHAs is not done here to keep the PR focused
  on the sample/fortification gate. The workflow now at least uses
  `permissions: contents: read`.
- No visual UI screenshot is attached because this PR does not change UI. The
  rendered qtop outputs are published as CI artifacts and were generated
  locally during validation.

Independent structure reference:

- Ruff uses repository-local commands and GitHub workflows around those commands
  rather than duplicating all quality-gate logic directly in workflow YAML. This
  PR follows the same pattern: Makefile targets are the contract, GitHub/GitLab
  are callers.

## Related

Refs #433

## Validation

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache python3 -m py_compile tools/validate_contrib_samples.py tools/validate_slurm_samples.py tools/validate_pbs_samples.py
```

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache python3 tools/fortify_diff.py --base upstream/develop
Fortify OK against upstream/develop (7 changed files)
```

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache python3 tools/validate_contrib_samples.py --output /private/tmp/qtop-contrib-rendered-check
Validated 3 contrib scheduler samples
```

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache python3 tools/validate_slurm_samples.py tests/plugins/slurm_samples --output /private/tmp/qtop-slurm-rendered-check
Validated 6 Slurm samples
```

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache PYTHON=/private/tmp/qtop-venv/bin/python make test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=/private/tmp/qtop-ci-artifacts/qtop-slurm-rendered PBS_OUTPUT_DIR=/private/tmp/qtop-ci-artifacts/qtop-pbs-rendered
tests/plugins/test_slurm.py ................... [100%]
19 passed
Validated 6 Slurm samples
Skipping PBS sample gate: ../qtop-test-repo/qtop5/results not found
```

```text
HOME=/private/tmp/qtop-home PYTHONPYCACHEPREFIX=/private/tmp/qtop-pycache PYTHON=/private/tmp/qtop-venv/bin/python make fortify FORTIFY_BASE=upstream/develop test-samples SAMPLE_MAX_FAILURES=0 SLURM_OUTPUT_DIR=/private/tmp/qtop-ci-artifacts2/qtop-slurm-rendered PBS_OUTPUT_DIR=/private/tmp/qtop-ci-artifacts2/qtop-pbs-rendered
Fortify OK against upstream/develop (7 changed files)
Validated 3 contrib scheduler samples
19 passed
Validated 6 Slurm samples
Skipping PBS sample gate: ../qtop-test-repo/qtop5/results not found
```

Note: AI assistance materially contributed to this change. The final patch was
locally inspected and validated with the commands above.
