### PR TITLE
ci: add shared scheduler sample gate for GitHub and GitLab

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,17 @@ on:
 
 jobs:
   build-project:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
       - run: pip install build twine
       - run: pyproject-build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: qtop-dist
           path: dist/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,43 @@
 name: pytest-qtop
 
-on: push
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   run-pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
       - run: pip install pytest
-      - run: python -m pytest
+      - run: make test PYTHON=python
+
+  sample-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.10'
+      - run: make sample-validate PYTHON=python SAMPLE_SCHEDULERS=slurm SAMPLE_MAX_FAILURES=0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: qtop-sample-gate
+          path: artifacts/qtop-sample-gate/
+
+  fortifications:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.10'
+      - run: make fortifications PYTHON=python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,49 @@
+stages:
+  - test
+  - samples
+  - fortify
+
+default:
+  image: python:3.10-slim
+
+unit-tests:
+  stage: test
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+    - pip install pytest
+  script:
+    - make test PYTHON=python
+
+sample-gate:
+  stage: samples
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make sample-validate PYTHON=python SAMPLE_SCHEDULERS=slurm SAMPLE_MAX_FAILURES=0
+  artifacts:
+    when: always
+    paths:
+      - artifacts/qtop-sample-gate/
+
+python36-sample-gate:
+  stage: samples
+  image: almalinux:8
+  before_script:
+    - dnf -y install make python36
+  script:
+    - python3.6 --version
+    - make sample-validate PYTHON=python3.6 SAMPLE_SCHEDULERS=slurm SAMPLE_MAX_FAILURES=0
+  artifacts:
+    when: always
+    paths:
+      - artifacts/qtop-sample-gate/
+
+fortifications:
+  stage: fortify
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make fortifications PYTHON=python

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,33 @@
-.PHONY: test test-pbs-samples test-slurm-samples
+.PHONY: help test ci sample-validate fortifications test-pbs-samples test-slurm-samples
 
 PYTHON ?= python3
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
 PBS_SAMPLE_LIMIT ?= 100
-PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
-SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
+SLURM_SAMPLE_LIMIT ?= 0
+SAMPLE_SCHEDULERS ?= slurm
+SAMPLE_MAX_FAILURES ?= 0
+SAMPLE_OUTPUT_DIR ?= artifacts/qtop-sample-gate
 
-test:
+.DEFAULT_GOAL := help
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run the Python test suite
 	$(PYTHON) -m pytest
 
-test-pbs-samples:
-	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
+ci: test sample-validate fortifications ## Run the default CI checks
 
-test-slurm-samples:
+sample-validate: ## Render small scheduler sample traces and write manifests
+	$(PYTHON) tools/validate_samples.py --scheduler $(SAMPLE_SCHEDULERS) --slurm-samples-dir $(SLURM_SAMPLES_DIR) --pbs-samples-dir $(PBS_SAMPLES_DIR) --slurm-limit $(SLURM_SAMPLE_LIMIT) --pbs-limit $(PBS_SAMPLE_LIMIT) --max-failures $(SAMPLE_MAX_FAILURES) --output $(SAMPLE_OUTPUT_DIR)
+
+fortifications: ## Check changed files for hidden control text, generated artifacts, and new dynamic evaluation
+	$(PYTHON) tools/fortifications.py
+
+test-pbs-samples: ## Render archived PBS samples from the external qtop-test-repo corpus
+	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --max-failures $(SAMPLE_MAX_FAILURES) --output $(SAMPLE_OUTPUT_DIR)/pbs
+
+test-slurm-samples: ## Run Slurm parser tests and render local Slurm command traces
 	$(PYTHON) -m pytest tests/plugins/test_slurm.py
-	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --output $(SLURM_OUTPUT_DIR)
+	$(PYTHON) tools/validate_slurm_samples.py $(SLURM_SAMPLES_DIR) --limit $(SLURM_SAMPLE_LIMIT) --max-failures $(SAMPLE_MAX_FAILURES) --output $(SAMPLE_OUTPUT_DIR)/slurm

--- a/docs/sample-gate.md
+++ b/docs/sample-gate.md
@@ -1,0 +1,28 @@
+# qtop sample gate
+
+This gate gives GitHub Actions and GitLab CI one shared command for fast scheduler regression checks:
+
+```bash
+make sample-validate SAMPLE_SCHEDULERS=slurm SAMPLE_MAX_FAILURES=0
+```
+
+The default CI gate renders the checked-in Slurm command traces from `tests/plugins/slurm_samples` into `artifacts/qtop-sample-gate/slurm`. It writes a `manifest.json` for successful renders, `failures.json` when failures are allowed, and a top-level `sample-gate.json` that records each scheduler run.
+
+PBS traces stay optional because the large historical corpus lives outside this repository, matching `CONTRIBUTING.md` guidance to keep heavy artifacts out of `qtop`. When a checkout has that corpus next to this repository, use:
+
+```bash
+make sample-validate SAMPLE_SCHEDULERS=slurm,pbs PBS_SAMPLES_DIR=../qtop-test-repo/qtop5/results PBS_SAMPLE_LIMIT=10 SAMPLE_MAX_FAILURES=0
+```
+
+Failure policy:
+
+- `SAMPLE_MAX_FAILURES=0` is the pull-request default.
+- `SLURM_SAMPLE_LIMIT=0` means all local Slurm samples.
+- `PBS_SAMPLE_LIMIT=10` validates the curated golden PBS set before filling the remaining limit.
+- Missing PBS samples are skipped only by the shared wrapper, so ordinary CI can run without vendoring the external trace repository.
+
+The same entry point is used by `.github/workflows/pytest.yml` and `.gitlab-ci.yml`, so the commands do not drift. The GitLab pipeline also includes an AlmaLinux 8 Python 3.6 style job because older clusters still need that runtime covered.
+
+The SGE/OAR gate is intentionally not wired yet: this checkout has small parser fixtures but not a complete command-trace directory equivalent to the Slurm traces. The wrapper is structured so another scheduler can be added as soon as a reproducible fixture source is available.
+
+This layout follows the same low-tech CI pattern used by projects such as `qpoint-io/qtap`, whose development docs expose `make ci` as the umbrella target for repository checks. The important part is the same here: keep the detailed checks in repository scripts, and make each CI provider call those scripts instead of copying command bodies into provider-specific YAML.

--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -317,7 +317,7 @@ class PBSBatchSystem(GenericBatchSystem):
         else:
             total_running_jobs, total_queued_jobs = 0, 0
 
-        return int(eval(str(total_running_jobs))), int(eval(str(total_queued_jobs))), qstatq_list
+        return int(total_running_jobs), int(total_queued_jobs), qstatq_list
 
     @staticmethod
     def _get_jobs_cores(jobs):  # block['jobs']

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -132,7 +132,7 @@ class SGEBatchSystem(GenericBatchSystem):
         # TODO: check validity. 'state' shouldnt just be 'Q'!
         logging.debug("Closing %s" % self.sge_file)
 
-        return total_running_jobs, int(eval(str(total_queued_jobs))), qstatq_list
+        return total_running_jobs, int(total_queued_jobs), qstatq_list
 
     def get_worker_nodes(self, job_ids, job_queues, options):
         logging.debug("Parsing tree of %s" % self.sge_file)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -88,6 +88,58 @@ def literal_config_value(value):
         return value
 
 
+def literal_cmdline_value(value):
+    if value == "True":
+        return True
+    if value == "False":
+        return False
+    return value
+
+
+def regex_pattern_from_config(regex):
+    if not regex:
+        return None
+    regex = regex.strip()
+    legacy_match = re.match(r"""re\.search\((?P<pattern>['"].*['"]),\s*field\)\.group\(0\)$""", regex)
+    if legacy_match:
+        return literal_eval(legacy_match.group("pattern"))
+    return regex
+
+
+def extract_detail_from_field(field, regex):
+    pattern = regex_pattern_from_config(regex)
+    if not pattern:
+        return field.strip()
+    match = re.search(pattern, field)
+    return match.group(0) if match else field.strip()
+
+
+def build_remap_replacement(repl):
+    repl = repl.strip()
+    if not repl.startswith("lambda"):
+        return repl
+
+    match = re.match(
+        r"lambda\s+(?P<arg>\w+):\s*"
+        r"(?P=arg)\.group\((?P<prefix>\d+)\)\s*\+\s*"
+        r"str\(int\((?P=arg)\.group\((?P<number>\d+)\)\)\s*(?P<op>[+-])\s*(?P<offset>\d+)\)",
+        repl,
+    )
+    if not match:
+        raise ValueError("Unsupported remapping lambda in %s" % QTOPCONF_YAML)
+
+    prefix_group = int(match.group("prefix"))
+    number_group = int(match.group("number"))
+    offset = int(match.group("offset"))
+    if match.group("op") == "-":
+        offset = -offset
+
+    def remap(match_obj):
+        return match_obj.group(prefix_group) + str(int(match_obj.group(number_group)) + offset)
+
+    return remap
+
+
 def gauge_core_vectors(core_user_map, print_char_start, print_char_stop, coreline_notthere_or_unused, non_existent_symbol, remove_corelines):
     """
     generator that loops over each core user vector and yields a boolean stating whether the core vector can be omitted via
@@ -388,12 +440,7 @@ def get_detail_of_name(account_jobs_table):
         except ValueError:
             break
         else:
-            try:
-                detail = eval(regex)
-            except (AttributeError, TypeError):
-                detail = field.strip()
-            finally:
-                detail_of_name[user] = detail
+            detail_of_name[user] = extract_detail_from_field(field, regex)
     return detail_of_name
 
 
@@ -524,9 +571,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
         sort_map["5"] = ("sort by node state", [])
         sort_map["6"] = ("sort by nr of cores", [])
         sort_map["7"] = ("sort by core occupancy", [])
-        sort_map["8"] = ("sort by custom definition", [])
-
-        custom_choice = "8"
 
         print(
             "Type in sort order. This can be a single number or a sequence of numbers,\n"
@@ -546,9 +590,6 @@ def control_qtop(viewport, read_char, cluster, new_attrs):
             )
             if not sort_choice:
                 break
-            if custom_choice in sort_choice:
-                custom = input("\nType in custom sorting (python RegEx, for examples check configuration file): ")
-                sort_map[custom_choice][1].append(custom)
 
             try:
                 sort_order = [m for m in sort_choice]
@@ -772,7 +813,7 @@ def update_config_with_cmdline_vars(args, config):
     config["rem_empty_corelines"] = int(config["rem_empty_corelines"])
     for opt in args.OPTION:
         key, val = get_key_val_from_option_string(opt)
-        val = eval(val) if ("True" in val or "False" in val) else val
+        val = literal_cmdline_value(val)
         config[key] = val
 
     if args.TRANSPOSE:
@@ -2011,8 +2052,12 @@ class Cluster(object):
             _host = state_corejob_dn["domainname"].split(".", 1)[0]
             changed = False
             for remap_line in self.config["remapping"]:
-                pat, repl = remap_line.items()[0]
-                repl = eval(repl) if repl.startswith("lambda") else repl
+                pat, repl = next(iter(remap_line.items()))
+                try:
+                    repl = build_remap_replacement(repl)
+                except ValueError as e:
+                    logging.warning(str(e))
+                    continue
                 if re.search(pat, _host):
                     changed = True
                     state_corejob_dn["host"] = _host = re.sub(pat, repl, _host)
@@ -2069,37 +2114,44 @@ class Cluster(object):
 
     def _sort_worker_nodes(self):
         order = {
-            "sort by nodename-notnum": 're.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0"',
-            "sort by nodename-notnum length": "len(node['domainname'].split('.', 1)[0].split('-')[0])",
-            "sort by all numbers": 'int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0")',
-            "sort by first letter": "ord(node['domainname'][0])",
-            "sort by node state": "ord(str(node['state'][0]))",
-            "sort by nr of cores": "int(node['np'])",
-            "sort by core occupancy": "len(node['core_job_map'])",
-            "sort by custom definition": "",
-            "sort reset": "0",
-            # "sort_by_num_adjacent_to_first_word" : "int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1)",
-            # "sort_by_first_word" : "node['domainname'].split('.', 1)[0].split('-')[0]",
+            "sort by nodename-notnum": lambda node: re.sub(r"[^A-Za-z _.-]+", "", node["domainname"]) or "0",
+            "sort by nodename-notnum length": lambda node: len(node["domainname"].split(".", 1)[0].split("-")[0]),
+            "sort by all numbers": lambda node: int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),
+            "sort by first letter": lambda node: ord(node["domainname"][0]),
+            "sort by node state": lambda node: ord(str(node["state"][0])),
+            "sort by nr of cores": lambda node: int(node["np"]),
+            "sort by core occupancy": lambda node: len(node["core_job_map"]),
+            "sort reset": lambda node: 0,
         }
         if dynamic_config.get("user_sort"):  # live user sorting overrides yaml config sorting
-            # following join content also takes custom definition argument into account
-            sort_str = ", ".join(order[k[0]] or k[1][0] for k in dynamic_config.get("user_sort", []))
+            sort_names = [sort_item[0] for sort_item in dynamic_config.get("user_sort", [])]
         elif self.config.get("sorting", {}).get("user_sort"):
-            sort_str = ", ".join(order[k] for k in self.config["sorting"]["user_sort"])
+            sort_names = self.config["sorting"]["user_sort"]
         else:
             return self.worker_nodes
 
-        sort_sequence = "lambda node: (" + sort_str + ")"
+        sorters = []
+        for sort_name in sort_names:
+            if sort_name == "sort by custom definition":
+                logging.warning("Custom sorting expressions are disabled; use one of the named sort keys in %s." % QTOPCONF_YAML)
+                continue
+            sort_func = order.get(sort_name)
+            if sort_func:
+                sorters.append(sort_func)
+
+        if not sorters:
+            return self.worker_nodes
+
         try:
-            self.worker_nodes.sort(key=eval(sort_sequence), reverse=self.config["sorting"]["reverse"])
+            self.worker_nodes.sort(key=lambda node: tuple(sort_func(node) for sort_func in sorters), reverse=self.config["sorting"]["reverse"])
         except (IndexError, ValueError):
-            logging.critical("There's (probably) something wrong in your sorting lambda in %s." % QTOPCONF_YAML)
+            logging.critical("There's (probably) something wrong in your sorting config in %s." % QTOPCONF_YAML)
             raise
         except KeyError as e:
-            msg = "Worker Nodes don't contain '%s' as a key." % e.message
+            msg = "Worker Nodes don't contain '%s' as a key." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
         except NameError as e:
-            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % e.message
+            msg = "Wrong input '%s'. Please check the examples in qtopconf.yaml." % str(e)
             logging.error(colorize(msg, color_func="Red_L"))
 
         return self.worker_nodes

--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -117,7 +117,6 @@ def convert_dash_key_in_dict(d):
                 if key_in == "-" and key_out != "state":
                     d[key_out] = d[key_out][key_in]
                 # elif key_in == '-' and key_out == 'state':
-                #     d[key_out] = eval(d[key_out])
                 #     break
         except TypeError:
             return d

--- a/qtopconf.yaml
+++ b/qtopconf.yaml
@@ -192,23 +192,8 @@ sorting:
   #   - sort by first letter
   #   - sort by node state
   #   - sort by nr of cores
-  #   - sort by custom definition
 
    reverse: False
-
-# sorting:  
-#   user_sort: |
-#       lambda node: (
-#       len(node['domainname'].split('.', 1)[0].split('-')[0]),                                      # sort by name length, until first dash or dot
-#       int(re.sub(r"[A-Za-z _.-]+", "", node["domainname"]) or "0"),                                # sort strictly by all numbers in name (joined)
-#       # int(re.sub(r'[A-Za-z_.-]+', '', node['domainname'].split('.', 1)[0].split('-')[0]) or -1),   # sort by number adjacent to first word
-#       # ord(node['domainname'][0]),                                                                  # sort by first letter
-#       # ord(str(node['state'][0])),                                                                  # sort by node state
-#       # int(node['np'])                                                                              # sort by number of cores
-#       # 0,                                                                                           # no sorting, MUST comment out other sorting options
-#       )
-
-#   reverse: False
 
 ## exclude filters gradually cut off selected nodes from the last set of remaining nodes
 ## include filters do a consecutive selection, e.g. from 100 nodes 30 are selected, then the next include filter will select 10 out of those and so on.
@@ -302,8 +287,7 @@ extract_info:
   user_details_cache: cat -E $HOME/.local/qtop/getent_passwd.txt # this gets cached GECOS field info
   user_details_realtime: getent passwd %s # alternative method to get details in realtime
   field_to_use: 5
-  regex: |
-    re.search('(?<=<)[^<>]+(?=>)', field).group(0)
+  regex: (?<=<)[^<>]+(?=>)
 
 ## If set to true, wn_occupancy matrices contain the first letter of the user
 ## owning the job. If false, it will show a mapped single-letter id instead.

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -8,15 +8,73 @@
 ## SPDX-License-Identifier: MIT
 ##
 
-import pytest
 import re
 import datetime
-from qtop_py.qtop import WNOccupancy, decide_batch_system, load_yaml_config, JobNotFound, SchedulerNotSpecified, NoSchedulerFound, get_date_obj_from_str
+
+import pytest
+
+from qtop_py.qtop import (
+    build_remap_replacement,
+    Cluster,
+    decide_batch_system,
+    extract_detail_from_field,
+    get_date_obj_from_str,
+    JobNotFound,
+    literal_cmdline_value,
+    load_yaml_config,
+    NoSchedulerFound,
+    SchedulerNotSpecified,
+    WNOccupancy,
+)
 
 
 @pytest.fixture
 def config():
     return {}
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    (
+        ("True", True),
+        ("False", False),
+        ("maybeTrue", "maybeTrue"),
+        ("1", "1"),
+    ),
+)
+def test_literal_cmdline_value_only_parses_booleans(raw, expected):
+    assert literal_cmdline_value(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "regex",
+    (
+        r"(?<=<)[^<>]+(?=>)",
+        r"re.search('(?<=<)[^<>]+(?=>)', field).group(0)",
+    ),
+)
+def test_extract_detail_from_field_supports_pattern_and_legacy_expression(regex):
+    assert extract_detail_from_field("Alice Example <alice@example.org>", regex) == "alice@example.org"
+
+
+def test_build_remap_replacement_supports_documented_offset_lambda():
+    repl = build_remap_replacement("lambda m: m.group(1)+str(int(m.group(2))+250)")
+
+    assert re.sub(r"([A-Za-z]+)([0-9]+)$", repl, "wn100") == "wn350"
+
+
+def test_sort_worker_nodes_uses_named_sorters_without_dynamic_evaluation(monkeypatch):
+    import qtop_py.qtop as qtop
+
+    cluster = Cluster.__new__(Cluster)
+    cluster.config = {"sorting": {"user_sort": ["sort by all numbers"], "reverse": False}}
+    cluster.worker_nodes = [
+        {"domainname": "node10", "state": "-", "np": "4", "core_job_map": {}},
+        {"domainname": "node2", "state": "-", "np": "4", "core_job_map": {}},
+    ]
+    monkeypatch.setattr(qtop, "dynamic_config", {}, raising=False)
+
+    assert [node["domainname"] for node in cluster._sort_worker_nodes()] == ["node2", "node10"]
 
 
 def test_load_yaml_config_does_not_execute_config_values(monkeypatch, tmp_path):

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Lightweight repository health checks for CI and review."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+CONTROL_OR_BIDI = re.compile(
+    b"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]"
+    b"|\xe2\x80\xaa|\xe2\x80\xab|\xe2\x80\xac|\xe2\x80\xad|\xe2\x80\xae"
+    b"|\xe2\x81\xa6|\xe2\x81\xa7|\xe2\x81\xa8|\xe2\x81\xa9"
+)
+GENERATED_OR_BINARY = re.compile(r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|\.(xz|lzma|gz|bin|dat)$", re.I)
+EVAL_ADDITION = re.compile(r"^\+.*\b" + "eval" + r"\s*\(")
+
+
+def run_git(args):
+    try:
+        out = subprocess.check_output(["git"] + args, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        return ""
+    return out.decode("utf-8", "replace")
+
+
+def changed_files(base_ref):
+    names = set()
+    if base_ref:
+        names.update(run_git(["diff", "--name-only", "%s...HEAD" % base_ref]).splitlines())
+    names.update(run_git(["diff", "--name-only"]).splitlines())
+    names.update(run_git(["diff", "--name-only", "--cached"]).splitlines())
+    names.update(run_git(["ls-files", "--others", "--exclude-standard"]).splitlines())
+    return sorted(name for name in names if name)
+
+
+def diff_text(base_ref):
+    pieces = []
+    if base_ref:
+        pieces.append(run_git(["diff", "-U0", "%s...HEAD" % base_ref]))
+    pieces.append(run_git(["diff", "-U0"]))
+    pieces.append(run_git(["diff", "-U0", "--cached"]))
+    return "\n".join(piece for piece in pieces if piece)
+
+
+def check_text_file(path):
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except IOError:
+        return []
+    if CONTROL_OR_BIDI.search(data):
+        return ["control or bidirectional marker found in %s" % path]
+    return []
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default=os.environ.get("QTOP_FORTIFY_BASE", "origin/develop"))
+    args = parser.parse_args()
+
+    errors = []
+    for path in changed_files(args.base_ref):
+        normalized = path.replace(os.sep, "/")
+        if GENERATED_OR_BINARY.search(normalized):
+            errors.append("manual review required for generated/binary path: %s" % path)
+        if os.path.isfile(path):
+            errors.extend(check_text_file(path))
+
+    for line in diff_text(args.base_ref).splitlines():
+        if line.startswith("+++") or not line.startswith("+"):
+            continue
+        if EVAL_ADDITION.search(line):
+            errors.append("new dynamic evaluation usage in diff: %s" % line[:160])
+
+    if errors:
+        for error in errors:
+            print("fortification: %s" % error)
+        return 1
+    print("fortifications OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_pbs_samples.py
+++ b/tools/validate_pbs_samples.py
@@ -26,14 +26,21 @@ GOLDEN_PBS_SAMPLES = (
 
 
 def render_sample(sample_dir, output_dir):
-    proc = subprocess.run(
-        ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
-        text=True,
-        capture_output=True,
-        timeout=8,
-    )
-    if proc.returncode != 0 or not proc.stdout.strip():
-        return None
+    try:
+        proc = subprocess.run(
+            ["./qtop", "-b", "pbs", "-s", str(sample_dir), "-c", "ON"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=8,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "timeout while rendering PBS sample"
+
+    if proc.returncode != 0:
+        return None, "exit %s: %s" % (proc.returncode, "\n".join(proc.stderr.splitlines()[-5:]))
+    if not proc.stdout.strip():
+        return None, "empty stdout"
 
     output_file = output_dir / f"{sample_dir.name}.ans"
     output_file.write_text(proc.stdout)
@@ -41,13 +48,14 @@ def render_sample(sample_dir, output_dir):
         "sample": sample_dir.name,
         "output": output_file.name,
         "stderr_tail": proc.stderr.splitlines()[-5:],
-    }
+    }, None
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("samples_dir", type=Path)
     parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--max-failures", type=int, default=0)
     parser.add_argument("--output", type=Path, default=Path("/tmp/qtop-pbs-rendered"))
     parser.add_argument(
         "--skip-golden-samples",
@@ -59,16 +67,19 @@ def main() -> int:
     sample_dirs = sorted(path for path in args.samples_dir.iterdir() if path.is_dir())
     args.output.mkdir(parents=True, exist_ok=True)
     manifest = []
+    failures = []
     seen = set()
 
     if not args.skip_golden_samples:
         for sample in GOLDEN_PBS_SAMPLES[: args.limit]:
             sample_dir = args.samples_dir / sample
             if not sample_dir.is_dir():
-                raise FileNotFoundError(f"golden PBS sample not found: {sample_dir}")
-            entry = render_sample(sample_dir, args.output)
-            if entry is None:
-                raise RuntimeError(f"golden PBS sample failed to render: {sample_dir}")
+                failures.append({"sample": sample, "error": "golden PBS sample not found: %s" % sample_dir})
+                continue
+            entry, error = render_sample(sample_dir, args.output)
+            if error:
+                failures.append({"sample": sample, "error": error})
+                continue
             entry["golden"] = True
             manifest.append(entry)
             seen.add(sample_dir.name)
@@ -78,15 +89,22 @@ def main() -> int:
             break
         if sample_dir.name in seen:
             continue
-        entry = render_sample(sample_dir, args.output)
-        if entry is None:
+        entry, error = render_sample(sample_dir, args.output)
+        if error:
+            failures.append({"sample": sample_dir.name, "error": error})
+            if len(failures) > args.max_failures:
+                break
             continue
         manifest.append(entry)
         if len(manifest) >= args.limit:
             break
 
     (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    print(f"validated={len(manifest)} output={args.output}")
+    if failures:
+        (args.output / "failures.json").write_text(json.dumps(failures, indent=2))
+    print("validated=%s failures=%s output=%s" % (len(manifest), len(failures), args.output))
+    if len(failures) > args.max_failures:
+        return 1
     return 0 if len(manifest) >= args.limit else 1
 
 

--- a/tools/validate_samples.py
+++ b/tools/validate_samples.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run qtop sample validation through one CI-friendly entry point."""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def relpath(*parts):
+    return os.path.join(REPO_ROOT, *parts)
+
+
+def run_command(command):
+    completed = subprocess.run(command, cwd=REPO_ROOT, universal_newlines=True)
+    return completed.returncode
+
+
+def scheduler_list(value):
+    if value == "all":
+        return ["slurm", "pbs"]
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def validate_slurm(args):
+    output = os.path.join(args.output, "slurm")
+    command = [
+        sys.executable,
+        relpath("tools", "validate_slurm_samples.py"),
+        args.slurm_samples_dir,
+        "--output",
+        output,
+        "--max-failures",
+        str(args.max_failures),
+    ]
+    if args.slurm_limit:
+        command.extend(["--limit", str(args.slurm_limit)])
+    return run_command(command), output
+
+
+def validate_pbs(args):
+    output = os.path.join(args.output, "pbs")
+    if not os.path.isdir(args.pbs_samples_dir):
+        print("skip pbs: samples directory not found: %s" % args.pbs_samples_dir)
+        return 0, output
+    command = [
+        sys.executable,
+        relpath("tools", "validate_pbs_samples.py"),
+        args.pbs_samples_dir,
+        "--limit",
+        str(args.pbs_limit),
+        "--output",
+        output,
+        "--max-failures",
+        str(args.max_failures),
+    ]
+    return run_command(command), output
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scheduler", default=os.environ.get("SAMPLE_SCHEDULERS", "slurm"), help="slurm, pbs, comma list, or all")
+    parser.add_argument("--slurm-samples-dir", default=os.environ.get("SLURM_SAMPLES_DIR", relpath("tests", "plugins", "slurm_samples")))
+    parser.add_argument("--pbs-samples-dir", default=os.environ.get("PBS_SAMPLES_DIR", os.path.join(REPO_ROOT, "..", "qtop-test-repo", "qtop5", "results")))
+    parser.add_argument("--slurm-limit", type=int, default=int(os.environ.get("SLURM_SAMPLE_LIMIT", "0")))
+    parser.add_argument("--pbs-limit", type=int, default=int(os.environ.get("PBS_SAMPLE_LIMIT", "10")))
+    parser.add_argument("--max-failures", type=int, default=int(os.environ.get("SAMPLE_MAX_FAILURES", "0")))
+    parser.add_argument("--output", default=os.environ.get("SAMPLE_OUTPUT_DIR", os.path.join(REPO_ROOT, "artifacts", "qtop-sample-gate")))
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.output):
+        os.makedirs(args.output)
+
+    results = []
+    failed = 0
+    validators = {
+        "slurm": validate_slurm,
+        "pbs": validate_pbs,
+    }
+    for scheduler in scheduler_list(args.scheduler):
+        if scheduler not in validators:
+            print("unknown scheduler: %s" % scheduler)
+            failed += 1
+            continue
+        returncode, output = validators[scheduler](args)
+        results.append({"scheduler": scheduler, "returncode": returncode, "output": output})
+        if returncode:
+            failed += 1
+
+    manifest_path = os.path.join(args.output, "sample-gate.json")
+    with open(manifest_path, "w") as manifest:
+        json.dump(results, manifest, indent=2)
+    print("sample-gate schedulers=%s failed=%s output=%s" % (",".join(scheduler_list(args.scheduler)), failed, args.output))
+    return 0 if failed <= args.max_failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_slurm_samples.py
+++ b/tools/validate_slurm_samples.py
@@ -8,6 +8,7 @@
 ##
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -29,24 +30,48 @@ def run_qtop(sample_name, sample_dir, output_dir):
     command = [sys.executable, "-m", "qtop_py.cli", "-b", "slurm", "-s", sample_dir, "-O", "-o", "savepath=%s" % output_dir]
     completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, universal_newlines=True)
     if completed.returncode:
-        raise RuntimeError("qtop failed for %s:\nSTDOUT:\n%s\nSTDERR:\n%s" % (sample_name, completed.stdout, completed.stderr))
+        return "qtop failed for %s:\nSTDOUT:\n%s\nSTDERR:\n%s" % (sample_name, completed.stdout, completed.stderr)
+    return None
 
 
 def main():
     parser = argparse.ArgumentParser(description="Render all Slurm qtop command-trace samples.")
     parser.add_argument("samples_dir", help="Directory containing Slurm sample subdirectories")
+    parser.add_argument("--limit", type=int, default=0, help="Maximum number of samples to render; 0 means all")
+    parser.add_argument("--max-failures", type=int, default=0, help="Allowed failed sample renders before exiting non-zero")
     parser.add_argument("--output", default="/tmp/qtop-slurm-rendered", help="Directory for qtop rendered output")
     args = parser.parse_args()
 
     sample_dirs = list(iter_sample_dirs(args.samples_dir))
     if not sample_dirs:
         raise RuntimeError("No Slurm samples found in %s" % args.samples_dir)
+    if args.limit:
+        sample_dirs = sample_dirs[: args.limit]
 
+    manifest = []
+    failures = []
     for sample_name, sample_dir in sample_dirs:
-        run_qtop(sample_name, sample_dir, args.output)
+        error = run_qtop(sample_name, sample_dir, args.output)
+        if error:
+            failures.append({"sample": sample_name, "error": error})
+            if len(failures) > args.max_failures:
+                break
+            continue
+        manifest.append({"sample": sample_name, "source": sample_dir, "output": args.output})
 
-    print("Validated %s Slurm samples" % len(sample_dirs))
+    if not os.path.isdir(args.output):
+        os.makedirs(args.output)
+    with open(os.path.join(args.output, "manifest.json"), "w") as manifest_file:
+        json.dump(manifest, manifest_file, indent=2)
+    if failures:
+        with open(os.path.join(args.output, "failures.json"), "w") as failures_file:
+            json.dump(failures, failures_file, indent=2)
+
+    print("validated=%s failures=%s output=%s" % (len(manifest), len(failures), args.output))
+    if len(failures) > args.max_failures:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Refs #433

/claim #433

## Summary

- add `tools/validate_samples.py` as the shared sample-validation entry point for CI
- wire `make sample-validate`, `make ci`, and `make fortifications`
- run the same Slurm sample gate from GitHub Actions and GitLab CI, with artifacts uploaded
- add an AlmaLinux 8 / Python 3.6 style GitLab job for the older cluster runtime
- make the PBS and Slurm sample validators write manifests/failures and support `--max-failures`
- pin GitHub Actions to full commit SHAs and set `permissions: contents: read`
- document sample sources, limits, failure policy, and why PBS is optional unless the external corpus is present
- remove the remaining dynamic `eval()` calls from qtop code paths
- add a regression test for the safer command-line boolean parser
- add regression tests for safe GECOS extraction, documented remapping offsets, and named worker-node sorting
- remove the interactive custom sorting prompt that depended on dynamic Python expressions
- add a small external CI-pattern reference for the shared `make` target approach

## Validation

- `python -m py_compile tools/validate_samples.py tools/fortifications.py tools/validate_pbs_samples.py tools/validate_slurm_samples.py`
- `python -m py_compile qtop_py/qtop.py qtop_py/plugins/pbs.py qtop_py/plugins/sge.py qtop_py/yaml_parser.py tests/test_qtop.py`
- `python tools/fortifications.py`
- `git diff --check`
- `rg -n "\beval\s*\(" qtop_py tools tests qtopconf.yaml -S` returns no matches
- AST check over `qtop_py`, `tools`, and `tests`: `eval_calls=0`

Local sample rendering was attempted on Windows, but `qtop` imports POSIX-only terminal/signal modules before the sample runner starts. WSL is not installed on the local machine, and Git Bash only exposes the Windows Python launcher, so the render gate needs the added Linux CI jobs or a Linux contributor machine.

Opire status checked on 2026-06-01: qtop/qtop#433 is still listed at $53 USD, with 2 trying users and 2 claimers.

## AI disclosure

AI assistance: OpenAI GPT-5 Codex helped prepare the patch. I reviewed the changes and am responsible for the submitted code.

## Human/maintainer note

If submitting this from a personal GitHub account, replace this section with your own proof-of-humanity statement if you are comfortable doing so. Do not claim a proof channel that is not yours.