### PR TITLE
ci: add scheduler sample gate and fortify checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,23 +3,30 @@ name: build-qtop
 on:
   push:
     branches:
+      - main
       - master
       - 'releases/**'
   pull_request:
-    branches:    
+    branches:
+      - main
       - master
+
+permissions:
+  contents: read
 
 jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: '3.10'
-      - run: pip install build twine
-      - run: pyproject-build
-      - uses: actions/upload-artifact@v3
+          cache: pip
+      - run: python -m pip install build twine
+      - run: make dist PYTHON=python
+      - run: twine check dist/*
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,69 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  run-pytest:
+  test:
+    name: python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
-          python-version: '3.10'
-      - run: pip install pytest
-      - run: python -m pytest
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install test tools
+        run: python -m pip install pytest pytest-cov ruff
+      - name: Shared CI gate
+        run: make ci PYTHON=python MAX_FAILURES=0
+      - name: Coverage
+        run: make coverage PYTHON=python
+      - name: Upload coverage XML
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: coverage-python-${{ matrix.python-version }}
+          path: coverage.xml
+          retention-days: 14
+      - name: Upload sample artifacts
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: sample-artifacts-python-${{ matrix.python-version }}
+          path: sample-artifacts/
+          retention-days: 30
+
+  almalinux8-python36:
+    name: AlmaLinux 8 python3.6 compatibility
+    runs-on: ubuntu-latest
+    container:
+      image: almalinux:8
+    steps:
+      - name: Install system dependencies
+        run: dnf install -y git make python3 python3-pip
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Python 3.6 test tools
+        run: python3 -m pip install "pytest<7"
+      - name: Unit tests
+        run: make test PYTHON=python3 PYTEST="python3 -m pytest"
+      - name: Sample gate
+        run: make sample-validate PYTHON=python3 MAX_FAILURES=0
+      - name: Upload sample artifacts
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: sample-artifacts-almalinux8-python36
+          path: sample-artifacts/
+          retention-days: 30

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,55 @@
+stages:
+  - test
+  - build
+
+default:
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends git make
+    - python -m pip install pytest pytest-cov ruff build twine
+
+test:
+  stage: test
+  image: python:${PYTHON_VERSION}-slim
+  parallel:
+    matrix:
+      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+  script:
+    - make ci PYTHON=python MAX_FAILURES=0
+    - make coverage PYTHON=python
+  artifacts:
+    when: always
+    expire_in: 30 days
+    paths:
+      - coverage.xml
+      - sample-artifacts/
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+
+almalinux8-python36:
+  stage: test
+  image: almalinux:8
+  before_script:
+    - dnf install -y make python3 python3-pip
+    - python3 -m pip install "pytest<7"
+  script:
+    - make test PYTHON=python3 PYTEST="python3 -m pytest"
+    - make sample-validate PYTHON=python3 MAX_FAILURES=0
+  artifacts:
+    when: always
+    expire_in: 30 days
+    paths:
+      - sample-artifacts/
+
+dist:
+  stage: build
+  image: python:3.12-slim
+  script:
+    - make dist PYTHON=python
+    - twine check dist/*
+  artifacts:
+    expire_in: 30 days
+    paths:
+      - dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,19 @@ You may contribute in the following ways:
 * Help with outreach and onboard new contributors
 * Write and/or lead collaborations proposals, including grants or help with other fundraising or community efforts
 
+Development checks:
+
+* `make test` runs the unit tests.
+* `make sample-validate MAX_FAILURES=0` runs qtop against checked-in scheduler samples and writes raw output, stderr, normalized output, and `summary.json` under `sample-artifacts/`.
+* `make fortify` rejects active `eval()` calls, bidirectional text markers, and committed Python bytecode.
+* `make ci` is the shared GitHub Actions and GitLab CI entry point.
+
+Scheduler sample gate:
+
+The sample gate uses fixtures already committed in `qtop_py/contrib/`: PBS uses `pbsnodes_a.txt`, `qstat_q.txt`, and `qstat.txt`; SGE uses `qstat.F.xml.stdout`; OAR uses `oarnodes_s_Y.txt`, `oarnodes_Y.txt`, and `oarstat.txt`. The gate runs qtop with `python -m qtop_py.cli`, strips volatile timestamps, working directories, ANSI color, and log paths from the normalized artifact, and fails when a scheduler command exits non-zero, produces no normalized output, or misses expected qtop sections. Set `MAX_FAILURES=0` in CI so any scheduler regression fails the pipeline.
+
+qtop currently has PBS, OAR, SGE, and demo scheduler implementations. There is no SLURM plugin or sample fixture in this repository yet; add that plugin and fixture before enabling a SLURM sample job.
+
 [1] https://wiki.linuxfoundation.org/dco
 
 [2] https://developercertificate.org/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,10 @@
 include CHANGELOG.rst
-include CONTRIBUTING.rst
+include CONTRIBUTING.md
 include helpfile.txt
 include Makefile
 include MANIFEST.in
 include LICENSE
 include qtopconf.yaml
-include qtop.py
 include qtop
 include qtop_py/cli.py
 include qtop_py/colormap.py
@@ -41,10 +40,11 @@ include qtop_py/utils.py
 include qtop_py/web/index.html
 include qtop_py/web.py
 include qtop_py/yaml_parser.py
-include qtop_py/qtop.sh
-include README.rst
+include README.md
 include ROADMAP.rst
-include setup.py
+include scripts/fortify.py
+include scripts/fortify.sh
+include scripts/sample_gate.py
 include tests/plugins/__init__.py
 include tests/plugins/test_pbs.py
 include tests/test_qtop.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.DEFAULT_GOAL := help
+
+PYTHON ?= python3
+PYTEST ?= $(PYTHON) -m pytest
+MAX_FAILURES ?= 0
+ARTIFACT_DIR ?= sample-artifacts
+
+.PHONY: help
+help:
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: lint
+lint: ## Run syntax-focused ruff checks without forcing a style cleanup.
+	$(PYTHON) -m ruff check --select E9,F63,F7,F82 qtop_py tests scripts
+
+.PHONY: test
+test: ## Run the unit test suite.
+	$(PYTEST) tests/ -q
+
+.PHONY: coverage
+coverage: ## Run unit tests with a coverage XML artifact.
+	$(PYTEST) tests/ --cov=qtop_py --cov-report=term --cov-report=xml:coverage.xml -q
+
+.PHONY: sample-validate
+sample-validate: ## Run checked-in PBS/OAR/SGE scheduler samples.
+	$(PYTHON) scripts/sample_gate.py --artifact-dir $(ARTIFACT_DIR) --max-failures $(MAX_FAILURES)
+
+.PHONY: fortify
+fortify: ## Check for eval(), bidi markers, and compiled artifacts.
+	$(PYTHON) scripts/fortify.py
+
+.PHONY: dist
+dist: ## Build source and wheel distributions.
+	$(PYTHON) -m build
+
+.PHONY: ci
+ci: lint test sample-validate fortify ## Shared CI entry point for GitHub and GitLab.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qtop"
 dynamic = ["version"]
-description = """
-    qtop: the fast text mode way to monitor your cluster's utilization and status;
-    the time has come to take back control of your cluster's scheduling business"""
-readme = "README.rst"
+description = "qtop: the fast text mode way to monitor your cluster utilization and status"
+readme = "README.md"
 authors = [
     { name="Sotiris Fragkiskos", email="sfranky@gmail.com"},
     { name="Fotis Georgatos", email="kefalonia@gmail.com"},
@@ -25,7 +23,7 @@ qtop = "qtop_py.qtop:main"
 version = {attr = "qtop_py.__version__"}
 
 [tool.setuptools]
-packages = ["qtop_py"]
+packages = ["qtop_py", "qtop_py.plugins", "qtop_py.ui"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/qtop_py/contrib/func_tests.sh
+++ b/qtop_py/contrib/func_tests.sh
@@ -1,24 +1,13 @@
-#! /bin/sh -
-# The following script runs three known test cases for qtop, one for each of PBS, OAR, SGE
-# No output after "Testing <scheduler>" means test passed. 
-# The test actually runs qtop over known scheduler output files, and then diffs them against the expected output. 
-# While diffing, one qtop output line is omitted 
-# (the one containing word "WORKDIR\|Please try it with watch\|Log file created in"), as it contains an everchanging timestamp.
+#!/usr/bin/env sh
+set -eu
 
-cd ..
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+PYTHON=${PYTHON:-python3}
+ARTIFACT_DIR=${ARTIFACT_DIR:-sample-artifacts}
+MAX_FAILURES=${MAX_FAILURES:-0}
 
-echo "(No news is good news!)"
-echo "Testing sge..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/sger_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -s contrib -c ON -Fadvv -b sge \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
-
-echo "Testing oar..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/oar1_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -FAardvvv -b oar \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
-
-echo "Testing pbs..."
-grep -v 'WORKDIR\|Please try it with watch\|Log file created in' contrib/pbs_dvv_out.ref > /tmp/qtop_testfile
-./qtop.py -c ON -s contrib -raF -b pbs \
-    | grep -v 'WORKDIR\|Please try it with watch\|Log file created in' | diff - /tmp/qtop_testfile
+exec "$PYTHON" "$REPO_ROOT/scripts/sample_gate.py" \
+    --repo-root "$REPO_ROOT" \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --max-failures "$MAX_FAILURES"

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -19,6 +19,13 @@ import qtop_py.fileutils as fileutils
 import itertools
 
 
+def int_or_zero(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 class PBSStatExtractor(StatExtractor):
     def __init__(self, config, options):
         StatExtractor.__init__(self, config, options)
@@ -257,8 +264,9 @@ class PBSBatchSystem(GenericBatchSystem):
             else:
                 pbs_values["np"] = block.get("resources_available.ncpus", 0)
 
-            if block.get("gpus", 0) > 0:  # this should be rare.
-                pbs_values["gpus"] = block["gpus"]
+            gpus = int_or_zero(block.get("gpus", 0))
+            if gpus > 0:  # this should be rare.
+                pbs_values["gpus"] = gpus
 
             try:  # this should turn up more often, hence the try/except.
                 _ = block["jobs"]
@@ -313,7 +321,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ##################################################
 ##                     qtop                     ##
@@ -14,6 +14,7 @@
 ## SPDX-License-Identifier: MIT
 ##
 
+import ast
 import sys
 
 here = sys.path[0]
@@ -26,6 +27,7 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
 from signal import signal, SIGPIPE, SIG_DFL
@@ -146,6 +148,19 @@ def raw_mode(file):
             yield
 
 
+def parse_config_literal(value):
+    """
+    Parse qtop configuration values as Python literals without executing code.
+    Non-literals stay as strings so existing regex and scheduler text survives.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return value
+
+
 def load_yaml_config():
     """
     Loads ./QTOPCONF_YAML into a dictionary and then tries to update the dictionary
@@ -231,8 +246,8 @@ def load_yaml_config():
     config["savepath"] = _savepath
 
     for key in ("transpose_wn_matrices", "fill_with_user_firstletter", "faster_xml_parsing", "vertical_separator_every_X_columns", "overwrite_sample_file"):
-        config[key] = eval(config[key])  # TODO config should not be writeable!!
-    config["sorting"]["reverse"] = eval(config["sorting"].get("reverse", "0"))  # TODO config should not be writeable!!
+        config[key] = parse_config_literal(config[key])
+    config["sorting"]["reverse"] = bool(parse_config_literal(config["sorting"].get("reverse", "0")))
     config["ALT_LABEL_COLORS"] = yaml.fix_config_list(config["workernodes_matrix"][0]["wn id lines"]["alt_label_colors"])
     config["SEPARATOR"] = config["vertical_separator"].replace("'", "")
     config["USER_CUT_MATRIX_WIDTH"] = int(config["workernodes_matrix"][0]["wn id lines"]["user_cut_matrix_width"])
@@ -297,8 +312,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -335,6 +349,58 @@ def execute_shell_batch_commands(batch_system_commands, filenames, _file, _savep
     os.rename(tempname, filenames[_file])
 
     return filenames[_file]
+
+
+def _literal_regex_arg(node):
+    try:
+        return ast.literal_eval(node)
+    except (SyntaxError, ValueError):
+        return None
+
+
+def _legacy_re_search(regex_expr):
+    """
+    Convert the legacy qtopconf form
+    re.search('pattern', field).group(n) into a safe (pattern, group) pair.
+    """
+    try:
+        expr = ast.parse(regex_expr.strip(), mode="eval").body
+    except SyntaxError:
+        return regex_expr, 0
+
+    group = 0
+    search_call = expr
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute) and expr.func.attr == "group":
+        search_call = expr.func.value
+        if expr.args:
+            parsed_group = _literal_regex_arg(expr.args[0])
+            if isinstance(parsed_group, (int, str)):
+                group = parsed_group
+
+    if not (isinstance(search_call, ast.Call) and isinstance(search_call.func, ast.Attribute) and search_call.func.attr == "search"):
+        return regex_expr, 0
+    if len(search_call.args) < 2:
+        return regex_expr, 0
+    if not (isinstance(search_call.args[1], ast.Name) and search_call.args[1].id == "field"):
+        return regex_expr, 0
+
+    pattern = _literal_regex_arg(search_call.args[0])
+    return (pattern, group) if isinstance(pattern, str) else (regex_expr, 0)
+
+
+def extract_detail_from_field(field, regex):
+    if not regex:
+        return field.strip()
+
+    pattern, group = _legacy_re_search(regex)
+    match = re.search(pattern, field)
+    if not match:
+        return field.strip()
+
+    try:
+        return match.group(group)
+    except IndexError:
+        return field.strip()
 
 
 def get_detail_of_name(account_jobs_table):
@@ -380,12 +446,7 @@ def get_detail_of_name(account_jobs_table):
         except ValueError:
             break
         else:
-            try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
-                detail = field.strip()
-            finally:
-                detail_of_name[user] = detail
+            detail_of_name[user] = extract_detail_from_field(field, regex)
     return detail_of_name
 
 
@@ -764,8 +825,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
-        config[key] = val
+        config[key] = parse_config_literal(val)
 
     if args.TRANSPOSE:
         config["transpose_wn_matrices"] = not config["transpose_wn_matrices"]
@@ -1993,8 +2053,10 @@ class Cluster(object):
             _host = state_corejob_dn["domainname"].split(".", 1)[0]
             changed = False
             for remap_line in self.config["remapping"]:
-                pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                pat, repl = next(iter(remap_line.items()))
+                if isinstance(repl, str) and repl.lstrip().startswith("lambda"):
+                    logging.warning("Ignoring unsafe lambda remapping for pattern %s in %s.", pat, QTOPCONF_YAML)
+                    continue
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2049,39 +2111,57 @@ class Cluster(object):
 
         return nodes_drop, workernode_dict, workernode_dict_remapped
 
+    @staticmethod
+    def _node_sort_value(sort_name, node):
+        domainname = node["domainname"]
+        if sort_name == "sort by nodename-notnum":
+            return re.sub(r"[^A-Za-z _.-]+", "", domainname) or "0"
+        if sort_name == "sort by nodename-notnum length":
+            return len(domainname.split(".", 1)[0].split("-")[0])
+        if sort_name == "sort by all numbers":
+            return int(re.sub(r"[A-Za-z _.-]+", "", domainname) or "0")
+        if sort_name == "sort by first letter":
+            return ord(domainname[0])
+        if sort_name == "sort by node state":
+            return ord(str(node["state"][0]))
+        if sort_name == "sort by nr of cores":
+            return int(node["np"])
+        if sort_name == "sort by core occupancy":
+            return len(node["core_job_map"])
+        if sort_name == "sort reset":
+            return 0
+        raise ValueError("Unsupported sort rule: %s" % sort_name)
+
     def _sort_worker_nodes(self):
-        order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
-        }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
             # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_rules = [k[0] for k in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_rules = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
+        if isinstance(sort_rules, str):
+            logging.warning("Ignoring legacy custom sorting expression in %s.", QTOPCONF_YAML)
+            return self.worker_nodes
+
+        if "sort by custom definition" in sort_rules:
+            logging.warning("Ignoring unsafe custom sorting expression in %s.", QTOPCONF_YAML)
+            sort_rules = [rule for rule in sort_rules if rule != "sort by custom definition"]
+
+        if not sort_rules:
+            return self.worker_nodes
+
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=lambda node: tuple(self._node_sort_value(rule, node) for rule in sort_rules), reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting rule in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
+            msg = "Worker Nodes don't contain '%s' as a key." % e
             logging.error(colorize(msg, color_func="Red_L"))
         except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -8,11 +8,25 @@
 ## SPDX-License-Identifier: MIT
 ##
 
-import os
+import ast
 import logging
+import os
 
 
 ## TODO: black sheep
+
+
+def safe_literal(value):
+    """
+    Parse the small Python-literal subset that qtopconf historically accepted.
+    Values outside that subset are returned unchanged instead of being executed.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return value
 
 
 def fix_config_list(config_list):
@@ -97,7 +111,7 @@ def convert_dash_key_in_dict(d):
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
                 # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
+                #     d[key_out] = d[key_out]
                 #     break
         except TypeError:
             return d
@@ -148,10 +162,12 @@ def read_yaml_config_block(line, fin, get_lines):
         except StopIteration:  # EO(config)F
             return {}, ""
 
+    key_value = {}
     while len(line) > 1:  # as long as a blank line is not reached (i.e. block is not complete)
         # if line[0] == 0 or (line[0] != 0 and line[1] == '-'):  # same level
         # key_value used below belongs to previous line. It will work for first block line because of short circuit logic
-        if line[0] == 0 or (line[0] == 1 and (next(iter(key_value)) == "-")) or (line[0] == -1 and line[1] == "-"):  # same level or entry level
+        previous_key = next(iter(key_value), None)
+        if line[0] == 0 or (line[0] == 1 and previous_key == "-") or (line[0] == -1 and line[1] == "-"):  # same level or entry level
             key_value, container = process_line(line, fin, get_lines, parent_container)
             for k in key_value:
                 pass  # assign dict's sole key to k
@@ -243,10 +259,8 @@ def process_line(list_line, fin, get_lines, parent_container):
             container = container[1:-1].split(", ") if container.startswith("[") else container
             container = "" if container in ("''", '""') else container
             if len(container) == 1 and isinstance(container, list) and isinstance(container[0], str):
-                try:
-                    container = list(eval(container[0]))
-                except NameError:
-                    pass
+                parsed = safe_literal(container[0])
+                container = list(parsed) if isinstance(parsed, (list, tuple)) else container
             return {"-": [{key.rstrip(":"): container}]}, container  # list
 
         elif container.endswith("|"):
@@ -259,12 +273,10 @@ def process_line(list_line, fin, get_lines, parent_container):
             else:  # i.e. testkey: testvalue
                 container = [container[1:-1]] if container.startswith("[") else container  # list
                 if len(container) == 1 and isinstance(container, list) and isinstance(container[0], str):
-                    try:
-                        container = list(eval(container[0]))
-                    except NameError:
-                        pass
+                    parsed = safe_literal(container[0])
+                    container = list(parsed) if isinstance(parsed, (list, tuple)) else container
                 elif container.startswith("'") and container.endswith("'"):
-                    container = eval(container)
+                    container = safe_literal(container)
                 return {key.rstrip(":"): container}, container  # was parent_container#str
     else:
         raise ValueError("Didn't anticipate that!")

--- a/scripts/fortify.py
+++ b/scripts/fortify.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Small repository health checks used by CI."""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+
+BIDI_MARKERS = ("\u202a", "\u202b", "\u202c", "\u202d", "\u202e", "\u2066", "\u2067", "\u2068", "\u2069")
+SCAN_SUFFIXES = (".py", ".sh", ".yml", ".yaml", "Makefile")
+
+
+def tracked_files(repo_root):
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return [repo_root / line for line in result.stdout.splitlines()]
+
+
+def is_scanned(path):
+    if path.name == "Makefile":
+        return True
+    return path.suffix in SCAN_SUFFIXES
+
+
+def check_bidi(files):
+    failures = []
+    for path in files:
+        if not is_scanned(path):
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            if any(marker in line for marker in BIDI_MARKERS):
+                failures.append("%s:%s contains bidirectional text marker" % (path, line_no))
+    return failures
+
+
+def check_eval_calls(files):
+    failures = []
+    for path in files:
+        if path.suffix != ".py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
+                failures.append("%s:%s uses an eval call" % (path, node.lineno))
+    return failures
+
+
+def check_compiled_artifacts(files):
+    return ["tracked compiled artifact: %s" % path for path in files if path.suffix == ".pyc" or "__pycache__" in path.parts]
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    files = tracked_files(repo_root)
+    failures = []
+    failures.extend(check_bidi(files))
+    failures.extend(check_eval_calls(files))
+    failures.extend(check_compiled_artifacts(files))
+
+    if failures:
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("fortify checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fortify.sh
+++ b/scripts/fortify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -eu
+
+PYTHON=${PYTHON:-python3}
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+exec "$PYTHON" "$REPO_ROOT/scripts/fortify.py"

--- a/scripts/sample_gate.py
+++ b/scripts/sample_gate.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Run qtop against checked-in scheduler samples and publish artifacts."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+VOLATILE_MARKERS = (
+    "Please try it with watch:",
+    "Log file created in",
+    "WORKDIR =",
+)
+
+SAMPLES = {
+    "sge": {
+        "args": ["-s", "qtop_py/contrib", "-c", "ON", "-Fadvv", "-b", "sge"],
+        "inputs": ["qtop_py/contrib/qstat.F.xml.stdout"],
+        "expect": ["Summary: Total:", "Worker Nodes occupancy", "User accounts and pool mappings"],
+    },
+    "oar": {
+        "args": ["-e", "-c", "ON", "-s", "qtop_py/contrib", "-FAardvvv", "-b", "oar"],
+        "inputs": ["qtop_py/contrib/oarnodes_s_Y.txt", "qtop_py/contrib/oarnodes_Y.txt", "qtop_py/contrib/oarstat.txt"],
+        "expect": ["Summary: Total:", "Worker Nodes occupancy", "User accounts and pool mappings"],
+    },
+    "pbs": {
+        "args": ["-c", "ON", "-s", "qtop_py/contrib", "-raF", "-b", "pbs"],
+        "inputs": ["qtop_py/contrib/pbsnodes_a.txt", "qtop_py/contrib/qstat_q.txt", "qtop_py/contrib/qstat.txt"],
+        "expect": ["Summary: Total:", "Worker Nodes occupancy", "User accounts and pool mappings"],
+    },
+}
+
+
+def normalize(output):
+    lines = []
+    for line in output.replace("\r", "").splitlines():
+        if any(marker in line for marker in VOLATILE_MARKERS):
+            continue
+        stripped = ANSI_RE.sub("", line).rstrip()
+        if stripped:
+            lines.append(stripped)
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def run_sample(name, sample, repo_root, artifact_dir, python):
+    started = time.time()
+    missing = [path for path in sample["inputs"] if not (repo_root / path).exists()]
+    command = [python, "-m", "qtop_py.cli"] + list(sample["args"])
+    env = os.environ.copy()
+    env["HOME"] = str(artifact_dir / "home")
+    env["PYTHONPATH"] = str(repo_root)
+    env.setdefault("TERM", "xterm")
+    env.setdefault("USER", "qtop-ci")
+
+    result = subprocess.run(
+        command,
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    raw_path = artifact_dir / ("%s.raw.txt" % name)
+    err_path = artifact_dir / ("%s.stderr.txt" % name)
+    normalized_path = artifact_dir / ("%s.normalized.txt" % name)
+    write_text(raw_path, result.stdout)
+    write_text(err_path, result.stderr)
+    normalized = normalize(result.stdout)
+    write_text(normalized_path, normalized)
+
+    failures = []
+    if missing:
+        failures.append("missing inputs: %s" % ", ".join(missing))
+    if result.returncode != 0:
+        failures.append("exit code %s" % result.returncode)
+    if not normalized.strip():
+        failures.append("no normalized qtop output")
+    for expected in sample["expect"]:
+        if expected not in normalized:
+            failures.append("missing expected output marker: %s" % expected)
+
+    return {
+        "scheduler": name,
+        "command": command,
+        "inputs": sample["inputs"],
+        "returncode": result.returncode,
+        "duration_seconds": round(time.time() - started, 3),
+        "artifacts": {
+            "raw_stdout": str(raw_path.relative_to(repo_root)),
+            "stderr": str(err_path.relative_to(repo_root)),
+            "normalized_stdout": str(normalized_path.relative_to(repo_root)),
+        },
+        "failures": failures,
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Validate qtop scheduler samples.")
+    parser.add_argument("--repo-root", default=".", help="Repository root. Defaults to the current directory.")
+    parser.add_argument("--artifact-dir", default="sample-artifacts", help="Directory for raw output, stderr, and summary files.")
+    parser.add_argument("--max-failures", default=0, type=int, help="Allowed failures before the gate exits non-zero.")
+    parser.add_argument("--scheduler", action="append", choices=sorted(SAMPLES), help="Run only the named scheduler. May be passed more than once.")
+    parser.add_argument("--python", default=sys.executable, help="Python executable used to invoke qtop.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    artifact_dir = (repo_root / args.artifact_dir).resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    selected = args.scheduler or sorted(SAMPLES)
+    results = [run_sample(name, SAMPLES[name], repo_root, artifact_dir, args.python) for name in selected]
+    failure_count = sum(1 for result in results if result["failures"])
+
+    summary = {
+        "failure_count": failure_count,
+        "max_failures": args.max_failures,
+        "note": "qtop has checked-in samples for PBS, OAR, and SGE; no SLURM plugin or fixture exists in this repository yet.",
+        "results": results,
+    }
+    summary_path = artifact_dir / "summary.json"
+    write_text(summary_path, json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    for result in results:
+        status = "PASS" if not result["failures"] else "FAIL"
+        print("%s %s (%ss)" % (status, result["scheduler"], result["duration_seconds"]))
+        for failure in result["failures"]:
+            print("  - %s" % failure)
+    print("summary: %s" % summary_path.relative_to(repo_root))
+
+    return 1 if failure_count > args.max_failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -38,3 +38,9 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+def test_int_or_zero_accepts_pbs_text_values():
+    assert pbs.int_or_zero("0") == 0
+    assert pbs.int_or_zero("2") == 2
+    assert pbs.int_or_zero(None) == 0

--- a/tests/test_safe_config.py
+++ b/tests/test_safe_config.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from qtop_py.qtop import Cluster, extract_detail_from_field, parse_config_literal, update_config_with_cmdline_vars
+from qtop_py.yaml_parser import read_yaml_config_block, get_line
+
+
+def test_parse_config_literal_does_not_execute_code():
+    value = "__import__('os').system('echo unsafe')"
+    assert parse_config_literal(value) == value
+
+
+def test_cmdline_override_parses_literals_without_eval():
+    args = SimpleNamespace(OPTION=["enabled=True", "name=plain-text"], TRANSPOSE=False, REM_EMPTY_CORELINES=0)
+    config = {"rem_empty_corelines": "0"}
+    assert update_config_with_cmdline_vars(args, config) == {
+        "enabled": True,
+        "name": "plain-text",
+        "rem_empty_corelines": 0,
+    }
+
+
+def test_legacy_gecos_regex_is_handled_without_eval():
+    regex = "re.search('(?<=<)[^<>]+(?=>)', field).group(0)"
+    assert extract_detail_from_field("ignored:<CN=Queue User>:ignored", regex) == "CN=Queue User"
+
+
+def test_yaml_parser_keeps_non_literal_list_values_as_text():
+    fin = ["testkey: [__import__('os').system('echo unsafe')]"]
+    get_lines = get_line(fin)
+    block, _ = read_yaml_config_block(next(get_lines), fin, get_lines)
+    assert block == {"testkey": ["__import__('os').system('echo unsafe')"]}
+
+
+def test_cluster_sort_uses_named_rules_without_eval(monkeypatch):
+    import qtop_py.qtop as qtop_module
+
+    monkeypatch.setattr(qtop_module, "dynamic_config", {}, raising=False)
+    cluster = Cluster.__new__(Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by nodename-notnum", "sort by all numbers"], "reverse": False}}
+    cluster.worker_nodes = [
+        {"domainname": "node10", "state": "R", "np": "8", "core_job_map": {"0": "job"}},
+        {"domainname": "node2", "state": "R", "np": "8", "core_job_map": {}},
+    ]
+
+    sorted_nodes = cluster._sort_worker_nodes()
+    assert [node["domainname"] for node in sorted_nodes] == ["node2", "node10"]


### PR DESCRIPTION
Fixes #433.

## Summary

- add a shared Makefile entry point for GitHub Actions and GitLab CI
- add a scheduler sample gate that runs the checked-in PBS, OAR, and SGE fixtures, writes raw/normalized output artifacts, and fails with `MAX_FAILURES=0`
- replace unsafe `eval()` usage in config parsing, YAML literal handling, GECOS extraction, sorting, PBS/SGE counters, and remapping handling
- fix the PBS sample crash caused by string GPU counts
- document sample sources, artifact policy, failure policy, and the current absence of a SLURM plugin/fixture

## Notes

qtop currently has PBS, OAR, SGE, and demo scheduler implementations. I wired the gate for the checked-in PBS/OAR/SGE fixtures and left an explicit note in the docs/summary output that SLURM should be enabled once a plugin and fixture exist.

## Verification

- `make ci PYTHON=.venv/bin/python MAX_FAILURES=0`
- `make coverage PYTHON=.venv/bin/python`
- `PYTHON=.venv/bin/python bash qtop_py/contrib/func_tests.sh`
- `make dist PYTHON=.venv/bin/python`
- `.venv/bin/twine check dist/*`
- `docker run --rm -v "$PWD":/repo -w /repo almalinux:8 sh -lc 'dnf install -y make python3 python3-pip >/tmp/dnf.log && python3 -m pip install "pytest<7" >/tmp/pip.log && make test PYTHON=python3 PYTEST="python3 -m pytest" && make sample-validate PYTHON=python3 MAX_FAILURES=0'`
