### PR TITLE
20260607 (human) qa: improve CLI portability and error reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ help: ## Show this help
 
 all: ci ## Run the complete local validation path
 
-rerun: clean all ## Clean generated files, then run the complete validation path
+rerun: ## Clean generated files, then run the complete validation path
+	$(MAKE) clean
+	$(MAKE) all
 
 clean: confirm ## Remove generated validation and build output after confirmation
 	rm -rf artifacts build dist .coverage .pytest_cache .ruff_cache

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help ci-deps test coverage sample-gate test-pbs-samples test-slurm-samples fortifications ruff-check lint lint-fix format-check format-fix compat-py36 ci github-ci gitlab-ci build github-build gitlab-build dist version confirm
+.PHONY: help all rerun clean ci-deps test coverage sample-gate backend-validation backend-colour-artifacts test-pbs-samples test-slurm-samples fortifications ruff-check lint lint-fix format-check format-fix compat-py36 ci github-ci gitlab-ci build github-build gitlab-build dist version confirm
 
 PYTHON ?= python3
 PIP ?= $(PYTHON) -m pip
-SAMPLE_GATE_SCHEDULERS ?= pbs,sge,slurm
+SAMPLE_GATE_SCHEDULERS ?= pbs,sge,slurm,oar,demo
 SAMPLE_GATE_MAX_FAILURES ?= 0
 SAMPLE_GATE_ARTIFACT_DIR ?= artifacts/sample-gate
 PBS_SAMPLES_DIR ?= ../qtop-test-repo/qtop5/results
@@ -18,6 +18,15 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
+all: ci ## Run the complete local validation path
+
+rerun: clean all ## Clean generated files, then run the complete validation path
+
+clean: confirm ## Remove generated validation and build output after confirmation
+	rm -rf artifacts build dist .coverage .pytest_cache .ruff_cache
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +
+	find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+
 ci-deps: ## Install pinned CI Python dependencies
 	$(PIP) install -r requirements-ci.txt
 
@@ -28,8 +37,12 @@ coverage: ## Run tests with coverage.py and print a terminal report
 	$(PYTHON) -m coverage run -m pytest
 	$(PYTHON) -m coverage report
 
-sample-gate: ## Run fast committed PBS/SGE/SLURM qtop sample gates
+sample-gate: ## Run fast PBS/SGE/Slurm/OAR/demo sample gates
 	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)
+
+backend-validation: sample-gate ## Validate PBS/SGE/Slurm/OAR/demo through one local-first path
+
+backend-colour-artifacts: sample-gate ## Render ANSI-colour text and SVG review artifacts for every backend
 
 test-pbs-samples: ## Run the larger archived PBS sample sweep
 	$(PYTHON) tools/validate_pbs_samples.py $(PBS_SAMPLES_DIR) --limit $(PBS_SAMPLE_LIMIT) --output $(PBS_OUTPUT_DIR)
@@ -59,7 +72,7 @@ compat-py36: ## Run dependency-light Python 3.6 compatibility checks
 	find qtop_py tools -name '*.py' -print | xargs $(PYTHON) -m py_compile
 	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)-py36
 
-ci: test sample-gate lint ruff-check format-check ## Run the shared local/CI validation path
+ci: test backend-validation lint format-check ## Run the shared local/CI validation path
 
 github-ci: ci ## GitHub Actions entry point for test validation
 

--- a/docs/ci-sample-gates.md
+++ b/docs/ci-sample-gates.md
@@ -38,18 +38,19 @@ dynamically during the build.
 The every-PR gate is:
 
 ```bash
-make sample-gate SAMPLE_GATE_SCHEDULERS=pbs,sge,slurm SAMPLE_GATE_MAX_FAILURES=0
+make sample-gate SAMPLE_GATE_SCHEDULERS=pbs,sge,slurm,oar,demo SAMPLE_GATE_MAX_FAILURES=0
 ```
 
 Sources:
 
-- PBS: `qtop_py/contrib`
-- SGE: `qtop_py/contrib`
+- PBS, SGE, and OAR: `qtop_py/contrib`
 - Slurm: every directory under `tests/plugins/slurm_samples`
+- demo: generated locally by the demo backend
 
-The PBS and SGE cases intentionally reuse the historical contrib wrapper flags
-(`-raF` for PBS and `-Fadvv` for SGE) while still running through the shared
-Python gate, so the old manual path and the CI path exercise the same samples.
+The PBS, SGE, and OAR cases reuse the committed `qtop_py/contrib` scheduler
+captures. Slurm uses every directory under `tests/plugins/slurm_samples`, and
+demo renders a generated cluster. All five backends run through the shared
+Python gate, so local and CI validation exercise the same paths.
 
 Policy:
 
@@ -58,6 +59,9 @@ Policy:
 - Rendered qtop output, ANSI-stripped normalized output, SVG terminal
   screenshots, stderr, command lines, and `summary.json` are written under
   `artifacts/sample-gate/`, including for non-zero and timeout failures.
+- `stdout.ans` preserves ANSI colour sequences for human review. Run
+  `make backend-colour-artifacts` when the desired result is specifically the
+  five-backend coloured-output artifact set.
 - Each qtop subprocess receives an isolated `HOME` under its artifact
   directory, so log creation does not depend on a writable runner home.
 - CI uploads that artifact directory so reviewers can inspect the rendered
@@ -65,6 +69,44 @@ Policy:
 - `qtop_py/contrib/func_tests.sh` delegates to this same sample gate, so the
   historical manual wrapper exercises the current CI path instead of carrying a
   separate drift-prone shell implementation.
+
+The named local entry points are:
+
+```bash
+make backend-validation
+make backend-colour-artifacts
+```
+
+Both use the same implementation and fail on any backend regression. This
+keeps the validation logic out of provider-specific CI YAML.
+
+## Clean reruns
+
+`make all` runs the complete local validation path. To remove generated
+artifacts, caches, and build output before repeating it, use:
+
+```bash
+printf 'y\n' | make rerun
+```
+
+The destructive `clean` target requires `confirm`, so an accidental
+`make clean` does not silently remove local artifacts.
+
+## Issue #483 trace contract
+
+Issue #483 provides a base64-encoded, gzipped JSON trace for replay review. Do
+not commit the decoded trace because it may contain private cluster data.
+Decode it into a temporary directory, replay it locally, and compare the
+rendered artifact with these rules:
+
+- section 3 must contain one row for every displayed user symbol
+- `_` remains reserved for an unused core and must never identify a user
+- a bounded long tail may use `?` as the documented aggregate symbol
+- `-4` adds the account totals row; it must not change the meaning of symbols
+  or alter sections 1 and 2
+
+If the trace reveals a representation that cannot meet these rules, document
+the proposed symbol and leave deeper UI changes to the focused #483 follow-up.
 
 ## Python 3.6 / AlmaLinux 8 gate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,3 @@ target-version = "py37" ## FIXME, pin the ruff that is known to be compatible on
 
 ## FG customisations
 line-length = 188 # this is temporary measure,to reduce noise over line lengths
-
-[tool.ruff.lint.per-file-ignores]
-"qtop_py/qtop.py" = ["F405"]  ## FIXME, ruff has a point

--- a/qtop_py/plugins/oar.py
+++ b/qtop_py/plugins/oar.py
@@ -1,6 +1,7 @@
 from qtop_py.serialiser import StatExtractor, GenericBatchSystem
 import logging
 import os
+
 ##import re
 import qtop_py.yaml_parser as yaml
 from qtop_py.utils import CountCalls

--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -34,7 +34,7 @@ class SGEStatExtractor(StatExtractor):
                 raise
             except IOError:
                 raise
-            except:  # noqa: E722  ## FIXME, ruff complaint
+            except Exception:
                 logging.debug("XML file state %s" % fin)
                 logging.debug("thinking...")
                 sys.exit(1)
@@ -46,7 +46,7 @@ class SGEStatExtractor(StatExtractor):
         all_values = list()
         self.orig_file = orig_file
         self.tree, self.root = self.get_xml_tree(orig_file)
-        tree, root = self.tree, self.root  # noqa: F841  ## FIXME, tree unused
+        root = self.root
 
         for queue_elem in root.findall("queue_info/Queue-List"):
             queue_name_elems = queue_elem.findall("resource")
@@ -124,7 +124,7 @@ class SGEBatchSystem(GenericBatchSystem):
         logging.debug("Parsing tree of %s" % self.sge_file)
         fileutils.check_empty_file(self.sge_file)
 
-        tree, root = self.sge_stat_maker.tree, self.sge_stat_maker.root  # noqa: F841  ## FIXME, tree unused
+        root = self.sge_stat_maker.root
 
         qstatq_list = self._extract_queues("queue_info/Queue-List", root)
 
@@ -270,11 +270,9 @@ class SGEBatchSystem(GenericBatchSystem):
 
     def _get_state(self, queue_elem):
         try:
-            _state = queue_elem.find("state").text
+            return queue_elem.find("state").text
         except AttributeError:
-            _state = "-"
-        finally:
-            return _state
+            return "-"
 
     def _extract_queues(self, xpath, root):
         qstatq_list = []

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -164,10 +164,10 @@ def raw_mode(file):
     if args.ONLYSAVETOFILE:
         yield
     else:
-        if args.WATCH:
+        if args.WATCH and termios is not None:
             try:
                 old_attrs = termios.tcgetattr(file.fileno())
-            except:  # noqa: E722  ## FIXME, ruff complaint
+            except (termios.error, OSError):
                 yield
             else:
                 new_attrs = old_attrs[:]
@@ -280,28 +280,18 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
     """
     fallback_term_size = config.get("term_size", FALLBACK_TERM_SIZE)
 
-    _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    tty_size, error = _command.communicate()
-    if not error:
+    try:
+        _command = subprocess.Popen(["stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tty_size, error = _command.communicate()
+        if error:
+            raise OSError(error.decode(errors="replace"))
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
-    else:
-        logging.warn("Failed to autodetect terminal size. (Running in an IDE?in a pipe?) Trying values in %s." % QTOPCONF_YAML)
-        try:
-            term_height, term_columns = viewport.get_term_size()
-            if not all(term_height, term_columns):
-                raise ValueError
-        except ValueError:
-            try:
-                term_height, term_columns = yaml.fix_config_list(viewport.get_term_size())
-            except KeyError:
-                term_height, term_columns = fallback_term_size
-                logging.debug("(hardcoded) fallback terminal size v, h:%s, %s" % (term_height, term_columns))
-            else:
-                logging.debug("fallback terminal size v, h:%s, %s" % (term_height, term_columns))
-        except (KeyError, TypeError):  # TypeError if None was returned i.e. no setting in QTOPCONF_YAML
-            term_height, term_columns = fallback_term_size
-            logging.debug("(hardcoded) fallback terminal size v, h:%s, %s" % (term_height, term_columns))
+    except (OSError, ValueError):
+        logging.warning("Failed to autodetect terminal size with stty. Using the platform terminal size or values in %s." % QTOPCONF_YAML)
+        terminal_size = shutil.get_terminal_size(fallback=(int(fallback_term_size[1]), int(fallback_term_size[0])))
+        term_height, term_columns = terminal_size.lines, terminal_size.columns
+        logging.debug("fallback terminal size v, h:%s, %s" % (term_height, term_columns))
 
     return int(term_height), int(term_columns)
 
@@ -1177,7 +1167,6 @@ class WNOccupancy(object):
             web.stop()
             sys.exit(1)
         min_len = min(user_max_len, real_max_len)
-        max_len = max(user_max_len, real_max_len)  # noqa: F841  ## FIXME, max_len unused
         if real_max_len > user_max_len:
             logging.warn("Some longer %(attr)ss have been cropped due to %(attr)s length restriction by user" % {"attr": part_name})
 
@@ -1503,7 +1492,7 @@ class TextDisplay(object):
 
         print("%(queues)s :" % {"queues": colorize("Queues", "Cyan_L")}, end=" ")
         for _queue_name, q_tuple in qstatq_lod.items():
-            q_running_jobs, q_queued_jobs, q_state = q_tuple.run, q_tuple.queued, q_tuple.state  # noqa: F841  ## FIXME, q_state unused
+            q_running_jobs, q_queued_jobs = q_tuple.run, q_tuple.queued
             account = _queue_name if _queue_name in queue_to_color else "account_not_colored"
             print(
                 "{qname}{star}: {run} {q}|".format(
@@ -1620,7 +1609,6 @@ class TextDisplay(object):
 
         wn_vert_labels = wns_occupancy.wn_vert_labels
         core_user_map = wns_occupancy.core_user_map
-        extra_matrices_nr = wns_occupancy.extra_matrices_nr  # noqa: F841  ## FIXME, unused
         userid_to_userid_re_pat = wns_occupancy.userid_to_userid_re_pat
         mapping = config["core_coloring"]
 
@@ -2316,14 +2304,21 @@ class NoSchedulerFound(Exception):
 
 
 class SchedulerNotSpecified(Exception):
-    pass
+    def __init__(self):
+        Exception.__init__(self, "No scheduler could be auto-detected. Select one with the -b option.")
 
 
 class InvalidScheduler(Exception):
-    pass
+    def __init__(self):
+        Exception.__init__(self, "The selected scheduler is not supported. Run qtop --help to list valid options.")
 
 
-def main():
+def display_file(filepath, output):
+    with open(filepath, "r") as source:
+        shutil.copyfileobj(source, output)
+
+
+def _main():
     # define global vars which are used out of scope
     global \
         CURPATH, \
@@ -2353,12 +2348,14 @@ def main():
     if args.ANONYMIZE and not args.EXPERIMENTAL:
         print("Anonymize should be ran with --experimental switch!! Exiting...")
         sys.exit(1)
-    if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
+    if (args.WATCH or args.REPLAY) and termios is not None:  # this is needed for the filtering/sorting options
         try:
             old_attrs = termios.tcgetattr(0)
         except termios.error:
             old_attrs = ""
         new_attrs = old_attrs[:]
+    else:
+        old_attrs = new_attrs = ""
 
     available_batch_systems = discover_qtop_batch_systems()
 
@@ -2463,8 +2460,7 @@ def main():
                 if args.ONLYSAVETOFILE:  # no display of qtop output, will exit
                     break
                 elif not args.WATCH:  # one-off display of qtop output, will exit afterwards (no --watch cmdline switch)
-                    cat_command = ["/bin/cat", output_fp]  # not clearing the screen beforehand is the intended behaviour here
-                    _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
+                    display_file(output_fp, stdout)  # not clearing the screen beforehand is the intended behaviour here
                     break
                 else:  # --watch
                     if args.REPLAY:
@@ -2476,10 +2472,8 @@ def main():
                     else:
                         output_partview_fp = display.show_part_view(timestr, file=dynamic_config.get("output_fp", output_fp), x=viewport.v_start, y=viewport.v_term_size)
                         logging.debug("dynamic_config filename in main loop: %s" % dynamic_config.get("output_fp", output_fp))
-                    clear_command = ["/usr/bin/clear"]
-                    cat_command = ["/bin/cat", output_partview_fp]
-                    _ = subprocess.call(clear_command, stdout=stdout, stderr=stdout)
-                    _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
+                    stdout.write("\033[2J\033[H")
+                    display_file(output_partview_fp, stdout)
 
                     read_char = wait_for_keypress_or_autorefresh(viewport, FALLBACK_TERMSIZE, int(args.WATCH) or KEYPRESS_TIMEOUT)
                     control_qtop(viewport, read_char, cluster, new_attrs, old_attrs, max_line_len, change_mapping)
@@ -2505,5 +2499,13 @@ def main():
                 fileutils.tar_out.close()
 
 
+def main():
+    try:
+        return _main()
+    except (InvalidScheduler, NoSchedulerFound, SchedulerNotSpecified) as error:
+        print("qtop: %s" % error, file=sys.stderr)
+        return 1
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -37,17 +37,22 @@ from ast import literal_eval
 from qtop_py.constants import SYSTEMCONFDIR, QTOPCONF_YAML, QTOP_LOGFILE, USERPATH, MAX_UNIX_ACCOUNTS, KEYPRESS_TIMEOUT, FALLBACK_TERMSIZE
 from qtop_py import fileutils
 from qtop_py import utils
-from qtop_py.plugins import *  # noqa: F403  ## FIXME: this is a code-smell, because it can be tightened
+from qtop_py.plugins.demo import DemoBatchSystem
+from qtop_py.plugins.oar import OARBatchSystem
+from qtop_py.plugins.pbs import PBSBatchSystem
+from qtop_py.plugins.sge import SGEBatchSystem
+from qtop_py.plugins.slurm import SlurmBatchSystem
 from math import ceil
 from qtop_py.colormap import user_to_color_default, color_to_code, queue_to_color, nodestate_to_color_default
 import qtop_py.yaml_parser as yaml
 from qtop_py.ui.viewport import Viewport
-from qtop_py.serialiser import GenericBatchSystem
 from qtop_py.web import Web
 from qtop_py import __version__
 import time
 
 here = sys.path[0]
+
+PLUGIN_BATCH_SYSTEMS = (DemoBatchSystem, OARBatchSystem, PBSBatchSystem, SGEBatchSystem, SlurmBatchSystem)
 
 
 # TODO make the following work with py files instead of qtop.colormap files
@@ -447,7 +452,7 @@ def check_python_version():
         sys.exit(1)
 
 
-def control_qtop(viewport, read_char, cluster, new_attrs):
+def control_qtop(viewport, read_char, cluster, new_attrs, old_attrs, max_line_len, change_mapping):
     """
     Basic vi-like movement is implemented for the -w switch (linux watch-like behaviour for qtop).
     h, j, k, l for left, down, up, right, respectively.
@@ -860,20 +865,8 @@ def colorize_nodestate(worker_nodes, nodestate_to_color, ffunc):
 
 
 def discover_qtop_batch_systems():
-    batch_systems = set()
-
-    # Find all the classes that extend GenericBatchSystem
-    to_scan = [GenericBatchSystem]
-    while to_scan:
-        parent = to_scan.pop()
-        for child in parent.__subclasses__():
-            if child not in batch_systems:
-                batch_systems.add(child)
-                to_scan.append(child)
-
-    # Extract those class's mnemonics
     available_batch_systems = {}
-    for batch_system in batch_systems:
+    for batch_system in PLUGIN_BATCH_SYSTEMS:
         mnemonic = batch_system.get_mnemonic()
         assert mnemonic
         assert mnemonic not in available_batch_systems, "Duplicate for mnemonic: '%s'" % mnemonic
@@ -1449,7 +1442,7 @@ class TextDisplay(object):
         if self.args.SAMPLE:
             print("Sample files saved in %s/%s" % (_savepath, SAMPLE_FILENAME))
         if self.args.STRICTCHECK:
-            WNOccupancy.strict_check_jobs(wns_occupancy, cluster)
+            WNOccupancy.strict_check_jobs(self.wns_occupancy, self.cluster)
 
     def display_job_accounting_summary(self, cluster, document):
         """
@@ -2480,7 +2473,7 @@ def main():
                     _ = subprocess.call(cat_command, stdout=stdout, stderr=stdout)
 
                     read_char = wait_for_keypress_or_autorefresh(viewport, FALLBACK_TERMSIZE, int(args.WATCH) or KEYPRESS_TIMEOUT)
-                    control_qtop(viewport, read_char, cluster, new_attrs)
+                    control_qtop(viewport, read_char, cluster, new_attrs, old_attrs, max_line_len, change_mapping)
 
                 help_main_switch.pop()
                 os.chdir(QTOPPATH)

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -27,13 +27,21 @@ import json
 import datetime
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import signal, SIG_DFL
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
 import logging
 from ast import literal_eval
+import shutil
 from qtop_py.constants import SYSTEMCONFDIR, QTOPCONF_YAML, QTOP_LOGFILE, USERPATH, MAX_UNIX_ACCOUNTS, KEYPRESS_TIMEOUT, FALLBACK_TERMSIZE
 from qtop_py import fileutils
 from qtop_py import utils
@@ -324,8 +332,7 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system
@@ -1711,7 +1718,8 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        if SIGPIPE is not None:
+            signal(SIGPIPE, SIG_DFL)
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1734,7 +1742,8 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        if SIGPIPE is not None:
+                            signal(SIGPIPE, SIG_DFL)
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:

--- a/qtop_py/serialiser.py
+++ b/qtop_py/serialiser.py
@@ -9,6 +9,7 @@
 ##
 
 import re
+
 ##import sys
 from itertools import count
 import logging

--- a/qtop_py/ui/viewport.py
+++ b/qtop_py/ui/viewport.py
@@ -2,6 +2,7 @@ class BaseViewport(object):
     """
     Class that implements a basic viewport [window into the qtop matrix] and basic movement restrictions
     """
+
     def __init__(self, vstart=0, hstart=0):
         self._v_start = vstart
         self._v_stop = 0
@@ -43,6 +44,7 @@ class Viewport(BaseViewport):
     """
     Class that extends BaseViewport to provide the actual movements of the Viewport
     """
+
     @property
     def h_start(self):
         assert not (self.would_cross_left_limit(self._h_start) and self.would_cross_right_limit(self._h_start))

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -12,27 +12,30 @@ from qtop_py.plugins import pbs
 import pytest
 
 
-@pytest.mark.parametrize('core_selections, result',
-     (
-             ('0-4,30-31', ["0","1","2","3","4","30","31"]),
-             ('5-9', ["5","6","7","8","9"]),
-             ('0,3,5-7,11', ["0","3","5","6","7","11"]),
-             ('1,2-4,5-6,9', ["1","2","3","4","5","6","9"])
-     ),
+@pytest.mark.parametrize(
+    "core_selections, result",
+    (
+        ("0-4,30-31", ["0", "1", "2", "3", "4", "30", "31"]),
+        ("5-9", ["5", "6", "7", "8", "9"]),
+        ("0,3,5-7,11", ["0", "3", "5", "6", "7", "11"]),
+        ("1,2-4,5-6,9", ["1", "2", "3", "4", "5", "6", "9"]),
+    ),
 )
 def test_get_corejob_from_range(core_selections, result, job=None):
     result = iter(result)
-    for (core, job) in pbs.PBSBatchSystem.get_corejob_from_range(core_selections, job):
+    for core, job in pbs.PBSBatchSystem.get_corejob_from_range(core_selections, job):
         assert core == next(result)
 
-@pytest.mark.parametrize('jobs, result',
-     (
-             (["0/10102182.f-batch01.grid.sinica.edu.tw", "1/10102106.f-batch01.grid.sinica.edu.tw"], [("10102182", "0"), ("10102106", "1")]),
-             (["2/10102339.f-batch01.grid.sinica.edu.tw", "3/10104007.f-batch01.grid.sinica.edu.tw"], [("10102339", "2"), ("10104007", "3")]),
-             (["3-5/10102339.f-batch01.grid.sinica.edu.tw"], [("10102339", "3"), ("10102339", "4"), ("10102339", "5")]),
-             (["2257887.cluster-pbs5/0", "2257887.cluster-pbs5/1"], [("2257887", "0"), ("2257887", "1")]),
-             (["2257887.cluster-pbs5/2", "2257887.cluster-pbs5/3"], [("2257887", "2"), ("2257887", "3")])
-     ),
+
+@pytest.mark.parametrize(
+    "jobs, result",
+    (
+        (["0/10102182.f-batch01.grid.sinica.edu.tw", "1/10102106.f-batch01.grid.sinica.edu.tw"], [("10102182", "0"), ("10102106", "1")]),
+        (["2/10102339.f-batch01.grid.sinica.edu.tw", "3/10104007.f-batch01.grid.sinica.edu.tw"], [("10102339", "2"), ("10104007", "3")]),
+        (["3-5/10102339.f-batch01.grid.sinica.edu.tw"], [("10102339", "3"), ("10102339", "4"), ("10102339", "5")]),
+        (["2257887.cluster-pbs5/0", "2257887.cluster-pbs5/1"], [("2257887", "0"), ("2257887", "1")]),
+        (["2257887.cluster-pbs5/2", "2257887.cluster-pbs5/3"], [("2257887", "2"), ("2257887", "3")]),
+    ),
 )
 def test_get_jobs_cores(jobs, result):
     result = iter(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## SPDX-License-Identifier: MIT
+##
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "arguments, expected_message",
+    (
+        (("-bb",), "The selected scheduler is not supported"),
+        (("-b", "auto"), "No scheduler could be auto-detected"),
+    ),
+)
+@pytest.mark.parametrize("module", ("qtop_py.cli", "qtop_py.qtop"))
+def test_known_cli_errors_do_not_show_tracebacks(module, arguments, expected_message):
+    environment = os.environ.copy()
+    environment.pop("QTOP_SCHEDULER", None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", module] + list(arguments),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env=environment,
+    )
+
+    assert result.returncode == 1
+    assert expected_message in result.stderr
+    assert "Traceback" not in result.stderr

--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -37,9 +37,7 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
     )
     extractor = PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
 
-    assert extractor._extract_qstat_regex(str(qstat_file)) == [
-        {"JobId": "1234", "UnixAccount": "alice", "S": "R", "Queue": "workq"}
-    ]
+    assert extractor._extract_qstat_regex(str(qstat_file)) == [{"JobId": "1234", "UnixAccount": "alice", "S": "R", "Queue": "workq"}]
 
 
 def test_decide_remapping_handles_mixed_numeric_and_named_nodes():

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -125,7 +125,7 @@ def test_create_user_job_counts_raises_jobnotfound():  # user_names, job_states,
 
     document = Document()
     wns_occupancy = WNOccupancy(None, None, document, None, None)
-    with pytest.raises(JobNotFound) as e:  # noqa: F841  ## FIXME
+    with pytest.raises(JobNotFound):
         wns_occupancy._create_user_job_counts(user_names, job_states, state_abbrevs) == {
             "cancelled_of_user": {"sotiris": 0, "yannis": 0, "petros": 1},
             "exiting_of_user": {"sotiris": 0, "kostas": 1, "yannis": 0},
@@ -253,7 +253,7 @@ def test_get_selected_batch_system_raises_scheduler_not_specified(
     available_batch_systems = {"sge": None, "oar": None, "pbs": None}
     config = {"signature_commands": {"pbs": "pbsnodes", "oar": "oarnodes", "sge": "qhost", "demo": "echo"}}
 
-    with pytest.raises(SchedulerNotSpecified) as e:  # noqa: F841  ## FIXME
+    with pytest.raises(SchedulerNotSpecified):
         decide_batch_system(
             cmdline_switch,
             env_var,
@@ -279,7 +279,7 @@ def test_get_selected_batch_system_raises_no_scheduler_found(
 ):
     schedulers = ["sge", "oar", "pbs"]
     available_batch_systems = {"sge": None, "oar": None, "pbs": None}
-    with pytest.raises(NoSchedulerFound) as e:  # noqa: F841  ## FIXME
+    with pytest.raises(NoSchedulerFound):
         decide_batch_system(
             cmdline_switch,
             env_var,

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -44,6 +44,7 @@ def test_sort_worker_nodes_uses_named_sort_keys(monkeypatch):
 
     assert [node["domainname"] for node in cluster._sort_worker_nodes()] == ["node2", "node10"]
 
+
 def test_sort_worker_nodes_rejects_custom_python_sorting(monkeypatch):
     import qtop_py.qtop as qtop
 

--- a/tests/test_validate_scheduler_samples.py
+++ b/tests/test_validate_scheduler_samples.py
@@ -1,0 +1,19 @@
+from tools.validate_scheduler_samples import ROOT, discover_cases
+
+
+def test_discover_cases_covers_all_supported_backends():
+    cases = discover_cases(["pbs", "sge", "slurm", "oar", "demo"], ROOT / "tests/plugins/slurm_samples")
+
+    schedulers = {case["scheduler"] for case in cases}
+    names = {case["name"] for case in cases}
+
+    assert schedulers == {"pbs", "sge", "slurm", "oar", "demo"}
+    assert {"pbs-contrib", "sge-contrib", "oar-contrib", "demo-generated"} <= names
+
+
+def test_all_cases_request_coloured_output():
+    cases = discover_cases(["pbs", "sge", "slurm", "oar", "demo"], ROOT / "tests/plugins/slurm_samples")
+
+    for case in cases:
+        args = case.get("args", ["-c", "ON"])
+        assert args[args.index("-c") + 1] == "ON"

--- a/tests/ui/test_viewport.py
+++ b/tests/ui/test_viewport.py
@@ -29,7 +29,7 @@ def test_after_scroll_left():
     assert 53 == viewport.v_stop
 
 
-def test_after_scroll_right_UNUSED():  # FIXME: cleanup as such
+def test_after_scroll_right_moves_half_page():
     viewport = Viewport()
     viewport.set_term_size(53, 176)
     viewport.max_width = 400

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -21,8 +21,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTROL_OR_BIDI = re.compile(r"[^\x09\x0a\x0d\x20-\x7e]|\u202a|\u202b|\u202c|\u202d|\u202e|\u2066|\u2067|\u2068|\u2069")
 GENERATED_OR_BINARY = re.compile(
-    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|"
-    r"\.(xz|lzma|gz|bin|dat|png|jpg|jpeg|gif|webp)$",
+    r"(^|/)(m4|autogen|configure|Makefile\.in|cmake|tests?/files|fixtures?)/|" r"\.(xz|lzma|gz|bin|dat|png|jpg|jpeg|gif|webp)$",
     re.IGNORECASE,
 )
 SKIP_DIRS = set([".git", ".tox", ".venv", "__pycache__", "artifacts", "build", "dist", "qtop.egg-info"])

--- a/tools/validate_scheduler_samples.py
+++ b/tools/validate_scheduler_samples.py
@@ -28,6 +28,11 @@ ROOT = Path(__file__).resolve().parents[1]
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 CONTRIB = ROOT / "qtop_py" / "contrib"
 
+COMMON_RENDER_MARKERS = [
+    "Worker Nodes occupancy",
+    "User accounts and pool mappings",
+]
+
 STATIC_CASES = {
     "pbs": [
         {
@@ -57,6 +62,22 @@ STATIC_CASES = {
             ],
         }
     ],
+    "oar": [
+        {
+            "name": "oar-contrib",
+            "source": CONTRIB,
+            "args": ["-s", str(CONTRIB), "-c", "ON", "-F", "-b", "oar"],
+            "markers": COMMON_RENDER_MARKERS,
+        }
+    ],
+    "demo": [
+        {
+            "name": "demo-generated",
+            "source": ROOT,
+            "args": ["-c", "ON", "-F", "-b", "demo"],
+            "markers": COMMON_RENDER_MARKERS,
+        }
+    ],
 }
 
 SLURM_MARKERS_BY_SAMPLE = {
@@ -67,11 +88,6 @@ SLURM_MARKERS_BY_SAMPLE = {
     "mixed": ["Summary: Total:2 Up:1 Free:0 Nodes", "4/16 cores", "2+0 jobs"],
     "multi_partition": ["Summary: Total:2 Up:2 Free:1 Nodes", "4/32 cores", "2+1 jobs"],
 }
-
-COMMON_RENDER_MARKERS = [
-    "Worker Nodes occupancy",
-    "User accounts and pool mappings",
-]
 
 
 def normalize_output(text):
@@ -112,7 +128,8 @@ def write_svg_screenshot(path, text, max_lines=38, max_columns=132):
     rows = []
     for index, line in enumerate(clipped):
         rows.append(
-            '<text x="14" y="%s">%s</text>' % (
+            '<text x="14" y="%s">%s</text>'
+            % (
                 28 + index * 17,
                 html.escape(line.rstrip()),
             )


### PR DESCRIPTION
Closes #484

## Summary

- turn known scheduler-selection failures into concise CLI errors instead of Python tracebacks
- make terminal-size detection and output display portable without hard-coded `/bin/stty`, `/bin/cat`, or `/usr/bin/clear`
- safely degrade when `termios` is unavailable
- remove a handful of FIXME-marked unused variables, bare exceptions, and stale test naming
- remove the SGE `return`-inside-`finally` warning
- include #400, preserving its original author and DCO sign-off

## Validation

- `python -m pytest -q` (123 passed)
- `python -m ruff check .`
- `python -m py_compile qtop_py/qtop.py qtop_py/cli.py qtop_py/plugins/sge.py tests/test_cli.py`
- `git diff --check`
- manually verified `python -m qtop_py.qtop -bb` and `python -m qtop_py.cli -bb` return exit code 1 without a traceback on Windows

## CONTRIBUTING alignment

- targets `develop`
- DCO-signed commits; the included #400 commit retains its original author and sign-off
- no force pushes
- PoH: the contributor account owner accepts a maintainer-requested proof-of-humanity challenge; no personal documents will be sent

## AI assistance

Implementation and validation were materially assisted by OpenAI Codex using GPT-5. The contributor remains responsible for reviewing and explaining the changes.