### PR TITLE
20260611 (SDP) (PRO) (LI) (human) ci: realign GitLab CI layout to pvgis-style structure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,51 +1,37 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Root pipeline: shared defaults plus one include per concern, mirroring the
+# layout of https://code.europa.eu/pvgis/pvgis/ (thin root ``.gitlab-ci.yml``,
+# per-concern child files under ``ci/``, CI-only helpers under ``ci/scripts/``).
+#
+# Concerns included below:
+#
+# - ``ci/test.gitlab-ci.yml`` -- merge-request/branch validation through the
+#                                 shared Makefile contract (``make gitlab-ci``)
+#                                 plus the dependency-light Python 3.6 gate.
+# - ``ci/build.gitlab-ci.yml`` -- sdist/wheel build on top of green tests.
+#
+# Job behaviour is intentionally identical to the previous monolithic file:
+# this realignment only changes *where* jobs are defined, not *what* they do.
+# Every job body stays a thin wrapper around a Makefile target so GitHub
+# Actions and GitLab CI remain behaviourally aligned; see docs/ci-structure.md.
+
+image: python:3.12.3-bookworm
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 stages:
   - test
   - build
 
-modern-python:
-  image: python:3.12.3-bookworm
-  stage: test
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make git
-    - make ci-deps PYTHON=python
-    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
-    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
-    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
-  script:
-    - make gitlab-ci PYTHON=python
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate/
-
-almalinux-python36:
-  image: almalinux:8
-  stage: test
-  before_script:
-    - dnf -y install make findutils
-    - dnf -y install python36
-  script:
-    - |
-      PYTHON_BIN="$(command -v python3.6)"
-      "$PYTHON_BIN" --version
-      make compat-py36 PYTHON="$PYTHON_BIN"
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate-py36/
-
-build:
-  image: python:3.12.3-bookworm
-  stage: build
-  needs:
-    - modern-python
-    - almalinux-python36
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make
-  script:
-    - make gitlab-build PYTHON=python
-  artifacts:
-    paths:
-      - dist/
+include:
+  - local: ci/test.gitlab-ci.yml
+  - local: ci/build.gitlab-ci.yml

--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,4 @@
+## Summary
+## Related
+Refs #
+## Validation

--- a/ci/build.gitlab-ci.yml
+++ b/ci/build.gitlab-ci.yml
@@ -1,0 +1,29 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Build concern: package the sdist/wheel once the test concern is green.
+#
+# ``make gitlab-build`` wraps ``python -m build --no-isolation`` with the
+# pinned CI dependencies from requirements-ci.txt, so the artefacts produced
+# here match what a contributor builds locally with the same Makefile target.
+
+build:
+  image: python:3.12.3-bookworm
+  stage: build
+  needs:
+    - modern-python
+    - almalinux-python36
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make gitlab-build PYTHON=python
+  artifacts:
+    paths:
+      - dist/

--- a/ci/test.gitlab-ci.yml
+++ b/ci/test.gitlab-ci.yml
@@ -1,0 +1,54 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Test concern: merge-request/branch validation.
+#
+# - ``modern-python`` -- the full shared validation path (``make gitlab-ci``:
+#   pytest, scheduler sample gates, ruff, fortifications, format checks) on the
+#   pinned modern interpreter. ``FORTIFY_BASE_REF`` follows the MR target branch
+#   so diff-health checks compare against the right base.
+# - ``almalinux-python36`` -- dependency-light Python 3.6 compatibility gate on
+#   AlmaLinux 8 (``make compat-py36``), matching the python3.6/rhel8 floor that
+#   several production clusters still run (see CONTRIBUTING.md).
+#
+# Both jobs are thin wrappers around Makefile targets so the same validation
+# can be reproduced locally and on GitHub Actions without divergence.
+
+modern-python:
+  image: python:3.12.3-bookworm
+  stage: test
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make git
+    - make ci-deps PYTHON=python
+    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
+    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
+  script:
+    - make gitlab-ci PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+
+almalinux-python36:
+  image: almalinux:8
+  stage: test
+  before_script:
+    - dnf -y install make findutils
+    - dnf -y install python36
+  script:
+    - |
+      PYTHON_BIN="$(command -v python3.6)"
+      "$PYTHON_BIN" --version
+      make compat-py36 PYTHON="$PYTHON_BIN"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate-py36/

--- a/docs/ci-structure.md
+++ b/docs/ci-structure.md
@@ -1,0 +1,55 @@
+# CI structure
+
+qtop's GitLab pipeline follows the layout of
+[pvgis](https://code.europa.eu/pvgis/pvgis/): a thin root `.gitlab-ci.yml`
+holding only shared defaults (`image`, `variables`, `stages`) and one
+`include: local:` line per concern, with the actual jobs living in
+per-concern child files under `ci/`. CI-only helper scripts go to
+`ci/scripts/`. GitLab-side templates (merge requests) live under `.gitlab/`,
+mirroring `.github/`.
+
+```
+.gitlab-ci.yml              # root: defaults + stages + includes, no jobs
+ci/
+  test.gitlab-ci.yml        # test concern: modern python + py3.6/rhel8 gate
+  build.gitlab-ci.yml       # build concern: sdist/wheel
+  scripts/                  # CI-only helpers (never on the runtime path)
+.gitlab/
+  merge_request_templates/  # mirrors .github/PULL_REQUEST_TEMPLATE.md
+```
+
+## The Makefile contract
+
+Every CI job -- on either forge -- is a thin wrapper around a Makefile target.
+The Makefile is the single source of truth for *what* validation means; the
+CI files only decide *where and when* it runs. This keeps GitHub Actions and
+GitLab CI behaviourally identical and lets contributors reproduce any CI
+failure locally with the same command.
+
+| Concern | Makefile target | GitHub Actions | GitLab CI |
+|---|---|---|---|
+| Full validation | `make github-ci` / `make gitlab-ci` | `.github/workflows/build.yml` | `ci/test.gitlab-ci.yml` (`modern-python`) |
+| Python 3.6 / RHEL8 floor | `make compat-py36` | `.github/workflows/build.yml` (`almalinux-python36`) | `ci/test.gitlab-ci.yml` (`almalinux-python36`) |
+| Package build | `make github-build` / `make gitlab-build` | `.github/workflows/build.yml` (`build`) | `ci/build.gitlab-ci.yml` (`build`) |
+
+## Adding a new concern
+
+1. Create `ci/<concern>.gitlab-ci.yml` with a header comment explaining what
+   runs, when, and why (see existing child files for the expected register).
+2. Add any new stage to the root `stages:` list.
+3. Add `- local: ci/<concern>.gitlab-ci.yml` to the root `include:` list.
+4. If the concern introduces new validation logic, expose it as a Makefile
+   target first and keep the job body a one-line wrapper; put CI-only helper
+   scripts in `ci/scripts/`.
+
+## Why this layout
+
+- **Review isolation** -- security, matrix, coverage, and release changes stop
+  competing for the same monolithic file; diffs stay per-concern.
+- **GitLab linkage** ([#488](https://github.com/qtop/qtop/issues/488)) -- a
+  pegged GitLab mirror picks up the same pipeline unchanged, because nothing
+  in `ci/` assumes which forge triggered the run; everything routes through
+  the Makefile.
+- **Precedent** -- the structure is proven on
+  [code.europa.eu/pvgis/pvgis](https://code.europa.eu/pvgis/pvgis/), the
+  reference named in #488.


### PR DESCRIPTION
## Summary

Prerequisite PR for the #488 checklist: realign the qtop CI structure to
look like https://code.europa.eu/pvgis/pvgis/ - a thin root `.gitlab-ci.yml`
holding only shared defaults (`image`, `variables`, `stages`) and one
`include: local:` per concern, with jobs living in per-concern child files
under `ci/`, CI-only helpers reserved at `ci/scripts/`, and `.gitlab/`
mirroring `.github/` (merge-request template).

Job behaviour is intentionally identical to the previous monolithic file:
the same `modern-python`, `almalinux-python36` and `build` jobs wrap the
same Makefile targets with the same images, scripts and artifacts. This
change only moves *where* jobs are defined, so the diff is reviewable as a
pure restructure. `docs/ci-structure.md` documents the layout, the
Makefile-contract parity table (GitHub Actions <-> GitLab CI), and how to
add a new concern.

## Related

Refs #488 (prerequisite PR, before the bounty PR; bounty PR follows
stacked on this branch)

## Validation

- `make ci PYTHON=python` -> green locally: 139 tests passed, 10/10
  scheduler sample gates, fortifications ok, ruff lint and format clean,
  `git diff --check` clean.
- `python -c "import yaml; ..."` -> root + both child files parse.
- All added lines are pure printable ASCII (fortifications-compatible).
- Live on the fork: the project's own `pytest-qtop` workflow ran green on
  this branch stack: https://github.com/Vadik-x/qtop/actions
- Python 3.6.15 conformance: `make compat-py36` -> exit 0, 10/10 sample
  gates (transcript + qtop SGE render SVG in the evidence repo:
  https://github.com/Vadik-x/qtop-488-evidence ).

## DCO / AI / PoH

- DCO: every commit carries `Signed-off-by: Vadik-x <vadik.core@gmail.com>`
  matching the commit author.
- AI disclosure (mandatory, with version): Claude Opus 4.8 used.
- PoH: verified via the maintainer's checks (the (SDP) Student Developer Pack
  tag, a verified LinkedIn profile, and the emailed code-relay). No personal
  documents or private data were submitted.
- No force-pushing was used at any point; all commits are append-only
  (the push tooling rejects non-fast-forward updates by construction).
