### PR TITLE
20260601: ci: add committed scheduler sample gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+artifacts/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help test test-pbs-samples test-slurm-samples fortifications lint format-check
+.PHONY: help test sample-gate test-pbs-samples test-slurm-samples fortifications lint format-check ci
 
 PYTHON ?= python3
+SAMPLE_GATE_SCHEDULERS ?= pbs,sge,slurm
+SAMPLE_GATE_MAX_FAILURES ?= 0
+SAMPLE_GATE_ARTIFACT_DIR ?= artifacts/sample-gate
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
@@ -16,6 +19,9 @@ help: ## Show this help
 
 test: ## Run the Python test suite
 	$(PYTHON) -m pytest
+
+sample-gate: ## Run fast committed PBS/SGE/SLURM qtop sample gates
+	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)
 
 test-pbs-samples: ## Run the larger archived PBS sample sweep
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
@@ -31,3 +37,5 @@ lint: fortifications ## Run dependency-light source and diff health checks
 
 format-check: ## Check the branch diff for whitespace errors
 	git diff --check $(FORTIFY_BASE_REF)...HEAD
+
+ci: test sample-gate lint format-check ## Run the shared local validation path

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.DEFAULT_GOAL := help
+
+.PHONY: help test test-pbs-samples test-slurm-samples fortifications lint format-check
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -6,13 +8,26 @@ PBS_SAMPLE_LIMIT ?= 100
 PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+FORTIFY_BASE_REF ?= origin/develop
 
-test:
+help: ## Show this help
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the Python test suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
+test-pbs-samples: ## Run the larger archived PBS sample sweep
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
 
-test-slurm-samples:
+test-slurm-samples: ## Run Slurm parser tests and render committed Slurm samples
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
 	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+
+fortifications: ## Check diff health and reject eval() call sites
+	$(PYTHON) tools/fortifications.py --base-ref $(FORTIFY_BASE_REF)
+
+lint: fortifications ## Run dependency-light source and diff health checks
+
+format-check: ## Check the branch diff for whitespace errors
+	git diff --check $(FORTIFY_BASE_REF)...HEAD

--- a/docs/ci-sample-gates.md
+++ b/docs/ci-sample-gates.md
@@ -1,0 +1,35 @@
+# CI sample gates
+
+Issue #433 asks for a small validation path that can be reproduced locally and
+then reused by CI. The local entry point is:
+
+```bash
+make sample-gate SAMPLE_GATE_SCHEDULERS=pbs,sge,slurm SAMPLE_GATE_MAX_FAILURES=0
+```
+
+Sources:
+
+- PBS: `qtop_py/contrib`
+- SGE: `qtop_py/contrib`
+- Slurm: every directory under `tests/plugins/slurm_samples`
+
+The PBS and SGE cases reuse the historical contrib wrapper flags (`-raF` for
+PBS and `-Fadvv` for SGE) while running through the shared Python gate. The
+legacy `qtop_py/contrib/func_tests.sh` wrapper delegates to the same target, so
+manual and automated sample checks exercise one implementation.
+
+Policy:
+
+- `SAMPLE_GATE_MAX_FAILURES=0` is the default and means any failed scheduler
+  case fails the gate.
+- Rendered qtop output, ANSI-stripped normalized output, SVG terminal
+  screenshots, stderr, command lines, and `summary.json` are written under
+  `artifacts/sample-gate/`, including for non-zero and timeout failures.
+- Each qtop subprocess receives an isolated `HOME` under its artifact
+  directory, so log creation does not depend on a writable runner home.
+- Generated artifacts stay out of the repository. The `artifacts/` path is
+  ignored and can be uploaded by a later CI wiring change.
+
+`make ci` currently composes the unit tests, sample gate, fortifications, and
+branch whitespace check. Provider-specific GitHub/GitLab wiring can call this
+same target in a follow-up change without redefining the validation contract.

--- a/qtop_py/contrib/func_tests.sh
+++ b/qtop_py/contrib/func_tests.sh
@@ -1,24 +1,21 @@
 #! /bin/sh -
-# The following script runs three known test cases for qtop, one for each of PBS, OAR, SGE
-# No output after "Testing <scheduler>" means test passed. 
-# The test actually runs qtop over known scheduler output files, and then diffs them against the expected output. 
-# While diffing, one qtop output line is omitted 
-# (the one containing word "WORKDIR\|Please try it with watch\|Log file created in"), as it contains an everchanging timestamp.
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Jacob Hatchett
+##
+## SPDX-License-Identifier: MIT
+##
 
-cd ..
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/../.." && pwd)
 
-echo "(No news is good news!)"
-echo "Testing sge..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/sger_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -s contrib -c ON -Fadvv -b sge \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
+cd "$REPO_ROOT" || exit 1
 
-echo "Testing oar..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/oar1_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -FAardvvv -b oar \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
+PYTHON=${PYTHON:-python3}
+SAMPLE_GATE_ARTIFACT_DIR=${SAMPLE_GATE_ARTIFACT_DIR:-artifacts/sample-gate-contrib}
 
-echo "Testing pbs..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/pbs_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -raF -b pbs \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
+exec make sample-gate \
+	PYTHON="$PYTHON" \
+	SAMPLE_GATE_ARTIFACT_DIR="$SAMPLE_GATE_ARTIFACT_DIR" \
+	"$@"

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -88,6 +88,19 @@ def literal_config_value(value):
         return value
 
 
+def extract_regex_detail(regex, field):
+    expression = (regex or "").strip()
+    if not expression:
+        return field.strip()
+
+    match = re.match(r"^re\.search\((?P<quote>['\"])(?P<pattern>.*)(?P=quote),\s*field\)\.group\((?P<group>\d+)\)$", expression, re.DOTALL)
+    if not match:
+        raise ValueError("Unsupported user detail regex expression in %s" % QTOPCONF_YAML)
+
+    found = re.search(match.group("pattern"), field)
+    return found.group(int(match.group("group")))
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -389,8 +402,8 @@ def get_detail_of_name(account_jobs_table):
             break
         else:
             try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
+                detail = extract_regex_detail(regex, field)
+            except (AttributeError, TypeError, ValueError):
                 detail = field.strip()
             finally:
                 detail_of_name[user] = detail
@@ -524,9 +537,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
         sort_map["5"] = ("sort by node state", [])
         sort_map["6"] = ("sort by nr of cores", [])
         sort_map["7"] = ("sort by core occupancy", [])
-        sort_map["8"] = ("sort by custom definition", [])
-
-        custom_choice = "8"
 
         print(
             "Type in sort order. This can be a single number or a sequence of numbers,\n"
@@ -546,9 +556,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
             )
             if not sort_choice:
                 break
-            if custom_choice in sort_choice:
-                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
-                sort_map[custom_choice][1].append(custom)
 
             try:
                 sort_order = [m for m in sort_choice]
@@ -772,8 +779,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = literal_config_value(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -2011,8 +2017,9 @@ class Cluster(object):
             _host = state_corejob_dn["domainname"].split(".", 1)[0]
             changed = False
             for remap_line in self.config["remapping"]:
-                pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                pat, repl = list(remap_line.items())[0]
+                if isinstance(repl, str) and repl.strip().startswith("lambda"):
+                    raise ValueError("lambda remapping is no longer supported in %s because eval is disabled" % QTOPCONF_YAML)
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2069,37 +2076,40 @@ class Cluster(object):
 
     def _sort_worker_nodes(self):
         order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
+            "sort by nodename-notnum": lambda node: re.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0",
+            "sort by nodename-notnum length": lambda node: len(node["domainname"].split(".", 1)[0].split("-")[0]),
+            "sort by all numbers": lambda node: int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),
+            "sort by first letter": lambda node: ord(node["domainname"][0]),
+            "sort by node state": lambda node: ord(str(node["state"][0])),
+            "sort by nr of cores": lambda node: int(node["np"]),
+            "sort by core occupancy": lambda node: len(node["core_job_map"]),
+            "sort reset": lambda node: 0,
         }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
-            # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_labels = [k[0] for k in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_labels = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
+        def sort_key(node):
+            values = []
+            for label in sort_labels:
+                if label == "sort by custom definition":
+                    raise ValueError("custom Python sorting expressions are no longer supported because eval is disabled")
+                values.append(order[label](node))
+            return tuple(values)
+
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=sort_key, reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting configuration in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
+            msg = "Worker Nodes don't contain '%s' as a key." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
         except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -116,9 +116,6 @@ def convert_dash_key_in_dict(d):
             for key_in in d[key_out]:
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
-                # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
-                #     break
         except TypeError:
             return d
         except IndexError:

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -172,9 +172,6 @@ nodestate_color_mappings:
 ## if cluster numbering should start on a number # above this, do automatic blind remapping
 exotic_starting_wn_nr: 9000
 remapping:
-# - "([A-Za-z]+)([1-9]|[1-9][0-9]|[0-9][0-9][0-9])$": |
-#     lambda m: m.group(1)+str(int(m.group(2))+250)
-     ## e.g. wn100 --> wn350, wn101 --> wn351 and so on
 # - torvalds(\d+): tor\1
 # - gridlab(\d+): glab\1
 # - gridmon(\d*): mon\1
@@ -192,23 +189,12 @@ sorting:
   #   - sort by first letter
   #   - sort by node state
   #   - sort by nr of cores
-  #   - sort by custom definition
+  #   custom Python sort expressions are not supported
 
    reverse: False
 
-# sorting:  
-#   user_sort: |
-#       lambda node: (
-#       len(node['domainname'].split('.', 1)[0].split('-')[0]),                                      # sort by name length, until first dash or dot
-#       int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),                                # sort strictly by all numbers in name (joined)
-#       # int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1),   # sort by number adjacent to first word
-#       # ord(node['domainname'][0]),                                                                  # sort by first letter
-#       # ord(str(node['state'][0])),                                                                  # sort by node state
-#       # int(node['np'])                                                                              # sort by number of cores
-#       # 0,                                                                                           # no sorting, MUST comment out other sorting options
-#       )
-
-#   reverse: False
+## Custom Python sorting expressions are intentionally unsupported; use the
+## named sort options above so configuration does not execute code.
 
 ## exclude filters gradually cut off selected nodes from the last set of remaining nodes
 ## include filters do a consecutive selection, e.g. from 100 nodes 30 are selected, then the next include filter will select 10 out of those and so on.

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -11,7 +11,18 @@
 import pytest
 import re
 import datetime
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+from qtop_py.qtop import (
+    WNOccupancy,
+    decide_batch_system,
+    extract_regex_detail,
+    load_yaml_config,
+    update_config_with_cmdline_vars,
+    JobNotFound,
+    SchedulerNotSpecified,
+    NoSchedulerFound,
+    get_date_obj_from_str,
+    get_detail_of_name,
+)
 
 
 @pytest.fixture
@@ -58,6 +69,81 @@ def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):
     assert config["vertical_separator_every_X_columns"] == 0
     assert config["overwrite_sample_file"] == dangerous_value
     assert not sentinel.exists()
+
+
+def test_extract_regex_detail_supports_configured_re_search():
+    field = "User Name <alice@example.org>"
+
+    assert extract_regex_detail("re.search('(?<=<)[^<>]+(?=>)', field).group(0)", field) == "alice@example.org"
+
+
+def test_get_detail_of_name_falls_back_for_unsupported_regex(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    class Args:
+        GET_GECOS = False
+
+    class Process:
+        def communicate(self, _input):
+            return ("alice:x:1:1:Alice Example:/home/alice:/bin/sh\n", "")
+
+    monkeypatch.setattr(qtop, "args", Args(), raising=False)
+    monkeypatch.setattr(
+        qtop,
+        "config",
+        {
+            "extract_info": {
+                "field_to_use": "5",
+                "regex": "__import__('pathlib').Path('/tmp/should-not-run').touch()",
+                "user_details_cache": "cat /dev/null",
+            }
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(qtop.subprocess, "Popen", lambda *args, **kwargs: Process())
+
+    assert get_detail_of_name([]) == {"alice": "Alice Example"}
+
+
+def test_update_config_with_cmdline_vars_does_not_execute_option_values(tmp_path):
+    class Args:
+        OPTION = ["enabled=True", "dangerous=__import__('pathlib').Path(%r).touch()" % str(tmp_path / "executed")]
+        TRANSPOSE = False
+        REM_EMPTY_CORELINES = 0
+
+    config = {"rem_empty_corelines": "0", "transpose_wn_matrices": True}
+
+    updated = update_config_with_cmdline_vars(Args(), config)
+
+    assert updated["enabled"] is True
+    assert updated["dangerous"].startswith("__import__")
+    assert not (tmp_path / "executed").exists()
+
+
+def test_sort_worker_nodes_uses_named_sort_keys(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by all numbers"], "reverse": False}}
+    cluster.worker_nodes = [
+        {"domainname": "node10", "state": "-", "np": "1", "core_job_map": {}},
+        {"domainname": "node2", "state": "-", "np": "1", "core_job_map": {}},
+    ]
+
+    assert [node["domainname"] for node in cluster._sort_worker_nodes()] == ["node2", "node10"]
+
+
+def test_sort_worker_nodes_rejects_custom_python_sorting(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+    cluster = qtop.Cluster.__new__(qtop.Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by custom definition"], "reverse": False}}
+    cluster.worker_nodes = [{"domainname": "node1", "state": "-", "np": "1", "core_job_map": {}}]
+
+    with pytest.raises(ValueError, match="custom Python sorting expressions"):
+        cluster._sort_worker_nodes()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -9,7 +9,7 @@ from qtop_py.yaml_parser import get_line, convert_dash_key_in_dict, read_yaml_co
         (["schedulers"], [0, "schedulers"]),
         (["  pbs"], [1, "pbs"]),
         (["   - r'moonshot'"], [2, "-", "r'moonshot'"]),
-        ([" - '\w*cms048': Blue"], [1, "-", "'\\w*cms048': Blue"]),
+        ([" - '\\w*cms048': Blue"], [1, "-", "'\\w*cms048': Blue"]),
         (["term_size: [53, 176]"], [0, "term_size:", "[53, 176]"]),
     ),
 )

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Jacob Hatchett
+##
+## SPDX-License-Identifier: MIT
+##
+
+"""Diff and source-health checks used by local and CI validation."""
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROL_OR_BIDI = re.compile(r"[^\x09\x0a\x0d\x20-\x7e]|\u202a|\u202b|\u202c|\u202d|\u202e|\u2066|\u2067|\u2068|\u2069")
+GENERATED_OR_BINARY = re.compile(
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
+    r"\.(xz|lzma|gz|bin|dat|png|jpg|jpeg|gif|webp)$",
+    re.IGNORECASE,
+)
+SKIP_DIRS = set([".git", ".tox", ".venv", "__pycache__", "artifacts", "build", "dist", "qtop.egg-info"])
+
+
+def run_git(args):
+    return subprocess.check_output(["git"] + args, cwd=str(ROOT), stderr=subprocess.STDOUT, universal_newlines=True)
+
+
+def changed_files(base_ref):
+    output = run_git(["diff", "--name-only", "%s...HEAD" % base_ref])
+    return [line for line in output.splitlines() if line]
+
+
+def diff_lines(base_ref):
+    output = run_git(["diff", "--unified=0", "%s...HEAD" % base_ref])
+    return output.splitlines()
+
+
+def iter_python_files():
+    for dirpath, dirnames, filenames in os.walk(str(ROOT)):
+        dirnames[:] = [name for name in dirnames if name not in SKIP_DIRS]
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def find_eval_calls():
+    problems = []
+    for path in iter_python_files():
+        relative = str(path.relative_to(ROOT))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        except SyntaxError as exc:
+            problems.append("%s:%s syntax error while scanning for eval: %s" % (relative, exc.lineno, exc.msg))
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
+                problems.append("%s:%s eval() call is not allowed" % (relative, getattr(node, "lineno", "?")))
+    return problems
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default="origin/develop", help="Diff base for changed-file checks")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    problems = []
+
+    try:
+        files = changed_files(args.base_ref)
+        lines = diff_lines(args.base_ref)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.output)
+        sys.stderr.write("Unable to compare against %s\n" % args.base_ref)
+        return 2
+
+    for filename in files:
+        if GENERATED_OR_BINARY.search(filename):
+            problems.append("manual review required for generated/binary-looking path: %s" % filename)
+
+    for line in lines:
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if CONTROL_OR_BIDI.search(line[1:]):
+            problems.append("control, bidi, or non-ASCII character found in an added diff line")
+            break
+
+    problems.extend(find_eval_calls())
+
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 1
+
+    print("fortifications: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_scheduler_samples.py
+++ b/tools/validate_scheduler_samples.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2026 Jacob Hatchett
+##
+## SPDX-License-Identifier: MIT
+##
+
+"""Shared fast qtop sample gate for CI and local review.
+
+The gate intentionally uses small committed scheduler traces, so GitHub and
+GitLab can run the same command without access to the larger artifact corpus.
+"""
+
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+CONTRIB = ROOT / "qtop_py" / "contrib"
+
+STATIC_CASES = {
+    "pbs": [
+        {
+            "name": "pbs-contrib",
+            "source": CONTRIB,
+            "args": ["-c", "ON", "-s", str(CONTRIB), "-raF", "-b", "pbs"],
+            "markers": [
+                "Summary: Total:829 Up:819 Free:91 Nodes",
+                "7629/7872 cores",
+                "7590+3365 jobs",
+                "Worker Nodes occupancy",
+                "User accounts and pool mappings",
+            ],
+        }
+    ],
+    "sge": [
+        {
+            "name": "sge-contrib",
+            "source": CONTRIB,
+            "args": ["-s", str(CONTRIB), "-c", "ON", "-Fadvv", "-b", "sge"],
+            "markers": [
+                "Summary: Total:17 Up:17 Free:4 Nodes",
+                "61/408 cores",
+                "61+31 jobs",
+                "Worker Nodes occupancy",
+                "User accounts and pool mappings",
+            ],
+        }
+    ],
+}
+
+SLURM_MARKERS_BY_SAMPLE = {
+    "basic": ["Summary: Total:3 Up:3 Free:2 Nodes", "4/16 cores", "2+1 jobs"],
+    "large_cluster": ["Summary: Total:18 Up:17 Free:9 Nodes", "120/288 cores", "3+1 jobs"],
+    "large_mixed": ["Summary: Total:20 Up:19 Free:9 Nodes", "160/320 cores", "3+1 jobs"],
+    "large_multi_partition": ["Summary: Total:18 Up:17 Free:10 Nodes", "104/288 cores", "3+1 jobs"],
+    "mixed": ["Summary: Total:2 Up:1 Free:0 Nodes", "4/16 cores", "2+0 jobs"],
+    "multi_partition": ["Summary: Total:2 Up:2 Free:1 Nodes", "4/32 cores", "2+1 jobs"],
+}
+
+COMMON_RENDER_MARKERS = [
+    "Worker Nodes occupancy",
+    "User accounts and pool mappings",
+]
+
+
+def normalize_output(text):
+    text = ANSI_RE.sub("", text)
+    return re.sub(r"\s+", " ", text)
+
+
+def normalize_for_artifact(text):
+    lines = ANSI_RE.sub("", text).splitlines()
+    return "\n".join(line.rstrip() for line in lines).strip() + ("\n" if lines else "")
+
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def output_text(value):
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value
+
+
+def display_path(path):
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def write_svg_screenshot(path, text, max_lines=38, max_columns=132):
+    lines = ANSI_RE.sub("", text).splitlines()[:max_lines]
+    clipped = [line[:max_columns] for line in lines]
+    width = max(760, min(1320, 22 + max([len(line) for line in clipped] or [0]) * 8))
+    height = 36 + max(1, len(clipped)) * 17
+    rows = []
+    for index, line in enumerate(clipped):
+        rows.append(
+            '<text x="14" y="%s">%s</text>' % (
+                28 + index * 17,
+                html.escape(line.rstrip()),
+            )
+        )
+    svg = """<svg xmlns="http://www.w3.org/2000/svg" width="%s" height="%s" viewBox="0 0 %s %s">
+<rect width="100%%" height="100%%" fill="#111111"/>
+<g font-family="Menlo, Consolas, monospace" font-size="13" fill="#f2f2f2">
+%s
+</g>
+</svg>
+""" % (
+        width,
+        height,
+        width,
+        height,
+        "\n".join(rows),
+    )
+    write_text(path, svg)
+
+
+def discover_cases(schedulers, slurm_samples_dir):
+    cases = []
+    for scheduler in schedulers:
+        if scheduler in STATIC_CASES:
+            for case in STATIC_CASES[scheduler]:
+                item = dict(case)
+                item["scheduler"] = scheduler
+                cases.append(item)
+        elif scheduler == "slurm":
+            sample_root = Path(slurm_samples_dir)
+            for sample_dir in sorted(path for path in sample_root.iterdir() if path.is_dir()):
+                if sample_dir.name not in SLURM_MARKERS_BY_SAMPLE:
+                    raise SystemExit("Missing Slurm marker expectations for sample: %s" % sample_dir.name)
+                cases.append(
+                    {
+                        "name": "slurm-%s" % sample_dir.name,
+                        "scheduler": "slurm",
+                        "source": sample_dir,
+                        "markers": SLURM_MARKERS_BY_SAMPLE[sample_dir.name] + COMMON_RENDER_MARKERS,
+                    }
+                )
+        else:
+            raise SystemExit("Unknown scheduler: %s" % scheduler)
+    return cases
+
+
+def run_case(case, artifact_dir, timeout):
+    case_dir = artifact_dir / case["name"]
+    if case_dir.exists():
+        shutil.rmtree(str(case_dir))
+    qtop_home = case_dir / "home"
+    qtop_home.mkdir(parents=True, exist_ok=True)
+
+    command = [sys.executable, "-m", "qtop_py.cli"] + case.get(
+        "args",
+        ["-s", str(case["source"]), "-c", "ON", "-F", "-b", case["scheduler"]],
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(qtop_home)
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(ROOT),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = output_text(exc.stdout)
+        stderr = output_text(exc.stderr)
+        write_text(case_dir / "stdout.ans", stdout)
+        write_text(case_dir / "rendered.normalized.txt", normalize_for_artifact(stdout))
+        write_text(case_dir / "stderr.log", stderr)
+        write_text(case_dir / "command.txt", " ".join(command) + "\n")
+        write_svg_screenshot(case_dir / "screenshot.svg", stdout)
+        return {
+            "name": case["name"],
+            "scheduler": case["scheduler"],
+            "source": display_path(case["source"]),
+            "command": command,
+            "returncode": None,
+            "artifact": display_path(case_dir),
+            "screenshot": display_path(case_dir / "screenshot.svg"),
+            "ok": False,
+            "missing_markers": [],
+            "error": "timeout after %s seconds" % timeout,
+        }
+
+    write_text(case_dir / "stdout.ans", completed.stdout)
+    write_text(case_dir / "rendered.normalized.txt", normalize_for_artifact(completed.stdout))
+    write_text(case_dir / "stderr.log", completed.stderr)
+    write_text(case_dir / "command.txt", " ".join(command) + "\n")
+    write_svg_screenshot(case_dir / "screenshot.svg", completed.stdout)
+
+    result = {
+        "name": case["name"],
+        "scheduler": case["scheduler"],
+        "source": display_path(case["source"]),
+        "command": command,
+        "returncode": completed.returncode,
+        "artifact": display_path(case_dir),
+        "screenshot": display_path(case_dir / "screenshot.svg"),
+        "ok": False,
+        "missing_markers": [],
+    }
+
+    if completed.returncode != 0:
+        result["error"] = "qtop exited non-zero"
+        return result
+
+    normalized = normalize_output(completed.stdout)
+    missing = [marker for marker in case["markers"] if marker not in normalized]
+    result["missing_markers"] = missing
+    result["ok"] = not missing
+    if missing:
+        write_text(case_dir / "missing-markers.txt", "\n".join(missing) + "\n")
+    return result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schedulers", default="pbs,sge,slurm", help="Comma-separated scheduler gates to run")
+    parser.add_argument("--max-failures", type=int, default=0, help="Allowed failed cases before returning non-zero")
+    parser.add_argument("--timeout", type=int, default=20, help="Per-case timeout in seconds")
+    parser.add_argument("--artifact-dir", default="artifacts/sample-gate", help="Output directory for rendered qtop artifacts")
+    parser.add_argument("--slurm-samples-dir", default="tests/plugins/slurm_samples", help="Committed Slurm sample directory")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    schedulers = [item.strip() for item in args.schedulers.split(",") if item.strip()]
+    artifact_dir = Path(args.artifact_dir)
+    if not artifact_dir.is_absolute():
+        artifact_dir = ROOT / artifact_dir
+    cases = discover_cases(schedulers, ROOT / args.slurm_samples_dir)
+    results = []
+
+    for case in cases:
+        result = run_case(case, artifact_dir, args.timeout)
+        results.append(result)
+        print("%s: %s" % (result["name"], "ok" if result["ok"] else "failed"))
+
+    failures = [result for result in results if not result["ok"]]
+    summary = {
+        "cases": len(results),
+        "passed": len(results) - len(failures),
+        "failed": len(failures),
+        "max_failures": args.max_failures,
+        "artifact_dir": display_path(artifact_dir),
+        "results": results,
+    }
+    write_text(artifact_dir / "summary.json", json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print("sample-gate: passed=%s failed=%s artifact_dir=%s" % (summary["passed"], summary["failed"], summary["artifact_dir"]))
+
+    return 0 if len(failures) <= args.max_failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_slurm_samples.py
+++ b/tools/validate_slurm_samples.py
@@ -26,6 +26,9 @@ def run_qtop(sample_name, sample_dir, output_dir):
     env = os.environ.copy()
     env["QTOP_SCHEDULER"] = "slurm"
     os.makedirs(output_dir, exist_ok=True)
+    qtop_home = os.path.join(output_dir, ".home", sample_name)
+    os.makedirs(qtop_home, exist_ok=True)
+    env["HOME"] = qtop_home
     command = [sys.executable, "-m", "qtop_py.cli", "-b", "slurm", "-s", sample_dir, "-O", "-o", "savepath=%s" % output_dir]
     completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, universal_newlines=True)
     if completed.returncode:


### PR DESCRIPTION
/claim #433

[2026-06-01 CONTRIBUTING alignment] Contributor: Jacob Hatchett. This PR
targets `develop`, uses DCO-signed commits, keeps generated artifacts out of
the repository, adds a header to the new Python sample-gate tool, and limits
this second split to the committed scheduler sample gate.

This is part 2 of the smaller split series for issue #433. It builds on PR
#473's eval-removal and fortification slice, and intentionally focuses only on
the committed scheduler sample gate. After #473 lands, this branch can be
rebased so the review diff is only the sample-gate delta. GitHub/GitLab
provider wiring is prepared as a follow-up slice.

## Summary
- add one committed PBS/SGE/SLURM sample gate with `SAMPLE_GATE_MAX_FAILURES=0` by default
- write rendered qtop output, ANSI-stripped normalized output, SVG screenshots, stderr, command lines, and `summary.json` for every case
- isolate each sample subprocess `HOME` under its artifact directory
- keep `qtop_py/contrib/func_tests.sh` as a legacy wrapper that delegates to the same Makefile sample gate
- document sample sources, failure policy, artifact paths, and the later CI upload path

## Validation
- `make ci PYTHON=/private/tmp/qtop-pr2-verify-venv/bin/python SAMPLE_GATE_ARTIFACT_DIR=artifacts/sample-gate-pr2-publish`
  - `118 passed, 7 warnings`
  - `sample-gate: passed=8 failed=0`
  - `fortifications: ok`
  - `git diff --check origin/develop...HEAD`
- `qtop_py/contrib/func_tests.sh PYTHON=/private/tmp/qtop-pr2-verify-venv/bin/python SAMPLE_GATE_ARTIFACT_DIR=artifacts/sample-gate-pr2-contrib-publish`
  - `sample-gate: passed=8 failed=0`

AI assistance disclosure: OpenAI Codex (GPT-5) helped prepare this change; I reviewed the diff and validation output before submission.
