### PR TITLE
20260602: (human)(PRO) ci: remove eval paths and add fortifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.DEFAULT_GOAL := help
+
+.PHONY: help test test-pbs-samples test-slurm-samples fortifications lint format-check
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -6,13 +8,26 @@ PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+FORTIFY_BASE_REF ?= origin/develop
 
-test:
+help: ## Show this help
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the Python test suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
+test-pbs-samples: ## Run the larger archived PBS sample sweep
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Run Slurm parser tests and render committed Slurm samples
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+
+fortifications: ## Check diff health and reject eval() call sites
+	$(PYTHON) tools/fortifications.py --base-ref $(FORTIFY_BASE_REF)
+
+lint: fortifications ## Run dependency-light source and diff health checks
+
+format-check: ## Check the branch diff for whitespace errors
+	git diff --check $(FORTIFY_BASE_REF)...HEAD

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -88,6 +88,19 @@ def literal_config_value(value):
         return value
 
 
+def extract_regex_detail(regex, field):
+    expression = (regex or "").strip()
+    if not expression:
+        return field.strip()
+
+    match = re.match(r"^re\.search\((?P<quote>['\"])(?P<pattern>.*)(?P=quote),\s*field\)\.group\((?P<group>\d+)\)$", expression, re.DOTALL)
+    if not match:
+        raise ValueError("Unsupported user detail regex expression in %s" % QTOPCONF_YAML)
+
+    found = re.search(match.group("pattern"), field)
+    return found.group(int(match.group("group")))
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -389,8 +402,8 @@ def get_detail_of_name(account_jobs_table):
             break
         else:
             try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
+                detail = extract_regex_detail(regex, field)
+            except (AttributeError, TypeError, ValueError):
                 detail = field.strip()
             finally:
                 detail_of_name[user] = detail
@@ -524,9 +537,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
         sort_map["5"] = ("sort by node state", [])
         sort_map["6"] = ("sort by nr of cores", [])
         sort_map["7"] = ("sort by core occupancy", [])
-        sort_map["8"] = ("sort by custom definition", [])
-
-        custom_choice = "8"
 
         print(
             "Type in sort order. This can be a single number or a sequence of numbers,\n"
@@ -546,9 +556,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
             )
             if not sort_choice:
                 break
-            if custom_choice in sort_choice:
-                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
-                sort_map[custom_choice][1].append(custom)
 
             try:
                 sort_order = [m for m in sort_choice]
@@ -772,8 +779,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -2011,8 +2017,9 @@ class Cluster(object):
             _host = state_corejob_dn["domainname"].split(".", 1)[0]
             changed = False
             for remap_line in self.config["remapping"]:
-                pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                pat, repl = list(remap_line.items())[0]
+                if isinstance(repl, str) and repl.strip().startswith("lambda"):
+                    raise ValueError("lambda remapping is no longer supported in %s because eval is disabled" % QTOPCONF_YAML)
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2069,37 +2076,40 @@ class Cluster(object):
 
     def _sort_worker_nodes(self):
         order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
+            "sort by nodename-notnum": lambda node: re.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0",
+            "sort by nodename-notnum length": lambda node: len(node["domainname"].split(".", 1)[0].split("-")[0]),
+            "sort by all numbers": lambda node: int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),
+            "sort by first letter": lambda node: ord(node["domainname"][0]),
+            "sort by node state": lambda node: ord(str(node["state"][0])),
+            "sort by nr of cores": lambda node: int(node["np"]),
+            "sort by core occupancy": lambda node: len(node["core_job_map"]),
+            "sort reset": lambda node: 0,
         }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
-            # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_labels = [k[0] for k in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_labels = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
+        def sort_key(node):
+            values = []
+            for label in sort_labels:
+                if label == "sort by custom definition":
+                    raise ValueError("custom Python sorting expressions are no longer supported because eval is disabled")
+                values.append(order[label](node))
+            return tuple(values)
+
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=sort_key, reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting configuration in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
+            msg = "Worker Nodes don't contain '%s' as a key." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
         except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -116,9 +116,6 @@ def convert_dash_key_in_dict(d):
             for key_in in d[key_out]:
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
-                # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
-                #     break
         except TypeError:
             return d
         except IndexError:

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -172,9 +172,6 @@ nodestate_color_mappings:
 ## if cluster numbering should start on a number # above this, do automatic blind remapping
 exotic_starting_wn_nr: 9000
 remapping:
-# - "([A-Za-z]+)([1-9]|[1-9][0-9]|[0-9][0-9][0-9])$": |
-#     lambda m: m.group(1)+str(int(m.group(2))+250)
-     ## e.g. wn100 --> wn350, wn101 --> wn351 and so on
 # - torvalds(\d+): tor\1
 # - gridlab(\d+): glab\1
 # - gridmon(\d*): mon\1
@@ -192,23 +189,12 @@ sorting:
   #   - sort by first letter
   #   - sort by node state
   #   - sort by nr of cores
-  #   - sort by custom definition
+  #   custom Python sort expressions are not supported
 
    reverse: False
 
-# sorting:  
-#   user_sort: |
-#       lambda node: (
-#       len(node['domainname'].split('.', 1)[0].split('-')[0]),                                      # sort by name length, until first dash or dot
-#       int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),                                # sort strictly by all numbers in name (joined)
-#       # int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1),   # sort by number adjacent to first word
-#       # ord(node['domainname'][0]),                                                                  # sort by first letter
-#       # ord(str(node['state'][0])),                                                                  # sort by node state
-#       # int(node['np'])                                                                              # sort by number of cores
-#       # 0,                                                                                           # no sorting, MUST comment out other sorting options
-#       )
-
-#   reverse: False
+## Custom Python sorting expressions are intentionally unsupported; use the
+## named sort options above so configuration does not execute code.
 
 ## exclude filters gradually cut off selected nodes from the last set of remaining nodes
 ## include filters do a consecutive selection, e.g. from 100 nodes 30 are selected, then the next include filter will select 10 out of those and so on.

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -11,7 +11,18 @@
 import pytest
 import re
 import datetime
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import (
+    WNOccupancy,
+    decide_batch_system,
+    extract_regex_detail,
+    load_yaml_config,
+    update_config_with_cmdline_vars,
+    JobNotFound,
+    SchedulerNotSpecified,
+    NoSchedulerFound,
+    get_date_obj_from_str,
+    get_detail_of_name,
+)
 
 
 @pytest.fixture
@@ -58,6 +69,81 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_extract_regex_detail_supports_configured_re_search():
+    field = "User Name <alice@example.org>"
+
+    assert extract_regex_detail("re.search('(?<=<)[^<>]+(?=>)', field).group(0)", field) == "alice@example.org"
+
+
+def test_get_detail_of_name_falls_back_for_unsupported_regex(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    class Args:
+        GET_GECOS = False
+
+    class Process:
+        def communicate(self, _input):
+            return ("alice:x:1:1:Alice Example:/home/alice:/bin/sh\n", "")
+
+    monkeypatch.setattr(qtop, "args", Args(), raising=False)
+    monkeypatch.setattr(
+        qtop,
+        "config",
+        {
+            "extract_info": {
+                "field_to_use": "5",
+                "regex": "__import__('pathlib').Path('/tmp/should-not-run').touch()",
+                "user_details_cache": "cat /dev/null",
+            }
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(qtop.subprocess, "Popen", lambda *args, **kwargs: Process())
+
+    assert get_detail_of_name([]) == {"alice": "Alice Example"}
+
+
+def test_update_config_with_cmdline_vars_does_not_execute_option_values(tmp_path):
+    class Args:
+        OPTION = ["enabled=True", "dangerous=__import__('pathlib').Path(%r).touch()" % str(tmp_path / "executed")]
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    config = {"rem_empty_corelines": "0", "transpose_wn_matrices": True}
+
+    updated = update_config_with_cmdline_vars(Args(), config)
+
+    assert updated["enabled"] is True
+    assert updated["dangerous"].startswith("__import__")
+    assert not (tmp_path / "executed").exists()
+
+
+def test_sort_worker_nodes_uses_named_sort_keys(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by all numbers"], "reverse": False}}
+    cluster.worker_nodes = [
+        {"domainname": "node10", "state": "-", "np": "1", "core_job_map": {}},
+        {"domainname": "node2", "state": "-", "np": "1", "core_job_map": {}},
+    ]
+
+    assert [node["domainname"] for node in cluster._sort_worker_nodes()] == ["node2", "node10"]
+
+
+def test_sort_worker_nodes_rejects_custom_python_sorting(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by custom definition"], "reverse": False}}
+    cluster.worker_nodes = [{"domainname": "node1", "state": "-", "np": "1", "core_job_map": {}}]
+
+    with pytest.raises(ValueError, match="custom Python sorting expressions"):
+        cluster._sort_worker_nodes()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -9,7 +9,7 @@ from qtop_py.yaml_parser import get_line, convert_dash_key_in_dict, read_yaml_co
         (["schedulers"], [0, "schedulers"]),
         (["  pbs"], [1, "pbs"]),
         (["   - r'moonshot'"], [2, "-", "r'moonshot'"]),
-        ([" - '\w*cms048': Blue"], [1, "-", "'\\w*cms048': Blue"]),
+        ([" - '\\w*cms048': Blue"], [1, "-", "'\\w*cms048': Blue"]),
         (["term_size: [53, 176]"], [0, "term_size:", "[53, 176]"]),
     ),
 )

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Jacob Hatchett
+##
+## SPDX-License-Identifier: MIT
+##
+
+"""Diff and source-health checks used by local and CI validation."""
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROL_OR_BIDI = re.compile(r"[^\x09\x0a\x0d\x20-\x7e]|\u202a|\u202b|\u202c|\u202d|\u202e|\u2066|\u2067|\u2068|\u2069")
+GENERATED_OR_BINARY = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
+    r"\.(xz|lzma|gz|bin|dat|png|jpg|jpeg|gif|webp)$",
+    re.IGNORECASE,
+)
+SKIP_DIRS = set([".git", ".tox", ".venv", "__pycache__", "artifacts", "build", "dist", "qtop.egg-info"])
+
+
+def run_git(args):
+    return subprocess.check_output(["git"] + args, cwd=str(ROOT), stderr=subprocess.STDOUT, universal_newlines=True)
+
+
+def changed_files(base_ref):
+    output = run_git(["diff", "--name-only", "%s...HEAD" % base_ref])
+    return [line for line in output.splitlines() if line]
+
+
+def diff_lines(base_ref):
+    output = run_git(["diff", "--unified=0", "%s...HEAD" % base_ref])
+    return output.splitlines()
+
+
+def iter_python_files():
+    for dirpath, dirnames, filenames in os.walk(str(ROOT)):
+        dirnames[:] = [name for name in dirnames if name not in SKIP_DIRS]
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def find_eval_calls():
+    problems = []
+    for path in iter_python_files():
+        relative = str(path.relative_to(ROOT))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        except SyntaxError as exc:
+            problems.append("%s:%s syntax error while scanning for eval: %s" % (relative, exc.lineno, exc.msg))
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
+                problems.append("%s:%s eval() call is not allowed" % (relative, getattr(node, "lineno", "?")))
+    return problems
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default="origin/develop", help="Diff base for changed-file checks")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    problems = []
+
+    try:
+        files = changed_files(args.base_ref)
+        lines = diff_lines(args.base_ref)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.output)
+        sys.stderr.write("Unable to compare against %s\n" % args.base_ref)
+        return 2
+
+    for filename in files:
+        if GENERATED_OR_BINARY.search(filename):
+            problems.append("manual review required for generated/binary-looking path: %s" % filename)
+
+    for line in lines:
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if CONTROL_OR_BIDI.search(line[1:]):
+            problems.append("control, bidi, or non-ASCII character found in an added diff line")
+            break
+
+    problems.extend(find_eval_calls())
+
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 1
+
+    print("fortifications: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #433

[2026-06-01 CONTRIBUTING alignment] Contributor: Jacob Hatchett. This PR
targets `develop`, uses a DCO-signed commit, keeps generated artifacts out of
the repository, adds a header to the new Python tool, and limits this first
split to the eval-removal and fortification slice.

This is part 1 of a smaller split series for issue #433, following the
maintainer's request to break the broad CI/testing change into reviewable
pieces. This PR intentionally covers only the eval-removal and fortification
slice; the committed sample gate and provider CI wiring are prepared as
follow-up slices. It is not intended to close #433 by itself.

## Summary
- remove remaining runtime `eval()` call paths from config options, account detail extraction, remapping, sorting, and PBS/SGE queue totals
- add named safe sort-key handling and reject custom Python sort expressions instead of executing them
- add regression coverage proving config values and command-line options are not executed
- add `tools/fortifications.py` and Makefile `lint` / `format-check` targets for diff health checks
- keep generated artifacts out of the repository and preserve the develop-branch CONTRIBUTING alignment

## Validation
- `make lint`
- `make format-check`
- `/private/tmp/qtop-ci-feedback-venv/bin/python -m pytest tests/test_qtop.py tests/plugins/test_pbs.py tests/plugins/test_slurm.py tests/test_yaml_parser.py -q`

AI assistance disclosure: OpenAI Codex (GPT-5.5 xhigh) helped prepare this change; I reviewed the diff and validation output before submission.
