### PR TITLE
20260611 (human) fix: keep SGE warnings out of concise CLI errors

### DIFF
--- a/qtop_py/plugins/sge.py
+++ b/qtop_py/plugins/sge.py
@@ -34,9 +34,9 @@ class SGEStatExtractor(StatExtractor):
                 raise
             except IOError:
                 raise
-            except:  # noqa: E722  ## FIXME, ruff complaint
+            except Exception:
                 logging.debug("XML file state %s" % fin)
-                logging.debug("thinking...")
+                logging.debug("thinking...", exc_info=True)
                 sys.exit(1)
             else:
                 root = tree.getroot()
@@ -46,7 +46,7 @@ class SGEStatExtractor(StatExtractor):
         all_values = list()
         self.orig_file = orig_file
         self.tree, self.root = self.get_xml_tree(orig_file)
-        tree, root = self.tree, self.root  # noqa: F841  ## FIXME, tree unused
+        root = self.root
 
         for queue_elem in root.findall("queue_info/Queue-List"):
             queue_name_elems = queue_elem.findall("resource")
@@ -124,7 +124,7 @@ class SGEBatchSystem(GenericBatchSystem):
         logging.debug("Parsing tree of %s" % self.sge_file)
         fileutils.check_empty_file(self.sge_file)
 
-        tree, root = self.sge_stat_maker.tree, self.sge_stat_maker.root  # noqa: F841  ## FIXME, tree unused
+        root = self.sge_stat_maker.root
 
         qstatq_list = self._extract_queues("queue_info/Queue-List", root)
 
@@ -269,12 +269,10 @@ class SGEBatchSystem(GenericBatchSystem):
         return worker_node
 
     def _get_state(self, queue_elem):
-        try:
-            _state = queue_elem.find("state").text
-        except AttributeError:
-            _state = "-"
-        finally:
-            return _state
+        state = queue_elem.find("state")
+        if state is None:
+            return "-"
+        return state.text
 
     def _extract_queues(self, xpath, root):
         qstatq_list = []
@@ -303,8 +301,6 @@ class SGEBatchSystem(GenericBatchSystem):
                     d["state"] = queue_elem.find("./state").text
                 except AttributeError:
                     d["state"] = "?"
-                except:
-                    raise
 
                 job_lists = queue_elem.findall("job_list")
                 run_count = 0

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -191,7 +191,7 @@ def raw_mode(file):
         if args.WATCH:
             try:
                 old_attrs = termios.tcgetattr(file.fileno())
-            except:  # noqa: E722  ## FIXME, ruff complaint
+            except (AttributeError, OSError, termios.error):
                 yield
             else:
                 new_attrs = old_attrs[:]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,3 +41,4 @@ def test_expected_cli_scheduler_errors_are_concise(tmp_path, args, expected):
     assert result.returncode != 0
     assert expected in output
     assert "Traceback" not in output
+    assert "SyntaxWarning" not in output

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -73,6 +73,32 @@ def test_sort_worker_nodes_uses_named_sort_keys(monkeypatch):
     assert [node["domainname"] for node in cluster._sort_worker_nodes()] == ["node2", "node10"]
 
 
+def test_raw_mode_allows_watch_mode_without_terminal_attrs(monkeypatch):
+    class NonTerminalFile:
+        def fileno(self):
+            raise OSError("not a terminal")
+
+    monkeypatch.setattr(qtop_module, "args", SimpleNamespace(ONLYSAVETOFILE=False, WATCH=True), raising=False)
+
+    entered_context = False
+    with qtop_module.raw_mode(NonTerminalFile()):
+        entered_context = True
+
+    assert entered_context
+
+
+def test_raw_mode_does_not_swallow_unexpected_fileno_errors(monkeypatch):
+    class BrokenFile:
+        def fileno(self):
+            raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(qtop_module, "args", SimpleNamespace(ONLYSAVETOFILE=False, WATCH=True), raising=False)
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        with qtop_module.raw_mode(BrokenFile()):
+            pass
+
+
 def test_sort_worker_nodes_rejects_custom_python_sorting(monkeypatch):
     import qtop_py.qtop as qtop
 


### PR DESCRIPTION
## Implementation checklist
- [x] Target branch is `develop`.
- [x] PR subject keeps the dated tag and adds the PoH `(human)` tag for prioritisation.
- [x] `CONTRIBUTING.md` reread on 2026-06-11; this PR follows the DCO, AI disclosure, no-force-push, branch-target, and no-repo-artifact expectations.
- [x] DCO sign-off is present on the commits.
- [x] AI assistance is disclosed with model/version: OpenAI GPT-5 Codex.
- [x] No force-push has been used.
- [x] SGE `return`-inside-`finally` SyntaxWarning path is removed from expected CLI scheduler errors.
- [x] Nearby SGE FIXME/noqa clutter is cleaned where it directly supported the warning/error-reporting slice.
- [x] CLI regression coverage verifies expected scheduler errors stay free of `Traceback` and `SyntaxWarning`.
- [x] `raw_mode` terminal setup handling is tightened with explicit terminal/file exceptions and regression tests.

## Summary
- Remove the SGE `return`-inside-`finally` path that emitted a Python `SyntaxWarning` before expected CLI scheduler errors.
- Clean nearby SGE FIXME/noqa clutter by using `except Exception`, removing unused `tree` bindings, and dropping a redundant bare re-raise.
- Extend CLI regression coverage so expected scheduler errors stay free of both `Traceback` and `SyntaxWarning`.
- Tighten `raw_mode` terminal setup handling by replacing the remaining bare `except` with explicit terminal/file exceptions.
- Add raw-mode tests covering non-terminal fallback and propagation of unexpected file errors.

## Related
Refs #484
/claim #484

## Validation
- `python3 -m py_compile qtop_py/plugins/sge.py qtop_py/cli.py tests/test_cli.py`
- `python3 -m qtop_py.cli -d`
- `python3 -m qtop_py.cli -bb`
- `. .venv/bin/activate && python -m pytest tests/test_cli.py tests/plugins/test_slurm.py tests/plugins/test_pbs.py` (31 passed)
- `. .venv/bin/activate && make test` (139 passed)
- `.venv/bin/python -m pytest tests/test_qtop.py -k raw_mode` (2 passed)
- `.venv/bin/python -m ruff check qtop_py/qtop.py tests/test_qtop.py`
- `.venv/bin/python -m ruff format --check qtop_py/qtop.py tests/test_qtop.py`
- `make test PYTHON=.venv/bin/python` (141 passed)
- `. .venv/bin/activate && python -m ruff check qtop_py/plugins/sge.py tests/test_cli.py`
- `. .venv/bin/activate && python -m ruff format --check qtop_py/plugins/sge.py tests/test_cli.py`
- `git diff --check origin/develop...HEAD`
- `git diff --check`

## DCO / AI / PoH
- DCO: commits are signed off with `Signed-off-by`.
- AI disclosure: OpenAI GPT-5 Codex assisted with issue triage, patch drafting, and validation command selection; I reviewed the diff and verified it locally.
- PoH: title tag is `(human)`. I can respond to maintainer proof-of-humanity challenge requests through GitHub-visible/verifiable channels; no private documents or personal data are being submitted here.
- No force-push has been used on this PR branch.
