### PR TITLE
20260611 (SDP) (PRO) (LI) (human) ci: GitLab linkage pilot for challenge 9 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,54 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Coverage concern (#488), GitHub flavour: the same ``make coverage-xml``
+# Cobertura artifact that ci/coverage.gitlab-ci.yml publishes to GitLab is
+# uploaded here as a workflow artifact and pushed to Codecov. The Codecov
+# step is tokenless (public repo) and never fails the build: coverage is
+# signal, not a gate, at the current 45% baseline.
+
+name: coverage-qtop
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.12.3'
+      - run: make ci-deps PYTHON=python
+      - run: make coverage-xml PYTHON=python
+      - uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: coverage-cobertura-xml
+          path: artifacts/coverage/coverage.xml
+      - uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: artifacts/coverage/coverage.xml
+          flags: pytest
+          fail_ci_if_error: false

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -98,7 +98,7 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git ca-certificates || true
               ;;
             rhel|fedora|amazon) dnf -y install git || true ;;
-            suse) zypper --non-interactive refresh || true; zypper --non-interactive install git ;;
+            suse) zypper --non-interactive refresh || true; zypper --non-interactive install git || true ;;
             arch) pacman -Sy --noconfirm git || true ;;
             *) echo "official image, git preinstalled" ;;
           esac

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -1,0 +1,86 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Nightly interpreter/distro compatibility matrix (#488): 35 lanes covering
+# CPython 3.6 through 3.15-rc plus PyPy across Debian, Ubuntu, AlmaLinux,
+# Rocky, Fedora, openSUSE, Amazon Linux and Arch. Every lane routes through
+# ci/scripts/matrix_lane.sh and the Makefile contract, mirroring
+# ci/nightly-matrix.gitlab-ci.yml lane-for-lane (same order, same fields).
+#
+# Lane targets are git-free on purpose: the nightly matrix watches
+# interpreter/runtime drift; diff-health checks stay in MR/PR pipelines.
+# Experimental lanes (prerelease interpreters, EOL-archived or rolling
+# distros) never fail the workflow.
+
+name: nightly-matrix-qtop
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lane:
+    name: ${{ matrix.image }} ${{ matrix.pybin }} ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.image }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # -- stable lanes -------------------------------------------------
+          - { image: 'python:3.7-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: false }
+          - { image: 'python:3.8-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.9-bookworm',  family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.10-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.11-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.12-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.13-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'python:3.14-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          - { image: 'ubuntu:22.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'ubuntu:24.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'ubuntu:25.10', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'debian:bullseye', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'debian:bookworm', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'debian:trixie', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'almalinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36, experimental: false }
+          - { image: 'almalinux:8', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
+          - { image: 'almalinux:9', family: rhel, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'almalinux:9', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
+          - { image: 'rockylinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36, experimental: false }
+          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3.11,python3.11-pip', pybin: python3.11, target: ci, experimental: false }
+          - { image: 'fedora:41', family: fedora, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'fedora:42', family: fedora, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python3', pybin: python3, target: compat-py36, experimental: false }
+          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python311,python311-pip', pybin: python3.11, target: ci, experimental: false }
+          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
+          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
+          # -- experimental lanes: prerelease / EOL-archived / rolling ------
+          - { image: 'python:3.6-buster', family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: true }
+          - { image: 'python:3.15-rc', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: true }
+          - { image: 'pypy:3.9', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
+          - { image: 'pypy:3.10', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
+          - { image: 'pypy:3.11', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
+          - { image: 'ubuntu:20.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: true }
+          - { image: 'debian:sid', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: true }
+          - { image: 'archlinux:base', family: arch, pkgs: 'python,python-pip', pybin: python, target: ci, experimental: true }
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - run: bash ci/scripts/matrix_lane.sh "${{ matrix.family }}" "${{ matrix.pkgs }}" "${{ matrix.pybin }}" "${{ matrix.target }}"
+      - uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: nightly-lane-${{ strategy.job-index }}
+          path: artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -17,6 +17,14 @@
 # interpreter/runtime drift; diff-health checks stay in MR/PR pipelines.
 # Experimental lanes (prerelease interpreters, EOL-archived or rolling
 # distros) never fail the workflow.
+#
+# Findings already produced by this matrix (first live run, 2026-06-11):
+# - the pinned CI set's floor is Python 3.9 (importlib-metadata==8.7.1
+#   requires >=3.9), so the 3.8 lanes run the dependency-light gate;
+# - qtop scheduler autodetection shells out to /usr/bin/which, which is
+#   absent from minimal RHEL-family/Arch images (now installed per lane);
+# - openSUSE Leap base images lack tar, so checkout's tarball fallback
+#   cannot extract; the bootstrap step below installs git first.
 
 name: nightly-matrix-qtop
 
@@ -40,7 +48,8 @@ jobs:
         include:
           # -- stable lanes -------------------------------------------------
           - { image: 'python:3.7-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: false }
-          - { image: 'python:3.8-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
+          # 3.8 runs the dependency-light gate: the pinned CI set needs >=3.9.
+          - { image: 'python:3.8-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: false }
           - { image: 'python:3.9-bookworm',  family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
           - { image: 'python:3.10-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
           - { image: 'python:3.11-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
@@ -72,10 +81,22 @@ jobs:
           - { image: 'pypy:3.9', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
           - { image: 'pypy:3.10', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
           - { image: 'pypy:3.11', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
-          - { image: 'ubuntu:20.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: true }
+          - { image: 'ubuntu:20.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: compat-py36, experimental: true }
           - { image: 'debian:sid', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: true }
           - { image: 'archlinux:base', family: arch, pkgs: 'python,python-pip', pybin: python, target: ci, experimental: true }
     steps:
+      - name: bootstrap git for checkout (best effort; suse strictly needs it)
+        run: |
+          case "${{ matrix.family }}" in
+            debian)
+              apt-get update || true
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git ca-certificates || true
+              ;;
+            rhel|fedora|amazon) dnf -y install git || true ;;
+            suse) zypper --non-interactive refresh && zypper --non-interactive install git ;;
+            arch) pacman -Sy --noconfirm git || true ;;
+            *) echo "official image, git preinstalled" ;;
+          esac
       - uses: actions/checkout@v6.0.3
       - run: bash ci/scripts/matrix_lane.sh "${{ matrix.family }}" "${{ matrix.pkgs }}" "${{ matrix.pybin }}" "${{ matrix.target }}"
       - uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -18,19 +16,20 @@
 # Experimental lanes (prerelease interpreters, EOL-archived or rolling
 # distros) never fail the workflow.
 #
-# Findings already produced by this matrix (first live run, 2026-06-11):
-# - the pinned CI set's floor is Python 3.9 (importlib-metadata==8.7.1
-#   requires >=3.9), so the 3.8 lanes run the dependency-light gate;
-# - qtop scheduler autodetection shells out to /usr/bin/which, which is
-#   absent from minimal RHEL-family/Arch images (now installed per lane);
-# - openSUSE Leap base images lack tar, so checkout's tarball fallback
-#   cannot extract; the bootstrap step below installs git first.
+# Findings from the first live runs (2026-06-11) and how they were resolved:
+# - the pinned CI set floors at Python 3.9 (importlib-metadata==8.7.1
+#   requires >=3.9), so the 3.7/3.8 lanes run the dependency-light gate;
+# - qtop autodetection used a hardcoded /usr/bin/which, which broke minimal
+#   RHEL-family/Arch images -- fixed in this PR by switching to stdlib
+#   shutil.which(), so no lane needs a "which" package anymore;
+# - openSUSE Leap base images lack tar (checkout's tarball fallback), so the
+#   bootstrap step below installs git first.
 
 name: nightly-matrix-qtop
 
 on:
   schedule:
-    - cron: '30 2 * * *'
+    - cron: '20 4 * * *'
   workflow_dispatch:
 
 permissions:
@@ -38,52 +37,58 @@ permissions:
 
 jobs:
   lane:
-    name: ${{ matrix.image }} ${{ matrix.pybin }} ${{ matrix.target }}
+    name: ${{ matrix.image }} ${{ matrix.pybin || 'python3' }} ${{ matrix.target || 'ci' }}
     runs-on: ubuntu-24.04
     container: ${{ matrix.image }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
+      # Readability: GitHub Actions matrix `include` has no native per-key
+      # defaults, so the defaults below are applied via `||` fallback in the
+      # job `name`, `continue-on-error`, and the run step. A lane may then omit
+      # any key equal to its default -- pkgs: '-', pybin: python3, target: ci,
+      # experimental: false -- and only non-default values are written out.
       matrix:
         include:
-          # -- stable lanes -------------------------------------------------
-          - { image: 'python:3.7-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: false }
-          # 3.8 runs the dependency-light gate: the pinned CI set needs >=3.9.
-          - { image: 'python:3.8-bullseye',  family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: false }
-          - { image: 'python:3.9-bookworm',  family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'python:3.10-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'python:3.11-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'python:3.12-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'python:3.13-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'python:3.14-bookworm', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: false }
-          - { image: 'ubuntu:22.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'ubuntu:24.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'ubuntu:25.10', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'debian:bullseye', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'debian:bookworm', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'debian:trixie', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'almalinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36, experimental: false }
-          - { image: 'almalinux:8', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
-          - { image: 'almalinux:9', family: rhel, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'almalinux:9', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
-          - { image: 'rockylinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36, experimental: false }
-          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3.11,python3.11-pip', pybin: python3.11, target: ci, experimental: false }
-          - { image: 'fedora:41', family: fedora, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'fedora:42', family: fedora, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python3', pybin: python3, target: compat-py36, experimental: false }
-          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python311,python311-pip', pybin: python3.11, target: ci, experimental: false }
-          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3,python3-pip', pybin: python3, target: ci, experimental: false }
-          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3.12,python3.12-pip', pybin: python3.12, target: ci, experimental: false }
+          # -- stable lanes: CPython on official images (pybin: python) -----
+          - { image: 'python:3.7-bullseye',  family: pythonimg, pybin: python, target: compat-py36 }
+          # 3.8 also runs the compat gate: pinned CI deps need >=3.9.
+          - { image: 'python:3.8-bullseye',  family: pythonimg, pybin: python, target: compat-py36 }
+          - { image: 'python:3.9-bookworm',  family: pythonimg, pybin: python }
+          - { image: 'python:3.10-bookworm', family: pythonimg, pybin: python }
+          - { image: 'python:3.11-bookworm', family: pythonimg, pybin: python }
+          - { image: 'python:3.12-bookworm', family: pythonimg, pybin: python }
+          - { image: 'python:3.13-bookworm', family: pythonimg, pybin: python }
+          - { image: 'python:3.14-bookworm', family: pythonimg, pybin: python }
+          # -- stable lanes: distro system interpreters (defaults: python3, ci)
+          - { image: 'ubuntu:22.04', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'ubuntu:24.04', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'ubuntu:25.10', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'debian:bullseye', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'debian:bookworm', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'debian:trixie', family: debian, pkgs: 'python3,python3-venv,python3-pip' }
+          - { image: 'almalinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36 }
+          - { image: 'almalinux:8', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12 }
+          - { image: 'almalinux:9', family: rhel, pkgs: 'python3,python3-pip' }
+          - { image: 'almalinux:9', family: rhel, pkgs: 'python3.12,python3.12-pip', pybin: python3.12 }
+          - { image: 'rockylinux:8', family: rhel, pkgs: 'python36', pybin: python3.6, target: compat-py36 }
+          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3,python3-pip' }
+          - { image: 'rockylinux:9', family: rhel, pkgs: 'python3.11,python3.11-pip', pybin: python3.11 }
+          - { image: 'fedora:41', family: fedora, pkgs: 'python3,python3-pip' }
+          - { image: 'fedora:42', family: fedora, pkgs: 'python3,python3-pip' }
+          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python3', target: compat-py36 }
+          - { image: 'opensuse/leap:15.6', family: suse, pkgs: 'python311,python311-pip', pybin: python3.11 }
+          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3,python3-pip' }
+          - { image: 'amazonlinux:2023', family: amazon, pkgs: 'python3.12,python3.12-pip', pybin: python3.12 }
           # -- experimental lanes: prerelease / EOL-archived / rolling ------
-          - { image: 'python:3.6-buster', family: pythonimg, pkgs: '-', pybin: python, target: compat-py36, experimental: true }
-          - { image: 'python:3.15-rc', family: pythonimg, pkgs: '-', pybin: python, target: ci, experimental: true }
-          - { image: 'pypy:3.9', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
-          - { image: 'pypy:3.10', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
-          - { image: 'pypy:3.11', family: pypyimg, pkgs: '-', pybin: pypy3, target: ci, experimental: true }
-          - { image: 'ubuntu:20.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: compat-py36, experimental: true }
-          - { image: 'debian:sid', family: debian, pkgs: 'python3,python3-venv,python3-pip', pybin: python3, target: ci, experimental: true }
-          - { image: 'archlinux:base', family: arch, pkgs: 'python,python-pip', pybin: python, target: ci, experimental: true }
+          - { image: 'python:3.6-buster', family: pythonimg, pybin: python, target: compat-py36, experimental: true }
+          - { image: 'python:3.15-rc', family: pythonimg, pybin: python, experimental: true }
+          - { image: 'pypy:3.9', family: pypyimg, pybin: pypy3, experimental: true }
+          - { image: 'pypy:3.10', family: pypyimg, pybin: pypy3, experimental: true }
+          - { image: 'pypy:3.11', family: pypyimg, pybin: pypy3, experimental: true }
+          - { image: 'ubuntu:20.04', family: debian, pkgs: 'python3,python3-venv,python3-pip', target: compat-py36, experimental: true }
+          - { image: 'debian:sid', family: debian, pkgs: 'python3,python3-venv,python3-pip', experimental: true }
+          - { image: 'archlinux:base', family: arch, pkgs: 'python,python-pip', pybin: python, experimental: true }
     steps:
       - name: bootstrap git for checkout (best effort; suse strictly needs it)
         run: |
@@ -98,7 +103,7 @@ jobs:
             *) echo "official image, git preinstalled" ;;
           esac
       - uses: actions/checkout@v6.0.3
-      - run: bash ci/scripts/matrix_lane.sh "${{ matrix.family }}" "${{ matrix.pkgs }}" "${{ matrix.pybin }}" "${{ matrix.target }}"
+      - run: bash ci/scripts/matrix_lane.sh "${{ matrix.family }}" "${{ matrix.pkgs || '-' }}" "${{ matrix.pybin || 'python3' }}" "${{ matrix.target || 'ci' }}"
       - uses: actions/upload-artifact@v7.0.1
         if: always()
         with:

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -93,7 +93,7 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git ca-certificates || true
               ;;
             rhel|fedora|amazon) dnf -y install git || true ;;
-            suse) zypper --non-interactive refresh && zypper --non-interactive install git ;;
+            suse) zypper --non-interactive refresh || true; zypper --non-interactive install git ;;
             arch) pacman -Sy --noconfirm git || true ;;
             *) echo "official image, git preinstalled" ;;
           esac

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# OpenSSF Scorecard (#488): supply-chain health checks on the repository
+# itself. Publishes results to the OpenSSF API (badge + scorecard.dev
+# viewer), uploads the SARIF to GitHub code scanning, and keeps a copy as
+# a workflow artifact. Baseline measured via the public Scorecard REST API
+# on 2026-06-08: score 7.1, with SAST, Security-Policy, CII-Best-Practices
+# and Fuzzing as the obvious uplift candidates (see
+# docs/secure-coding-pyscg.md for the gap-to-action mapping).
+#
+# The GitLab twin (ci/scorecard.gitlab-ci.yml) runs the scorecard CLI on a
+# schedule against the same GitHub repository, so a pegged mirror reports
+# the same numbers.
+
+name: scorecard-qtop
+
+on:
+  schedule:
+    - cron: '17 4 * * 6'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 30
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -23,10 +21,14 @@ name: scorecard-qtop
 
 on:
   schedule:
-    - cron: '17 4 * * 6'
+    - cron: '20 5 * * 6'
   push:
     branches:
       - main
+      # develop runs are informative for developers (SARIF in code scanning
+      # + workflow artifact); publishing to the public OpenSSF API happens
+      # only from main, see publish_results below.
+      - develop
   workflow_dispatch:
 
 permissions: read-all
@@ -44,11 +46,15 @@ jobs:
       - uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.2
+      - uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          # Publish to the public OpenSSF API only from the default branch;
+          # develop runs stay informative (SARIF + artifact) without
+          # overwriting the published badge. v2.4.3 is the latest release
+          # (no newer tag for several months as of 2026-07).
+          publish_results: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/upload-artifact@v7.0.1
         with:
           name: scorecard-sarif

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,14 @@
 #                                 shared Makefile contract (``make gitlab-ci``)
 #                                 plus the dependency-light Python 3.6 gate.
 # - ``ci/build.gitlab-ci.yml`` -- sdist/wheel build on top of green tests.
+# - ``ci/security.gitlab-ci.yml`` -- SAST/Secret-Detection/Dependency-Scanning
+#                                 templates plus code-quality, license and
+#                                 repo-sanity jobs (#488).
+# - ``ci/coverage.gitlab-ci.yml`` -- Cobertura coverage publishing (#488).
+# - ``ci/nightly-matrix.gitlab-ci.yml`` -- scheduled 35-lane distro x python
+#                                 compatibility matrix (#488).
+# - ``ci/scorecard.gitlab-ci.yml`` -- scheduled OpenSSF Scorecard run (#488).
 #
-# Job behaviour is intentionally identical to the previous monolithic file:
-# this realignment only changes *where* jobs are defined, not *what* they do.
 # Every job body stays a thin wrapper around a Makefile target so GitHub
 # Actions and GitLab CI remain behaviourally aligned; see docs/ci-structure.md.
 
@@ -31,7 +36,13 @@ variables:
 stages:
   - test
   - build
+  - security
+  - nightly
 
 include:
   - local: ci/test.gitlab-ci.yml
   - local: ci/build.gitlab-ci.yml
+  - local: ci/security.gitlab-ci.yml
+  - local: ci/coverage.gitlab-ci.yml
+  - local: ci/nightly-matrix.gitlab-ci.yml
+  - local: ci/scorecard.gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,51 +1,37 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Root pipeline: shared defaults plus one include per concern, mirroring the
+# layout of https://code.europa.eu/pvgis/pvgis/ (thin root ``.gitlab-ci.yml``,
+# per-concern child files under ``ci/``, CI-only helpers under ``ci/scripts/``).
+#
+# Concerns included below:
+#
+# - ``ci/test.gitlab-ci.yml`` -- merge-request/branch validation through the
+#                                 shared Makefile contract (``make gitlab-ci``)
+#                                 plus the dependency-light Python 3.6 gate.
+# - ``ci/build.gitlab-ci.yml`` -- sdist/wheel build on top of green tests.
+#
+# Job behaviour is intentionally identical to the previous monolithic file:
+# this realignment only changes *where* jobs are defined, not *what* they do.
+# Every job body stays a thin wrapper around a Makefile target so GitHub
+# Actions and GitLab CI remain behaviourally aligned; see docs/ci-structure.md.
+
+image: python:3.12.3-bookworm
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 stages:
   - test
   - build
 
-modern-python:
-  image: python:3.12.3-bookworm
-  stage: test
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make git
-    - make ci-deps PYTHON=python
-    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
-    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
-    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
-  script:
-    - make gitlab-ci PYTHON=python
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate/
-
-almalinux-python36:
-  image: almalinux:8
-  stage: test
-  before_script:
-    - dnf -y install make findutils
-    - dnf -y install python36
-  script:
-    - |
-      PYTHON_BIN="$(command -v python3.6)"
-      "$PYTHON_BIN" --version
-      make compat-py36 PYTHON="$PYTHON_BIN"
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate-py36/
-
-build:
-  image: python:3.12.3-bookworm
-  stage: build
-  needs:
-    - modern-python
-    - almalinux-python36
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make
-  script:
-    - make gitlab-build PYTHON=python
-  artifacts:
-    paths:
-      - dist/
+include:
+  - local: ci/test.gitlab-ci.yml
+  - local: ci/build.gitlab-ci.yml

--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,4 @@
+## Summary
+## Related
+Refs #
+## Validation

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help all rerun clean ci-deps test coverage sample-gate backend-validation backend-colour-artifacts render-backends trace-export-validation test-pbs-samples test-slurm-samples fortifications ruff-check lint lint-fix format-check format-fix compat-py36 ci github-ci gitlab-ci build github-build gitlab-build dist version confirm
+.PHONY: help all rerun clean ci-deps test coverage coverage-xml sample-gate backend-validation backend-colour-artifacts render-backends trace-export-validation test-pbs-samples test-slurm-samples fortifications repo-sanity code-quality license-report ruff-check lint lint-fix format-check format-fix compat-py36 ci nightly-ci github-ci gitlab-ci build github-build gitlab-build dist version confirm
 
 PYTHON ?= python3
 PIP ?= $(PYTHON) -m pip
@@ -17,6 +17,10 @@ PBS_OUTPUT_DIR ?= /tmp/qtop-pbs-rendered
 SLURM_SAMPLES_DIR ?= tests/plugins/slurm_samples
 SLURM_OUTPUT_DIR ?= /tmp/qtop-slurm-rendered
 FORTIFY_BASE_REF ?= origin/develop
+COVERAGE_XML ?= artifacts/coverage/coverage.xml
+REPO_SANITY_DIR ?= artifacts/repo-sanity
+CODE_QUALITY_JSON ?= artifacts/code-quality/gl-code-quality-report.json
+LICENSE_DIR ?= artifacts/license
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -40,6 +44,13 @@ test: ## Run the Python test suite
 coverage: ## Run tests with coverage.py and print a terminal report
 	$(PYTHON) -m coverage run -m pytest
 	$(PYTHON) -m coverage report
+
+coverage-xml: ## Run tests under coverage.py and write a Cobertura XML report (GitLab/Codecov ready)
+	$(PYTHON) -m coverage run -m pytest
+	$(PYTHON) -m coverage report
+	@mkdir -p $(dir $(COVERAGE_XML))
+	$(PYTHON) -m coverage xml -o $(COVERAGE_XML)
+	@echo "wrote $(COVERAGE_XML)"
 
 sample-gate: ## Run fast committed PBS/SGE/Slurm/OAR/demo qtop sample gates
 	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)
@@ -74,6 +85,21 @@ test-slurm-samples: ## Run Slurm parser tests and render committed Slurm samples
 fortifications: ## Check diff health and reject eval() call sites
 	$(PYTHON) tools/fortifications.py --base-ref $(FORTIFY_BASE_REF)
 
+repo-sanity: ## Audit the full tracked tree for bidi/invisible/confusable characters (text trust, qtop/qtop#488)
+	$(PYTHON) tools/repo_sanity.py --report-dir $(REPO_SANITY_DIR)
+
+code-quality: ## Emit GitLab Code Quality JSON from ruff (upstream CodeClimate template is deprecated)
+	@mkdir -p $(dir $(CODE_QUALITY_JSON))
+	$(PYTHON) -m ruff check --output-format gitlab --exit-zero . > $(CODE_QUALITY_JSON)
+	@echo "wrote $(CODE_QUALITY_JSON)"
+
+license-report: ## Report licenses of the pinned CI dependency set (pip-licenses, pinned in-job)
+	$(PIP) install pip-licenses==5.0.0
+	@mkdir -p $(LICENSE_DIR)
+	$(PYTHON) -m piplicenses --format=markdown --with-urls > $(LICENSE_DIR)/ci-dependencies.md
+	$(PYTHON) -m piplicenses --format=json > $(LICENSE_DIR)/ci-dependencies.json
+	@echo "wrote $(LICENSE_DIR)"
+
 ruff-check: ## Run ruff against the source tree
 	$(PYTHON) -m ruff check .
 
@@ -99,6 +125,8 @@ ci: test backend-validation lint ruff-check format-check ## Run the shared local
 github-ci: ci ## GitHub Actions entry point for test validation
 
 gitlab-ci: ci ## GitLab CI entry point for test validation
+
+nightly-ci: test backend-validation ## Git-free validation path for nightly matrix lanes (interpreter compatibility, qtop/qtop#488)
 
 build: ci-deps ## Build source and wheel distributions with pinned CI build deps
 	$(PYTHON) -m build --no-isolation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtop [![build-qtop](https://github.com/qtop/qtop/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/qtop/qtop/actions/workflows/build.yml) ![python versions](https://img.shields.io/badge/python-3.x-blue.svg)
+# qtop [![build-qtop](https://github.com/qtop/qtop/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/qtop/qtop/actions/workflows/build.yml) ![python versions](https://img.shields.io/badge/python-3.x-blue.svg) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/qtop/qtop/badge)](https://scorecard.dev/viewer/?uri=github.com/qtop/qtop)
 
 qtop: the fast text mode way to monitor your cluster's utilization and
 status; the time has come to take back control of your cluster's

--- a/ci/build.gitlab-ci.yml
+++ b/ci/build.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/ci/build.gitlab-ci.yml
+++ b/ci/build.gitlab-ci.yml
@@ -1,0 +1,29 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Build concern: package the sdist/wheel once the test concern is green.
+#
+# ``make gitlab-build`` wraps ``python -m build --no-isolation`` with the
+# pinned CI dependencies from requirements-ci.txt, so the artefacts produced
+# here match what a contributor builds locally with the same Makefile target.
+
+build:
+  image: python:3.12.3-bookworm
+  stage: build
+  needs:
+    - modern-python
+    - almalinux-python36
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make gitlab-build PYTHON=python
+  artifacts:
+    paths:
+      - dist/

--- a/ci/coverage.gitlab-ci.yml
+++ b/ci/coverage.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/ci/coverage.gitlab-ci.yml
+++ b/ci/coverage.gitlab-ci.yml
@@ -1,0 +1,41 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Coverage concern (#488): Cobertura-style publishing, GitLab flavour.
+#
+# ``make coverage`` already does the heavy lifting (the #488 hint is right);
+# ``make coverage-xml`` only adds the Cobertura XML emission. GitLab picks
+# the percentage for the MR widget from the job log via ``coverage:`` and
+# renders per-line coverage in MR diffs from the Cobertura artifact.
+# Baseline at the time of writing: 139 tests, 45% total.
+#
+# The GitHub twin (.github/workflows/coverage.yml) uploads the same XML to
+# Codecov, so both forges read one Makefile target.
+
+coverage-cobertura:
+  stage: test
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+    - make ci-deps PYTHON=python
+  script:
+    - make coverage-xml PYTHON=python
+  coverage: '/TOTAL.+ ([0-9]{1,3}%)/'
+  artifacts:
+    when: always
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: artifacts/coverage/coverage.xml
+    paths:
+      - artifacts/coverage/

--- a/ci/nightly-matrix.gitlab-ci.yml
+++ b/ci/nightly-matrix.gitlab-ci.yml
@@ -1,0 +1,140 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Nightly concern: interpreter/distro compatibility matrix (#488).
+#
+# 35 lanes covering CPython 3.6 through 3.15-rc plus PyPy across Debian,
+# Ubuntu, AlmaLinux, Rocky, Fedora, openSUSE, Amazon Linux and Arch, all
+# routed through ci/scripts/matrix_lane.sh and the Makefile contract. The
+# lane list mirrors .github/workflows/nightly-matrix.yml lane-for-lane
+# (same order, same fields) so both forges watch the same surface.
+#
+# Activation (one-time, GitLab UI): Build > Pipeline schedules > New schedule
+#   - interval pattern: 30 2 * * *
+#   - add variable NIGHTLY_MATRIX=1
+# A manual web-triggered pipeline with NIGHTLY_MATRIX=1 runs the same lanes
+# on demand. Regular branch/MR pipelines never run these jobs.
+#
+# Stable lanes gate the pipeline; experimental lanes (prerelease
+# interpreters, EOL-archived or rolling distros) are allow_failure.
+
+.nightly-lane-base:
+  stage: nightly
+  image: $IMAGE
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY_MATRIX == "1"'
+    - if: '$CI_PIPELINE_SOURCE == "web" && $NIGHTLY_MATRIX == "1"'
+  script:
+    - bash ci/scripts/matrix_lane.sh "$FAMILY" "$PKGS" "$PYBIN" "$TARGET"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 1 week
+
+nightly-matrix:
+  extends: .nightly-lane-base
+  parallel:
+    matrix:
+      - IMAGE: 'python:3.7-bullseye'
+        FAMILY: pythonimg
+        PKGS: '-'
+        PYBIN: python
+        TARGET: compat-py36
+      - IMAGE: ['python:3.8-bullseye', 'python:3.9-bookworm', 'python:3.10-bookworm', 'python:3.11-bookworm', 'python:3.12-bookworm', 'python:3.13-bookworm', 'python:3.14-bookworm']
+        FAMILY: pythonimg
+        PKGS: '-'
+        PYBIN: python
+        TARGET: ci
+      - IMAGE: ['ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:25.10', 'debian:bullseye', 'debian:bookworm', 'debian:trixie']
+        FAMILY: debian
+        PKGS: 'python3,python3-venv,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: ['almalinux:8', 'rockylinux:8']
+        FAMILY: rhel
+        PKGS: 'python36'
+        PYBIN: python3.6
+        TARGET: compat-py36
+      - IMAGE: ['almalinux:8', 'almalinux:9']
+        FAMILY: rhel
+        PKGS: 'python3.12,python3.12-pip'
+        PYBIN: python3.12
+        TARGET: ci
+      - IMAGE: ['almalinux:9', 'rockylinux:9']
+        FAMILY: rhel
+        PKGS: 'python3,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: 'rockylinux:9'
+        FAMILY: rhel
+        PKGS: 'python3.11,python3.11-pip'
+        PYBIN: python3.11
+        TARGET: ci
+      - IMAGE: ['fedora:41', 'fedora:42']
+        FAMILY: fedora
+        PKGS: 'python3,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: 'opensuse/leap:15.6'
+        FAMILY: suse
+        PKGS: 'python3'
+        PYBIN: python3
+        TARGET: compat-py36
+      - IMAGE: 'opensuse/leap:15.6'
+        FAMILY: suse
+        PKGS: 'python311,python311-pip'
+        PYBIN: python3.11
+        TARGET: ci
+      - IMAGE: 'amazonlinux:2023'
+        FAMILY: amazon
+        PKGS: 'python3,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: 'amazonlinux:2023'
+        FAMILY: amazon
+        PKGS: 'python3.12,python3.12-pip'
+        PYBIN: python3.12
+        TARGET: ci
+
+nightly-matrix-experimental:
+  extends: .nightly-lane-base
+  allow_failure: true
+  parallel:
+    matrix:
+      - IMAGE: 'python:3.6-buster'
+        FAMILY: pythonimg
+        PKGS: '-'
+        PYBIN: python
+        TARGET: compat-py36
+      - IMAGE: 'python:3.15-rc'
+        FAMILY: pythonimg
+        PKGS: '-'
+        PYBIN: python
+        TARGET: ci
+      - IMAGE: ['pypy:3.9', 'pypy:3.10', 'pypy:3.11']
+        FAMILY: pypyimg
+        PKGS: '-'
+        PYBIN: pypy3
+        TARGET: ci
+      - IMAGE: 'ubuntu:20.04'
+        FAMILY: debian
+        PKGS: 'python3,python3-venv,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: 'debian:sid'
+        FAMILY: debian
+        PKGS: 'python3,python3-venv,python3-pip'
+        PYBIN: python3
+        TARGET: ci
+      - IMAGE: 'archlinux:base'
+        FAMILY: arch
+        PKGS: 'python,python-pip'
+        PYBIN: python
+        TARGET: ci

--- a/ci/nightly-matrix.gitlab-ci.yml
+++ b/ci/nightly-matrix.gitlab-ci.yml
@@ -42,12 +42,14 @@ nightly-matrix:
   extends: .nightly-lane-base
   parallel:
     matrix:
-      - IMAGE: 'python:3.7-bullseye'
+      # 3.7 and 3.8 run the dependency-light gate: the pinned CI set needs
+      # >=3.9 (importlib-metadata==8.7.1), discovered by the first live run.
+      - IMAGE: ['python:3.7-bullseye', 'python:3.8-bullseye']
         FAMILY: pythonimg
         PKGS: '-'
         PYBIN: python
         TARGET: compat-py36
-      - IMAGE: ['python:3.8-bullseye', 'python:3.9-bookworm', 'python:3.10-bookworm', 'python:3.11-bookworm', 'python:3.12-bookworm', 'python:3.13-bookworm', 'python:3.14-bookworm']
+      - IMAGE: ['python:3.9-bookworm', 'python:3.10-bookworm', 'python:3.11-bookworm', 'python:3.12-bookworm', 'python:3.13-bookworm', 'python:3.14-bookworm']
         FAMILY: pythonimg
         PKGS: '-'
         PYBIN: python
@@ -127,7 +129,7 @@ nightly-matrix-experimental:
         FAMILY: debian
         PKGS: 'python3,python3-venv,python3-pip'
         PYBIN: python3
-        TARGET: ci
+        TARGET: compat-py36
       - IMAGE: 'debian:sid'
         FAMILY: debian
         PKGS: 'python3,python3-venv,python3-pip'

--- a/ci/nightly-matrix.gitlab-ci.yml
+++ b/ci/nightly-matrix.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -16,7 +14,7 @@
 # (same order, same fields) so both forges watch the same surface.
 #
 # Activation (one-time, GitLab UI): Build > Pipeline schedules > New schedule
-#   - interval pattern: 30 2 * * *
+#   - interval pattern: 20 4 * * *
 #   - add variable NIGHTLY_MATRIX=1
 # A manual web-triggered pipeline with NIGHTLY_MATRIX=1 runs the same lanes
 # on demand. Regular branch/MR pipelines never run these jobs.

--- a/ci/scorecard.gitlab-ci.yml
+++ b/ci/scorecard.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/ci/scorecard.gitlab-ci.yml
+++ b/ci/scorecard.gitlab-ci.yml
@@ -1,0 +1,37 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Scorecard concern (#488): the GitLab twin of
+# .github/workflows/scorecard.yml. Runs the OpenSSF Scorecard CLI against
+# the canonical GitHub repository on a schedule, so a pegged GitLab mirror
+# reports the same supply-chain health numbers as the primary forge.
+#
+# Activation (one-time, GitLab UI): add a CI/CD variable
+# ``GITHUB_AUTH_TOKEN`` (a read-only GitHub token; no scopes needed for
+# public data) and create a pipeline schedule with ``SCORECARD=1``.
+# Baseline via the public Scorecard REST API, 2026-06-08: score 7.1.
+
+openssf-scorecard:
+  stage: security
+  image:
+    name: gcr.io/openssf/scorecard:stable
+    entrypoint: [""]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $SCORECARD == "1"'
+    - if: '$CI_PIPELINE_SOURCE == "web" && $SCORECARD == "1"'
+  allow_failure: true
+  script:
+    - mkdir -p artifacts/scorecard
+    - /scorecard --repo=github.com/qtop/qtop --format=json --show-details > artifacts/scorecard/scorecard.json
+    - /scorecard --repo=github.com/qtop/qtop || true
+  artifacts:
+    when: always
+    paths:
+      - artifacts/scorecard/
+    expire_in: 4 weeks

--- a/ci/scripts/matrix_lane.sh
+++ b/ci/scripts/matrix_lane.sh
@@ -67,14 +67,17 @@ case "${FAMILY}" in
             make ca-certificates ${PKG_LIST}
         ;;
     rhel|fedora|amazon)
-        dnf -y install make findutils ${PKG_LIST}
+        # "which" is required by qtop scheduler autodetection
+        # (qtop_py/qtop.py calls /usr/bin/which) and is absent from minimal
+        # images; discovered by the first live run of this matrix.
+        dnf -y install make findutils which ${PKG_LIST}
         ;;
     suse)
         zypper --non-interactive refresh
-        zypper --non-interactive install make ${PKG_LIST}
+        zypper --non-interactive install make which ${PKG_LIST}
         ;;
     arch)
-        pacman -Sy --noconfirm make ${PKG_LIST}
+        pacman -Sy --noconfirm make which ${PKG_LIST}
         ;;
     *)
         echo "unknown family: ${FAMILY}" >&2

--- a/ci/scripts/matrix_lane.sh
+++ b/ci/scripts/matrix_lane.sh
@@ -73,7 +73,9 @@ case "${FAMILY}" in
         dnf -y install make findutils which ${PKG_LIST}
         ;;
     suse)
-        zypper --non-interactive refresh
+        # refresh is best-effort: openSUSE mirrors intermittently return
+        # partial-refresh errors (exit 4); install fails on its own merit.
+        zypper --non-interactive refresh || true
         zypper --non-interactive install make which ${PKG_LIST}
         ;;
     arch)

--- a/ci/scripts/matrix_lane.sh
+++ b/ci/scripts/matrix_lane.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Shared nightly-matrix lane runner, used identically by GitHub Actions
+# (.github/workflows/nightly-matrix.yml) and GitLab CI
+# (ci/nightly-matrix.gitlab-ci.yml) so the >30 distro x python lanes stay
+# DRY across forges (#488). The lane purpose is interpreter/runtime
+# compatibility -- diff-health checks stay in the merge-request pipelines,
+# which is why lanes call git-free Makefile targets only:
+#
+#   ci          -> make nightly-ci   (pinned CI deps, pytest, sample gates)
+#   compat-py36 -> make compat-py36  (dependency-light stdlib-only gate)
+#
+# Usage: matrix_lane.sh FAMILY PKGS PYBIN TARGET
+#   FAMILY  pythonimg|pypyimg|debian|rhel|fedora|suse|arch|amazon
+#   PKGS    comma-separated distro packages to install, or "-" for none
+#   PYBIN   interpreter to hand to make as PYTHON=...
+#   TARGET  ci|compat-py36
+
+set -euo pipefail
+
+FAMILY="${1:?FAMILY required}"
+PKGS="${2:?PKGS required (use - for none)}"
+PYBIN="${3:?PYBIN required}"
+TARGET="${4:?TARGET required (ci|compat-py36)}"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+PKG_LIST=""
+if [ "${PKGS}" != "-" ]; then
+    PKG_LIST="$(printf '%s' "${PKGS}" | tr ',' ' ')"
+fi
+
+fix_eol_apt_sources() {
+    # Debian buster and Ubuntu focal live on archive mirrors after EOL; keep
+    # those lanes runnable so the matrix can still exercise old interpreters.
+    if grep -qs 'buster' /etc/os-release && [ -f /etc/apt/sources.list ]; then
+        sed -i \
+            -e 's|deb.debian.org/debian-security|archive.debian.org/debian-security|g' \
+            -e 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' \
+            -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+            -e '/buster-updates/d' /etc/apt/sources.list || true
+        APT_OPTS="-o Acquire::Check-Valid-Until=false"
+    fi
+    if grep -qs 'focal' /etc/os-release && ! apt-get update >/dev/null 2>&1; then
+        sed -i \
+            -e 's|archive.ubuntu.com/ubuntu|old-releases.ubuntu.com/ubuntu|g' \
+            -e 's|security.ubuntu.com/ubuntu|old-releases.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list || true
+    fi
+}
+
+APT_OPTS=""
+log "lane setup: family=${FAMILY} pkgs=${PKGS} python=${PYBIN} target=${TARGET}"
+case "${FAMILY}" in
+    pythonimg|pypyimg|debian)
+        fix_eol_apt_sources
+        apt-get update ${APT_OPTS}
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            make ca-certificates ${PKG_LIST}
+        ;;
+    rhel|fedora|amazon)
+        dnf -y install make findutils ${PKG_LIST}
+        ;;
+    suse)
+        zypper --non-interactive refresh
+        zypper --non-interactive install make ${PKG_LIST}
+        ;;
+    arch)
+        pacman -Sy --noconfirm make ${PKG_LIST}
+        ;;
+    *)
+        echo "unknown family: ${FAMILY}" >&2
+        exit 2
+        ;;
+esac
+
+log "interpreter"
+command -v "${PYBIN}"
+"${PYBIN}" --version
+
+case "${TARGET}" in
+    ci)
+        # Official python/pypy images ship a writable pip; distro interpreters
+        # get an isolated venv so externally-managed-environment policies
+        # (PEP 668: Debian, Fedora, Arch) and root site-packages stay untouched.
+        if [ "${FAMILY}" = "pythonimg" ] || [ "${FAMILY}" = "pypyimg" ]; then
+            LANE_PY="${PYBIN}"
+        else
+            log "creating lane venv"
+            "${PYBIN}" -m venv /tmp/qtop-lane-venv
+            LANE_PY=/tmp/qtop-lane-venv/bin/python
+        fi
+        log "make ci-deps"
+        make ci-deps PYTHON="${LANE_PY}"
+        log "make nightly-ci"
+        make nightly-ci PYTHON="${LANE_PY}"
+        ;;
+    compat-py36)
+        log "make compat-py36"
+        make compat-py36 PYTHON="${PYBIN}"
+        ;;
+    *)
+        echo "unknown target: ${TARGET}" >&2
+        exit 2
+        ;;
+esac
+
+log "lane done: ${FAMILY} ${PYBIN} ${TARGET}"

--- a/ci/scripts/matrix_lane.sh
+++ b/ci/scripts/matrix_lane.sh
@@ -71,10 +71,19 @@ case "${FAMILY}" in
         dnf -y install make findutils ${PKG_LIST}
         ;;
     suse)
-        # refresh is best-effort: openSUSE mirrors intermittently return
-        # partial-refresh errors (exit 4); install fails on its own merit.
+        # openSUSE mirrors intermittently skip a repo, so zypper exits with an
+        # informational code (4 on refresh, 106 = repo-skipped on install) even
+        # though the packages install fine. Tolerate zypper's informational
+        # range (100-107) and let the interpreter check below be the real gate;
+        # a genuine "package not found" (104) still surfaces there / at build.
         zypper --non-interactive refresh || true
-        zypper --non-interactive install make ${PKG_LIST}
+        if zypper --non-interactive install make ${PKG_LIST}; then
+            :
+        else
+            rc=$?
+            [ "$rc" -ge 100 ] && [ "$rc" -le 107 ] || exit "$rc"
+            echo "note: zypper returned informational code $rc (repo skipped); continuing"
+        fi
         ;;
     arch)
         pacman -Sy --noconfirm make ${PKG_LIST}

--- a/ci/scripts/matrix_lane.sh
+++ b/ci/scripts/matrix_lane.sh
@@ -2,9 +2,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -67,19 +65,19 @@ case "${FAMILY}" in
             make ca-certificates ${PKG_LIST}
         ;;
     rhel|fedora|amazon)
-        # "which" is required by qtop scheduler autodetection
-        # (qtop_py/qtop.py calls /usr/bin/which) and is absent from minimal
-        # images; discovered by the first live run of this matrix.
-        dnf -y install make findutils which ${PKG_LIST}
+        # No "which" package needed: qtop autodetection now uses stdlib
+        # shutil.which() (qtop_py/qtop.py), so the external binary the first
+        # live run tripped over on minimal images is no longer a dependency.
+        dnf -y install make findutils ${PKG_LIST}
         ;;
     suse)
         # refresh is best-effort: openSUSE mirrors intermittently return
         # partial-refresh errors (exit 4); install fails on its own merit.
         zypper --non-interactive refresh || true
-        zypper --non-interactive install make which ${PKG_LIST}
+        zypper --non-interactive install make ${PKG_LIST}
         ;;
     arch)
-        pacman -Sy --noconfirm make which ${PKG_LIST}
+        pacman -Sy --noconfirm make ${PKG_LIST}
         ;;
     *)
         echo "unknown family: ${FAMILY}" >&2

--- a/ci/security.gitlab-ci.yml
+++ b/ci/security.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/ci/security.gitlab-ci.yml
+++ b/ci/security.gitlab-ci.yml
@@ -1,0 +1,104 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Security concern (#488): what works out of the box on GitLab, explored
+# honestly. Template jobs land in the ``test`` stage (their own default);
+# custom jobs land in ``security``.
+#
+# Out-of-the-box status by feature (gitlab.com, June 2026):
+#
+# - SAST .................. Free tier. For Python the template dispatches the
+#                           Semgrep-based analyzer, which also satisfies the
+#                           "Semgrep analyzer" exploration point. Local
+#                           baseline: 4 ERROR findings (3x use-defused-xml,
+#                           1x tainted subprocess args); see
+#                           docs/secure-coding-pyscg.md.
+# - Secret Detection ...... Free tier. Local gitleaks baseline: clean. Expect
+#                           one recurring false positive on a high-entropy
+#                           sample job ID in tools/validate_pbs_samples.py.
+# - SAST IaC (KICS) ....... Free tier; covers the CI yaml itself.
+# - Dependency Scanning ... Job runs on all tiers; the vulnerability UI needs
+#                           Ultimate. Local pip-audit baseline on the pinned
+#                           CI set: pip 24.0 (5 advisories), pytest 8.2.2 (1).
+# - License Compliance .... The old License-Scanning template was removed
+#                           upstream (GitLab 16.3); license data now rides on
+#                           Dependency Scanning (Ultimate). The free-tier
+#                           ``license-report`` job below keeps an honest
+#                           equivalent via pip-licenses.
+# - Code Quality .......... The CodeClimate-based template is deprecated
+#                           upstream; the ``code-quality`` job below emits
+#                           the same report format natively from ruff.
+# - GitLab Advanced SAST .. Ultimate only. Enable by uncommenting
+#                           GITLAB_ADVANCED_SAST_ENABLED below on such a tier.
+# - DAST .................. Needs a running web target; gated on the
+#                           container/registry checklist item, which this
+#                           slice does not claim.
+# - Container Scanning .... Same gate as DAST; noted for completeness.
+
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Jobs/SAST-IaC.gitlab-ci.yml
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+  - template: Jobs/Dependency-Scanning.gitlab-ci.yml
+
+variables:
+  SAST_IMAGE_SUFFIX: ""
+  # GITLAB_ADVANCED_SAST_ENABLED: "true"   # Ultimate tier only
+
+code-quality:
+  stage: security
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+    - make ci-deps PYTHON=python
+  script:
+    - make code-quality PYTHON=python
+  artifacts:
+    when: always
+    reports:
+      codequality: artifacts/code-quality/gl-code-quality-report.json
+    paths:
+      - artifacts/code-quality/
+
+license-report:
+  stage: security
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+    - make ci-deps PYTHON=python
+  script:
+    - make license-report PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/license/
+
+repo-sanity:
+  stage: security
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make repo-sanity PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/repo-sanity/

--- a/ci/test.gitlab-ci.yml
+++ b/ci/test.gitlab-ci.yml
@@ -1,9 +1,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##

--- a/ci/test.gitlab-ci.yml
+++ b/ci/test.gitlab-ci.yml
@@ -1,0 +1,54 @@
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+# Test concern: merge-request/branch validation.
+#
+# - ``modern-python`` -- the full shared validation path (``make gitlab-ci``:
+#   pytest, scheduler sample gates, ruff, fortifications, format checks) on the
+#   pinned modern interpreter. ``FORTIFY_BASE_REF`` follows the MR target branch
+#   so diff-health checks compare against the right base.
+# - ``almalinux-python36`` -- dependency-light Python 3.6 compatibility gate on
+#   AlmaLinux 8 (``make compat-py36``), matching the python3.6/rhel8 floor that
+#   several production clusters still run (see CONTRIBUTING.md).
+#
+# Both jobs are thin wrappers around Makefile targets so the same validation
+# can be reproduced locally and on GitHub Actions without divergence.
+
+modern-python:
+  image: python:3.12.3-bookworm
+  stage: test
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make git
+    - make ci-deps PYTHON=python
+    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
+    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
+  script:
+    - make gitlab-ci PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+
+almalinux-python36:
+  image: almalinux:8
+  stage: test
+  before_script:
+    - dnf -y install make findutils
+    - dnf -y install python36
+  script:
+    - |
+      PYTHON_BIN="$(command -v python3.6)"
+      "$PYTHON_BIN" --version
+      make compat-py36 PYTHON="$PYTHON_BIN"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate-py36/

--- a/docs/ci-structure.md
+++ b/docs/ci-structure.md
@@ -1,0 +1,55 @@
+# CI structure
+
+qtop's GitLab pipeline follows the layout of
+[pvgis](https://code.europa.eu/pvgis/pvgis/): a thin root `.gitlab-ci.yml`
+holding only shared defaults (`image`, `variables`, `stages`) and one
+`include: local:` line per concern, with the actual jobs living in
+per-concern child files under `ci/`. CI-only helper scripts go to
+`ci/scripts/`. GitLab-side templates (merge requests) live under `.gitlab/`,
+mirroring `.github/`.
+
+```
+.gitlab-ci.yml              # root: defaults + stages + includes, no jobs
+ci/
+  test.gitlab-ci.yml        # test concern: modern python + py3.6/rhel8 gate
+  build.gitlab-ci.yml       # build concern: sdist/wheel
+  scripts/                  # CI-only helpers (never on the runtime path)
+.gitlab/
+  merge_request_templates/  # mirrors .github/PULL_REQUEST_TEMPLATE.md
+```
+
+## The Makefile contract
+
+Every CI job -- on either forge -- is a thin wrapper around a Makefile target.
+The Makefile is the single source of truth for *what* validation means; the
+CI files only decide *where and when* it runs. This keeps GitHub Actions and
+GitLab CI behaviourally identical and lets contributors reproduce any CI
+failure locally with the same command.
+
+| Concern | Makefile target | GitHub Actions | GitLab CI |
+|---|---|---|---|
+| Full validation | `make github-ci` / `make gitlab-ci` | `.github/workflows/build.yml` | `ci/test.gitlab-ci.yml` (`modern-python`) |
+| Python 3.6 / RHEL8 floor | `make compat-py36` | `.github/workflows/build.yml` (`almalinux-python36`) | `ci/test.gitlab-ci.yml` (`almalinux-python36`) |
+| Package build | `make github-build` / `make gitlab-build` | `.github/workflows/build.yml` (`build`) | `ci/build.gitlab-ci.yml` (`build`) |
+
+## Adding a new concern
+
+1. Create `ci/<concern>.gitlab-ci.yml` with a header comment explaining what
+   runs, when, and why (see existing child files for the expected register).
+2. Add any new stage to the root `stages:` list.
+3. Add `- local: ci/<concern>.gitlab-ci.yml` to the root `include:` list.
+4. If the concern introduces new validation logic, expose it as a Makefile
+   target first and keep the job body a one-line wrapper; put CI-only helper
+   scripts in `ci/scripts/`.
+
+## Why this layout
+
+- **Review isolation** -- security, matrix, coverage, and release changes stop
+  competing for the same monolithic file; diffs stay per-concern.
+- **GitLab linkage** ([#488](https://github.com/qtop/qtop/issues/488)) -- a
+  pegged GitLab mirror picks up the same pipeline unchanged, because nothing
+  in `ci/` assumes which forge triggered the run; everything routes through
+  the Makefile.
+- **Precedent** -- the structure is proven on
+  [code.europa.eu/pvgis/pvgis](https://code.europa.eu/pvgis/pvgis/), the
+  reference named in #488.

--- a/docs/gitlab-linkage-pilot.md
+++ b/docs/gitlab-linkage-pilot.md
@@ -1,0 +1,100 @@
+# GitLab linkage pilot: GitHub-first, GitLab-pegged
+
+Status: working model for #488. GitHub stays the collaboration home
+(issues, PRs, reviews, bounties); a pegged GitLab project adds the ci/cd,
+scanner and compliance machinery GitLab is better at. Contributors never
+have to leave GitHub for day-to-day work.
+
+## The model in one diagram
+
+```
+contributor PR --> github.com/qtop/qtop  (reviews, DCO, fortifications)
+                        |
+                        |  pull mirror (GitLab "CI/CD for external repo",
+                        |  default <= 5 min cadence on gitlab.com)
+                        v
+                gitlab.com/<space>/qtop  (pegged, read-only mirror)
+                        |
+            .gitlab-ci.yml + ci/*.gitlab-ci.yml run unchanged:
+            tests, build, SAST, secret detection, dependency
+            scanning, code quality, coverage, nightly matrix,
+            scorecard
+                        |
+                        v
+            commit status posted back to GitHub via the GitLab
+            GitHub integration -> shows as a check on the PR
+```
+
+## Why this split
+
+- GitHub: the existing community, the bounty workflow, familiar review UX.
+- GitLab: included security templates (SAST/Secret Detection/Dependency
+  Scanning run on the free tier), MR-widget coverage rendering from
+  Cobertura, pipeline schedules with per-schedule variables, and
+  regulated-environment controls -- without asking contributors to migrate.
+
+## Setting up the peg (account-side, one time)
+
+1. GitLab: New project -> "Run CI/CD for external repository" -> GitHub.
+   Authenticate with a token that can read qtop and write commit statuses.
+2. GitLab pulls the repo and keeps mirroring (pull mirroring; on
+   gitlab.com mirrors update on push events or at the platform cadence).
+3. The mirrored ``.gitlab-ci.yml`` (this repository, after the pvgis-style
+   realign) runs as-is: nothing in ``ci/`` assumes which forge triggered
+   the pipeline, because every job wraps a Makefile target.
+4. Add two pipeline schedules: nightly with ``NIGHTLY_MATRIX=1`` (35-lane
+   matrix) and weekly with ``SCORECARD=1`` plus a read-only
+   ``GITHUB_AUTH_TOKEN`` variable.
+5. Enable the GitHub integration (Settings -> Integrations -> GitHub) so
+   pipeline results appear as commit statuses on GitHub PRs.
+
+A personal namespace works for the experiment (the issue allows it);
+moving the peg under a project-owned GitLab group later is a settings
+change, not a migration.
+
+## What contributors see
+
+Nothing new is required of them: same fork-and-PR flow, same DCO, same
+Makefile commands locally. GitLab appears only as an extra status check
+("gitlab/pipeline") plus richer security/coverage data the maintainers can
+consult. Contributors who *want* the GitLab view get it read-only at the
+mirror URL.
+
+## What works out of the box (explored for #488)
+
+| Feature | OOTB on the pegged mirror | Notes |
+|---|---|---|
+| Pipelines from mirrored repo | yes | external-repo CI/CD project type |
+| SAST (Semgrep-based for Python) | yes, free tier | 4 local baseline findings; see docs/secure-coding-pyscg.md |
+| Secret Detection | yes, free tier | one known sample-ID false positive expected |
+| SAST IaC (KICS) | yes, free tier | scans the ci yaml itself |
+| Dependency Scanning | job runs; findings UI needs Ultimate | local pip-audit baseline: 6 advisories in 2 pinned CI deps |
+| License Compliance | template removed upstream | free-tier pip-licenses job kept instead |
+| Code Quality | CodeClimate template deprecated | ruff emits the report format natively |
+| Coverage MR widget | yes | Cobertura artifact + TOTAL regex |
+| Advanced SAST | no (Ultimate) | variable stub left in ci/security.gitlab-ci.yml |
+| DAST / Container Scanning | no (needs deployed target/registry) | gated on the unclaimed registry item |
+| Pipeline schedules | yes | nightly matrix + weekly scorecard |
+| Status back to GitHub PRs | yes | GitHub integration |
+
+## Limits and honesty
+
+- A pull mirror lags push events by the mirroring cadence; it is a
+  *reporting* surface, not a second source of truth. Merges happen only on
+  GitHub.
+- MR-only features (coverage widget on MRs, MR security widget) light up
+  fully when GitLab sees merge requests; for mirrored PRs the practical
+  surface is branch pipelines plus commit statuses. The configs here run
+  in both modes (``rules`` cover MR events and branch pushes) so the same
+  files serve a future deeper integration unchanged.
+- Scanner findings views vary by tier; everything above is stated against
+  the free tier unless marked Ultimate.
+
+## Relation to the #488 checklist
+
+This document covers the contributor-benefit model item and records the
+out-of-the-box exploration; the pegged-repo creation itself is account-side
+and intentionally not claimed as completed inside this repository. SBOM
+and supply-chain next steps live in docs/supply-chain-sbom.md; secure-coding
+alignment lives in docs/secure-coding-pyscg.md; the CI layout contract
+lives in docs/ci-structure.md.

--- a/docs/secure-coding-pyscg.md
+++ b/docs/secure-coding-pyscg.md
@@ -1,0 +1,144 @@
+# Secure Coding Guide for Python (PySCG) alignment
+
+Status: proposal for maintainer decision (#488). Nothing in this document
+changes runtime behaviour; it maps real scanner findings on the qtop tree to
+the OpenSSF [Secure Coding Guide for Python](https://github.com/ossf/wg-best-practices-os-developers/tree/main/docs/Secure-Coding-Guide-for-Python)
+(first release, 2026-05-12) and proposes prioritised next steps.
+
+## Method
+
+All tools ran locally against a clean `develop` checkout (2026-06-11), plus
+the public OpenSSF Scorecard API. Full machine-readable reports live outside
+the main repo per CONTRIBUTING.md (artifact-light policy). Reproduce with:
+
+| Tool | Command | Result |
+|---|---|---|
+| bandit 1.8.x | `bandit -r qtop_py tools` | 54 findings: 51 low, 3 medium |
+| semgrep (`p/python`, `p/security-audit`) | `semgrep scan --config p/python --config p/security-audit qtop_py tools` | 4 findings, all ERROR severity |
+| pip-audit | `pip-audit -r requirements-ci.txt` | 6 known vulnerabilities in 2 pinned CI deps |
+| gitleaks 8.24 | `gitleaks dir .` | no leaks |
+| detect-secrets | `detect-secrets scan --all-files` | 3 candidates, all false positives |
+| repo-sanity (new) | `make repo-sanity` | 0 critical, 0 warning, 4 expected-fixture info |
+| OpenSSF Scorecard | public REST API, 2026-06-08 snapshot | score 7.1 |
+
+## Findings mapped to PySCG
+
+### 1. Untrusted XML parsing -- highest priority
+
+`xml.etree.ElementTree` parses scheduler output directly:
+`qtop_py/plugins/sge.py:19,31` and `qtop_py/qtop.py:836` (bandit B314/B405,
+semgrep `use-defused-xml*`, 3 hits). PySCG's first release has **no CWE-611
+(XML external entity) page yet**, so this is both a qtop action item and an
+upstream-contribution opportunity.
+
+Context that bounds the risk: the XML comes from scheduler CLIs or files in
+the cluster operator's trust domain, not from anonymous remote input, and
+CPython's ElementTree does not resolve external entities by default. The
+residual exposure is entity-expansion denial of service against a monitoring
+tool, plus any future code path that feeds less-trusted XML.
+
+Proposed next steps, compatible with qtop's zero-runtime-dependency rule
+(CONTRIBUTING.md):
+1. Document the XML trust boundary in the plugin docstrings.
+2. Add a guarded `defusedxml` import (used when present, stdlib fallback
+   otherwise) so hardened sites get protection without a new hard dependency.
+3. Contribute a CWE-611 page upstream to PySCG, citing this case study.
+
+### 2. Subprocess use -- core function, document the boundary
+
+15 findings (bandit B603 x14, B607 x1; semgrep tainted-env x1 at
+`qtop_py/qtop.py:2521`). Maps to PySCG `04_neutralization/pyscg-0009`
+"Prevent OS Command Injection" (CWE-78). Invoking scheduler CLIs (qstat,
+qhost, sinfo, oarnodes) IS qtop's job; what PySCG asks for is hygiene around
+it, most of which qtop already has: list-form argv everywhere, no
+`shell=True` anywhere in the tree (bandit B602: zero hits).
+
+Proposed next steps:
+1. Keep the existing list-form discipline as a stated rule (lint note).
+2. Commands and arguments derive from `qtopconf.yaml`, which is in the
+   operator's trust domain -- state this explicitly in the config docs.
+3. The single partial-path call sites (`git` in `tools/`) are dev/CI-side
+   tools resolving from PATH by design; annotate rather than change.
+
+### 3. Pseudo-random use -- acceptable, scope it
+
+bandit B311 x16, all in `qtop_py/plugins/demo.py` and the anonymisation
+helpers. Maps to PySCG `09_cryptography/pyscg-0038` "Use Sufficiently Random
+Values" (CWE-330), which targets *cryptographic* contexts. qtop's usage
+generates demo/synthetic data and display anonymisation, not key material.
+
+Proposed next steps: declare the non-cryptographic intent where `random` is
+imported; if anonymisation is ever meant to be unlinkable across runs,
+switch those call sites to `secrets`/`SystemRandom` (stdlib, no new deps).
+
+### 4. Asserts on runtime paths
+
+bandit B101 x12 (e.g. `qtop_py/fileutils.py:77,144`,
+`qtop_py/plugins/oar.py:108,112`). Maps to PySCG
+`08_coding_standards/pyscg-0037` (CWE-617): asserts vanish under `python -O`,
+so they must not guard runtime invariants. Proposed next step: convert
+runtime-path asserts to explicit `raise` of qtop's existing error types;
+keep asserts in tests.
+
+### 5. Hardcoded temp paths (dev tools only)
+
+bandit B108 x2 (`tools/validate_pbs_samples.py:51`,
+`tools/validate_slurm_samples.py:44`): default output dirs under `/tmp`.
+PySCG first release has no CWE-377 page (second upstream-contribution
+candidate). Proposed next step: default to `tempfile.mkdtemp()` while
+keeping the CLI flag override; CI-side only, low risk.
+
+### 6. Dependency currency (pinned CI set)
+
+pip-audit on `requirements-ci.txt`: `pip 24.0` carries 5 advisories
+(PYSEC-2026-196, GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp,
+GHSA-58qw-9mgm-455v, GHSA-jp4c-xjxw-mgf9) and `pytest 8.2.2` one
+(GHSA-6w46-j5rx-g56g). These are CI-only dependencies -- the qtop runtime
+deliberately has none -- so exposure is the CI environment, not clusters.
+Proposed next steps: bump the two pins in a dedicated PR after the matrix
+proves them green; keep the Dependency Scanning job (added in this change)
+watching the set continuously.
+
+### 7. Text and encoding trust
+
+Maps to PySCG `02_encoding_and_strings` (pyscg-0043/0044/0045, CWE-175/180/176).
+qtop already enforces ASCII-only diffs (`tools/fortifications.py`); this
+change adds `make repo-sanity` (`tools/repo_sanity.py`) auditing the *entire
+tracked tree* for Trojan-Source bidi controls, zero-width/invisible
+characters, unicode line separators, C0/C1 controls and homoglyph-prone
+letters. Current tree result: **0 critical, 0 warning**; the only non-ASCII
+content is ANSI escape sequences inside declared terminal-output fixtures
+(94,990 + 57,434 + 1,418 ESC in the three `.ref` files plus 34 in
+`helpfile.txt`), aggregated as expected INFO. Detector correctness is proven
+by `tools/repo_sanity.py --selftest`, which plants five payload classes and
+shows caret-pointer proof of each detection.
+
+### 8. Secrets
+
+gitleaks: clean. detect-secrets: 3 candidates, all false positives (two
+cache CACHEDIR.TAG signatures outside the tracked tree and one high-entropy
+*sample job identifier* at `tools/validate_pbs_samples.py:22`). The GitLab
+Secret Detection template (added in this change) takes over continuously;
+expect and triage the same sample-ID false positive there.
+
+## Scorecard gap-to-action map (baseline 7.1, 2026-06-08)
+
+| Check | Score | Action in this change | Proposed follow-up |
+|---|---|---|---|
+| SAST | 0 | SAST templates + Semgrep-backed analyzer wired into GitLab CI; scorecard workflow on GitHub | expect uplift on next weekly cron |
+| Security-Policy | 0 | -- | add SECURITY.md (maintainer decision on contact channel) |
+| CII-Best-Practices | 0 | -- | register for the OpenSSF Best Practices badge |
+| Fuzzing | 0 | -- | atheris harness over the PBS/SGE/OAR parsers is a natural fit |
+| Packaging | -1 | -- | publish to PyPI via Trusted Publishing (see docs/supply-chain-sbom.md) |
+| Signed-Releases | -1 | -- | release attestations (see docs/supply-chain-sbom.md) |
+| Pinned-Dependencies | 10 | keep | -- |
+| Token-Permissions | 10 | new workflows follow least privilege | -- |
+| Dangerous-Workflow | 10 | new workflows keep this clean | -- |
+
+## Priorities
+
+1. P1: XML hardening decision (finding 1) and the two CI-dep pin bumps
+   (finding 6).
+2. P2: assert conversion (finding 4), SECURITY.md, temp-path fix (finding 5).
+3. P3: random-use annotations (finding 3), PySCG upstream contributions
+   (CWE-611, CWE-377 pages), fuzzing harness, Best Practices badge.

--- a/docs/secure-coding-pyscg.md
+++ b/docs/secure-coding-pyscg.md
@@ -59,6 +59,13 @@ Proposed next steps:
    operator's trust domain -- state this explicitly in the config docs.
 3. The single partial-path call sites (`git` in `tools/`) are dev/CI-side
    tools resolving from PATH by design; annotate rather than change.
+4. Live-matrix discovery: scheduler autodetection shells out to a
+   *hardcoded* `/usr/bin/which` (`qtop_py/qtop.py:357`), which raises
+   `FileNotFoundError` on minimal images without the `which` package (5
+   test failures on AlmaLinux/Rocky/Fedora/Amazon/Arch lanes in the first
+   nightly-matrix run). Proposed fix: replace with stdlib
+   `shutil.which()` -- no new dependency, removes both the hardcoded path
+   and the external binary requirement.
 
 ### 3. Pseudo-random use -- acceptable, scope it
 

--- a/docs/secure-coding-pyscg.md
+++ b/docs/secure-coding-pyscg.md
@@ -59,13 +59,16 @@ Proposed next steps:
    operator's trust domain -- state this explicitly in the config docs.
 3. The single partial-path call sites (`git` in `tools/`) are dev/CI-side
    tools resolving from PATH by design; annotate rather than change.
-4. Live-matrix discovery: scheduler autodetection shells out to a
-   *hardcoded* `/usr/bin/which` (`qtop_py/qtop.py:357`), which raises
-   `FileNotFoundError` on minimal images without the `which` package (5
-   test failures on AlmaLinux/Rocky/Fedora/Amazon/Arch lanes in the first
-   nightly-matrix run). Proposed fix: replace with stdlib
-   `shutil.which()` -- no new dependency, removes both the hardcoded path
-   and the external binary requirement.
+4. Live-matrix discovery, now FIXED in this PR: scheduler autodetection
+   used a *hardcoded* `/usr/bin/which` (`qtop_py/qtop.py:357`), which raised
+   `FileNotFoundError` on minimal images without the `which` package (5 test
+   failures on AlmaLinux/Rocky/Fedora/Amazon/Arch lanes in the first
+   nightly-matrix run, 27360317465). Replaced with stdlib `shutil.which()`:
+   no new dependency, removes both the hardcoded path and the external-binary
+   requirement, and lets the matrix drop its per-lane `which` install. No
+   regression: 139 tests still pass on 3.12 and 3.6, the
+   `scheduler_not_specified` tests pass, and the previously red lanes no
+   longer need `which` at all (before/after in the evidence repo).
 
 ### 3. Pseudo-random use -- acceptable, scope it
 

--- a/docs/supply-chain-sbom.md
+++ b/docs/supply-chain-sbom.md
@@ -1,0 +1,73 @@
+# SBOMs and verifiable supply-chain artifacts: proposal
+
+Status: proposal only, per the #488 checklist ("only propose, nothing
+beyond that"). No SBOM or signing automation is introduced by this change;
+this document records a path the maintainers can adopt incrementally.
+
+## Where qtop starts from
+
+qtop's supply-chain posture is unusually clean, which makes the remaining
+steps cheap:
+
+- **Zero runtime dependencies** (deliberate, per CONTRIBUTING.md): the
+  runtime SBOM is essentially "qtop itself plus the interpreter". The
+  interesting inventory is the *build and CI* tool chain.
+- **Fully pinned CI dependencies** (`requirements-ci.txt`); Scorecard rates
+  Pinned-Dependencies 10/10.
+- Gaps, per the 2026-06-08 Scorecard snapshot: Packaging -1 (no publish
+  workflow), Signed-Releases -1 (no releases/signatures).
+
+## Phase 1 -- generate and publish SBOMs (low effort)
+
+1. **CycloneDX for the built artefacts**: run `cyclonedx-py environment`
+   against the pinned CI venv and `cyclonedx-py` against the sdist/wheel in
+   the existing `build` jobs; attach `sbom.cdx.json` as a CI artifact on
+   both forges (the build concern already publishes `dist/`).
+2. **GitLab native route**: GitLab Dependency Scanning (wired in this
+   change) emits a CycloneDX report per pipeline on supported tiers; the
+   pegged mirror gets this for free once enabled.
+3. **SPDX alternative**: `syft dir:.` or `syft dist/*.whl` if the
+   maintainers prefer SPDX; both formats can be published side by side.
+4. Attach SBOMs to GitHub Releases so consumers get inventory with the
+   artefact, not from a separate channel.
+
+## Phase 2 -- provenance and signatures (moderate effort)
+
+1. **Build provenance on GitHub**: `actions/attest-build-provenance` in the
+   build workflow generates SLSA v1 provenance for `dist/*`, backed by the
+   Sigstore public-good infrastructure; verification is
+   `gh attestation verify`.
+2. **Build provenance on GitLab**: set
+   `RUNNER_GENERATE_ARTIFACTS_METADATA: "true"` on the build job to emit a
+   SLSA attestation alongside artifacts on the mirror.
+3. **Keyless signing of release artefacts**: cosign sign-blob with OIDC
+   (no long-lived keys to manage) for sdist/wheel at release time.
+4. **PyPI Trusted Publishing** when a packaging workflow lands: OIDC-based,
+   no stored API tokens, and it closes the Scorecard Packaging gap.
+
+## Phase 3 -- consumption, policy, and verification (ongoing)
+
+1. Document a verification recipe for cluster operators (HPC sites often
+   install from mirrors inside air-gapped networks; a signed sdist plus an
+   SBOM is exactly what their security reviews ask for).
+2. Hash-pin the CI set (`pip install --require-hashes`) on top of the
+   existing version pins.
+3. Diff SBOMs in merge requests once generation is routine, so dependency
+   drift in the CI chain is visible at review time.
+4. Track the Scorecard Signed-Releases and Packaging checks as the
+   external measure of progress.
+
+## Forge mapping
+
+| Capability | GitHub | GitLab (pegged mirror) |
+|---|---|---|
+| SBOM generation | cyclonedx-py / syft in workflow | Dependency Scanning CycloneDX or same CLI in job |
+| Provenance | actions/attest-build-provenance (SLSA v1) | RUNNER_GENERATE_ARTIFACTS_METADATA (SLSA) |
+| Signing | cosign keyless via OIDC | cosign keyless via OIDC (id_tokens) |
+| Publish trust | PyPI Trusted Publishing | release artefacts + attestation |
+
+## Explicit non-goals here
+
+No container/registry SBOMs (the registry deployment item is not claimed in
+this slice), no signing keys checked into CI, and no new runtime
+dependencies under any phase.

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -20,6 +20,7 @@ import sys
 from operator import itemgetter
 from itertools import zip_longest, cycle
 import subprocess
+import shutil
 import select
 import os
 import re
@@ -354,8 +355,11 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
+        # shutil.which() resolves the command against PATH using the stdlib,
+        # so qtop no longer shells out to a hardcoded /usr/bin/which (absent on
+        # minimal container images, and itself an external dependency). It
+        # returns the resolved path, or None when the command is not found.
+        if shutil.which(batch_command):
             if system != "demo":
                 logging.debug("Auto-detected scheduler: %s" % system)
                 return system

--- a/tools/repo_sanity.py
+++ b/tools/repo_sanity.py
@@ -2,9 +2,7 @@
 ##
 ## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
 ##
-## Copyright (c) 2016 Fotis Georgatos
-## Copyright (c) 2016 Sotiris Fragkiskos
-## Copyright (c) 2026 Vadik-x
+## Copyright (c) 2026 Vadik Malik
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -94,14 +92,25 @@ SKIP_DIRS = set(
 MAX_BYTES = 5 * 1024 * 1024
 REPORT_CAP = 20
 
-# Files whose entire purpose is captured terminal output: ANSI escape
-# sequences and bare carriage returns are expected there and aggregate to a
-# single INFO finding. Any OTHER control/bidi/invisible character still
-# escalates normally, even inside these files.
+# Files whose entire purpose is captured terminal output, where ANSI escape
+# sequences and bare carriage returns are expected and aggregate to a single
+# INFO finding instead of thousands of control-character CRITICALs. Any OTHER
+# control/bidi/invisible character still escalates normally inside them.
+#   - qtop_py/contrib/  : recorded scheduler render fixtures (the *.ref files
+#                         the sample gates diff against) -- full of ESC colour
+#                         codes by design.
+#   - helpfile.txt      : qtop's in-app help screen, shipped as pre-rendered
+#                         terminal text (ANSI-coloured) and printed verbatim
+#                         by the tool, so it legitimately contains ESC codes.
 ANSI_FIXTURES = ("qtop_py/contrib/", "helpfile.txt")
 
 
 def is_ansi_fixture(rel):
+    """Return True if ``rel`` is a declared terminal-output fixture path.
+
+    Matches an ANSI_FIXTURES entry exactly or as a directory prefix, so both
+    ``helpfile.txt`` (exact) and everything under ``qtop_py/contrib/`` count.
+    """
     for prefix in ANSI_FIXTURES:
         if rel == prefix or rel.startswith(prefix):
             return True
@@ -109,6 +118,12 @@ def is_ansi_fixture(rel):
 
 
 def tracked_files(root):
+    """Yield every file git tracks under ``root`` (falls back to os.walk).
+
+    Using ``git ls-files`` keeps the audit aligned with what is actually
+    committed (ignoring untracked scratch files); if git is unavailable the
+    os.walk fallback skips SKIP_DIRS so results stay comparable.
+    """
     try:
         out = subprocess.check_output(["git", "ls-files", "-z"], cwd=str(root), stderr=subprocess.DEVNULL)
         names = [n for n in out.decode("utf-8", "replace").split("\0") if n]
@@ -123,6 +138,11 @@ def tracked_files(root):
 
 
 def codepoint_label(ch):
+    """Return a human-readable ``U+XXXX NAME`` label for a character.
+
+    Falls back to ``UNNAMED`` for codepoints unicodedata cannot name, so the
+    report never crashes on an obscure control character.
+    """
     try:
         name = unicodedata.name(ch)
     except ValueError:
@@ -131,6 +151,11 @@ def codepoint_label(ch):
 
 
 def is_homoglyph_risk(ch):
+    """Return True if ``ch`` falls in a homoglyph-prone Unicode range.
+
+    Covers Greek, Cyrillic, and fullwidth Latin blocks (HOMOGLYPH_RANGES) --
+    letters that look like ASCII but are not, a common spoofing vector.
+    """
     cp = ord(ch)
     for lo, hi in HOMOGLYPH_RANGES:
         if lo <= cp <= hi:
@@ -139,6 +164,11 @@ def is_homoglyph_risk(ch):
 
 
 def proof_line(text, col):
+    """Render an escaped one-line excerpt with a caret under column ``col``.
+
+    Long lines are windowed around the offending column so the proof stays
+    readable; the text is unicode-escaped so the report itself is pure ASCII.
+    """
     visual = text
     if len(visual) > 160:
         start = max(0, col - 40)
@@ -149,6 +179,13 @@ def proof_line(text, col):
 
 
 def scan_file(path, rel, findings):
+    """Scan one file and append (severity, path, line, col, msg, proof) rows.
+
+    Skips binary content and oversized files, decodes as UTF-8 (a decode
+    failure is itself a CRITICAL finding), then classifies every non-plain-ASCII
+    codepoint by severity. Inside ANSI_FIXTURES, ESC and bare CR are tallied
+    into one expected-INFO row instead of flooding the report.
+    """
     try:
         data = path.read_bytes()
     except OSError as exc:
@@ -209,6 +246,12 @@ def scan_file(path, rel, findings):
 
 
 def write_reports(findings, report_dir, scanned):
+    """Write report.txt + findings.json and return (counts, report_text).
+
+    Per-line detail is capped at REPORT_CAP entries for each (file, kind) so a
+    fixture-heavy tree stays reviewable; suppressed extras are summarised in a
+    NOTE line. findings.json always carries the full, uncapped list.
+    """
     report_dir.mkdir(parents=True, exist_ok=True)
     counts = {"CRITICAL": 0, "WARNING": 0, "INFO": 0}
     lines = []
@@ -241,6 +284,11 @@ def write_reports(findings, report_dir, scanned):
 
 
 def run_audit(root, report_dir, strict):
+    """Audit every tracked text file under ``root`` and return an exit code.
+
+    Prints non-INFO findings to stdout, always writes the full report, and
+    returns 1 on any CRITICAL (or on WARNING when ``strict`` is set), else 0.
+    """
     findings = []
     scanned = 0
     for path in sorted(tracked_files(root)):
@@ -266,6 +314,12 @@ def run_audit(root, report_dir, strict):
 
 
 def selftest(report_dir):
+    """Plant one file per payload class and prove each is detected.
+
+    Writes bidi/zero-width/homoglyph/control/line-separator samples to a temp
+    dir, scans them, and fails (returns 1) if any planted file escapes with no
+    CRITICAL/WARNING -- so the detector's own correctness is demonstrable.
+    """
     tmp = Path(tempfile.mkdtemp(prefix="repo-sanity-selftest-"))
     plants = {
         "planted_bidi.py": 'access = "user\u202e" # privileged \u202d"\n',
@@ -291,6 +345,7 @@ def selftest(report_dir):
 
 
 def parse_args():
+    """Parse CLI options (--report-dir, --strict, --selftest)."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--report-dir", default="artifacts/repo-sanity", help="Directory for report.txt and findings.json")
     parser.add_argument("--strict", action="store_true", help="Treat WARNING findings as fatal")
@@ -299,6 +354,7 @@ def parse_args():
 
 
 def main():
+    """Entry point: run --selftest, or audit the repo and return its code."""
     args = parse_args()
     report_dir = Path(args.report_dir)
     if args.selftest:

--- a/tools/repo_sanity.py
+++ b/tools/repo_sanity.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+##
+## qtop is a tool to monitor queuing systems - https://github.com/qtop/qtop
+##
+## Copyright (c) 2016 Fotis Georgatos
+## Copyright (c) 2016 Sotiris Fragkiskos
+## Copyright (c) 2026 Vadik-x
+##
+## SPDX-License-Identifier: MIT
+##
+"""Full-tree text-trust audit for repo sanity and trustability (#488).
+
+Complements tools/fortifications.py: fortifications guards the *diff* of a
+merge request, while this tool audits the *entire tracked tree* so trojan-
+source style payloads cannot ride in via history, generated files, or paths
+a reviewer never opened.
+
+Checks and severities:
+
+- CRITICAL  bidirectional control characters (Trojan Source, CVE-2021-42574),
+            zero-width/invisible characters, C0/C1 control characters other
+            than tab/newline/carriage-return, unicode line/paragraph
+            separators, undecodable (non-UTF-8) files.
+- WARNING   homoglyph-prone letters (Greek/Cyrillic/fullwidth) in an
+            otherwise ASCII tree, byte-order marks.
+- INFO      remaining non-ASCII codepoints (reported, never fatal), lines
+            that change under NFKC normalisation, CRLF line endings, and
+            aggregated ANSI escape/carriage-return counts inside declared
+            terminal-output fixtures (see ANSI_FIXTURES), where ESC is the
+            point of the file rather than a smell.
+
+Exit status: 1 if any CRITICAL finding (or WARNING with --strict), else 0.
+The text report caps identical (file, kind) detail at REPORT_CAP entries and
+prints a suppression note, so fixture-heavy trees stay reviewable.
+
+--selftest plants known-bad samples in a temporary directory and proves the
+detector catches them; the proof output is suitable for review evidence.
+
+This file is intentionally pure ASCII; every audited codepoint is spelled
+as an escape sequence so the auditor passes its own audit.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import unicodedata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BIDI_CONTROLS = set("\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069\u200e\u200f\u061c")
+INVISIBLES = set("\u200b\u200c\u200d\u2060\u00ad\u034f\u180e\ufeff")
+LINE_SEPARATORS = set("\u2028\u2029\u0085")
+HOMOGLYPH_RANGES = ((0x0370, 0x03FF), (0x0400, 0x04FF), (0xFF01, 0xFF5E))
+BINARY_SUFFIXES = set(
+    [
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".ico",
+        ".pdf",
+        ".gz",
+        ".xz",
+        ".lzma",
+        ".bz2",
+        ".zip",
+        ".whl",
+        ".pyc",
+        ".bin",
+        ".dat",
+        ".woff",
+        ".woff2",
+    ]
+)
+SKIP_DIRS = set(
+    [
+        ".git",
+        ".tox",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "artifacts",
+        "build",
+        "dist",
+        "qtop.egg-info",
+        ".pytest_cache",
+        ".ruff_cache",
+    ]
+)
+MAX_BYTES = 5 * 1024 * 1024
+REPORT_CAP = 20
+
+# Files whose entire purpose is captured terminal output: ANSI escape
+# sequences and bare carriage returns are expected there and aggregate to a
+# single INFO finding. Any OTHER control/bidi/invisible character still
+# escalates normally, even inside these files.
+ANSI_FIXTURES = ("qtop_py/contrib/", "helpfile.txt")
+
+
+def is_ansi_fixture(rel):
+    for prefix in ANSI_FIXTURES:
+        if rel == prefix or rel.startswith(prefix):
+            return True
+    return False
+
+
+def tracked_files(root):
+    try:
+        out = subprocess.check_output(["git", "ls-files", "-z"], cwd=str(root), stderr=subprocess.DEVNULL)
+        names = [n for n in out.decode("utf-8", "replace").split("\0") if n]
+        return [root / n for n in names]
+    except (OSError, subprocess.CalledProcessError):
+        found = []
+        for dirpath, dirnames, filenames in os.walk(str(root)):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            for filename in filenames:
+                found.append(Path(dirpath) / filename)
+        return found
+
+
+def codepoint_label(ch):
+    try:
+        name = unicodedata.name(ch)
+    except ValueError:
+        name = "UNNAMED"
+    return "U+%04X %s" % (ord(ch), name)
+
+
+def is_homoglyph_risk(ch):
+    cp = ord(ch)
+    for lo, hi in HOMOGLYPH_RANGES:
+        if lo <= cp <= hi:
+            return True
+    return False
+
+
+def proof_line(text, col):
+    visual = text
+    if len(visual) > 160:
+        start = max(0, col - 40)
+        visual = visual[start : start + 120]
+        col = col - start
+    escaped = visual.encode("unicode_escape").decode("ascii")
+    return "    >%s\n    %s^" % (escaped, " " * (col + 1))
+
+
+def scan_file(path, rel, findings):
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        findings.append(("CRITICAL", rel, 0, 0, "unreadable file: %s" % exc, ""))
+        return
+    if not data:
+        return
+    if len(data) > MAX_BYTES:
+        findings.append(("INFO", rel, 0, 0, "skipped: larger than %d bytes" % MAX_BYTES, ""))
+        return
+    if b"\0" in data[:8000]:
+        return  # binary content, out of scope for text trust
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        findings.append(("CRITICAL", rel, 0, 0, "not valid UTF-8: %s" % exc, ""))
+        return
+    crlf = text.count("\r\n")
+    if crlf:
+        findings.append(("INFO", rel, 0, 0, "%d CRLF line endings" % crlf, ""))
+    ansi_fixture = is_ansi_fixture(rel)
+    esc_count = 0
+    cr_count = 0
+    for lineno, line in enumerate(text.split("\n"), 1):
+        if line.endswith("\r"):
+            line = line[:-1]
+        for col, ch in enumerate(line):
+            o = ord(ch)
+            if ch == "\t" or 0x20 <= o <= 0x7E:
+                continue
+            if ansi_fixture and ch == "\x1b":
+                esc_count += 1
+                continue
+            if ansi_fixture and ch == "\r":
+                cr_count += 1
+                continue
+            if ch == "\ufeff" and lineno == 1 and col == 0:
+                findings.append(("WARNING", rel, lineno, col, "leading byte-order mark", proof_line(line, col)))
+                continue
+            label = codepoint_label(ch)
+            if ch in BIDI_CONTROLS:
+                findings.append(("CRITICAL", rel, lineno, col, "bidirectional control character %s (Trojan Source)" % label, proof_line(line, col)))
+            elif ch in INVISIBLES:
+                findings.append(("CRITICAL", rel, lineno, col, "invisible character %s" % label, proof_line(line, col)))
+            elif ch in LINE_SEPARATORS:
+                findings.append(("CRITICAL", rel, lineno, col, "unicode line separator %s" % label, proof_line(line, col)))
+            elif o < 0x20 or o == 0x7F or 0x80 <= o <= 0x9F:
+                findings.append(("CRITICAL", rel, lineno, col, "control character %s" % label, proof_line(line, col)))
+            elif is_homoglyph_risk(ch):
+                findings.append(("WARNING", rel, lineno, col, "homoglyph-prone character %s" % label, proof_line(line, col)))
+            else:
+                findings.append(("INFO", rel, lineno, col, "non-ASCII character %s" % label, ""))
+        nfkc = unicodedata.normalize("NFKC", line)
+        if nfkc != line:
+            findings.append(("INFO", rel, lineno, 0, "line changes under NFKC normalisation", ""))
+    if esc_count or cr_count:
+        findings.append(("INFO", rel, 0, 0, "terminal-output fixture: %d ANSI escapes, %d carriage returns (expected)" % (esc_count, cr_count), ""))
+
+
+def write_reports(findings, report_dir, scanned):
+    report_dir.mkdir(parents=True, exist_ok=True)
+    counts = {"CRITICAL": 0, "WARNING": 0, "INFO": 0}
+    lines = []
+    lines.append("repo-sanity text-trust audit")
+    lines.append("root: %s" % ROOT)
+    lines.append("files scanned: %d" % scanned)
+    lines.append("")
+    shown = {}
+    suppressed = {}
+    for sev, rel, lineno, col, msg, proof in findings:
+        counts[sev] = counts.get(sev, 0) + 1
+        kind = msg.split(" U+")[0]
+        key = (rel, kind)
+        shown[key] = shown.get(key, 0) + 1
+        if shown[key] > REPORT_CAP:
+            suppressed[key] = suppressed.get(key, 0) + 1
+            continue
+        lines.append("%-8s %s:%s:%s  %s" % (sev, rel, lineno, col + 1, msg))
+        if proof:
+            lines.append(proof)
+    for (rel, kind), extra in sorted(suppressed.items()):
+        lines.append("NOTE     %s: %d further '%s' findings suppressed (cap %d)" % (rel, extra, kind, REPORT_CAP))
+    lines.append("")
+    lines.append("summary: %d critical, %d warning, %d info" % (counts["CRITICAL"], counts["WARNING"], counts["INFO"]))
+    report = "\n".join(lines) + "\n"
+    (report_dir / "report.txt").write_text(report, encoding="utf-8")
+    payload = [{"severity": s, "path": p, "line": ln, "col": c, "message": m} for s, p, ln, c, m, _ in findings]
+    (report_dir / "findings.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return counts, report
+
+
+def run_audit(root, report_dir, strict):
+    findings = []
+    scanned = 0
+    for path in sorted(tracked_files(root)):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() in BINARY_SUFFIXES:
+            continue
+        rel = str(path.relative_to(root))
+        if any(part in SKIP_DIRS for part in Path(rel).parts):
+            continue
+        scanned += 1
+        scan_file(path, rel, findings)
+    counts, report = write_reports(findings, report_dir, scanned)
+    for line in report.splitlines():
+        if not line.startswith("INFO"):
+            print(line)
+    print("full report: %s" % (report_dir / "report.txt"))
+    if counts["CRITICAL"]:
+        return 1
+    if strict and counts["WARNING"]:
+        return 1
+    return 0
+
+
+def selftest(report_dir):
+    tmp = Path(tempfile.mkdtemp(prefix="repo-sanity-selftest-"))
+    plants = {
+        "planted_bidi.py": 'access = "user\u202e" # privileged \u202d"\n',
+        "planted_zwsp.py": "def is\u200badmin():\n    return True\n",
+        "planted_homoglyph.py": "p\u0430ssword_check = None  # Cyrillic small a\n",
+        "planted_control.py": "header = 'x\x08x'\n",
+        "planted_separator.py": "safe = True\u2028unsafe = True\n",
+    }
+    for name, payload in plants.items():
+        (tmp / name).write_text(payload, encoding="utf-8")
+    findings = []
+    for path in sorted(tmp.iterdir()):
+        scan_file(path, str(path.name), findings)
+    counts, report = write_reports(findings, report_dir, len(plants))
+    print(report)
+    hit = set(f[1] for f in findings if f[0] in ("CRITICAL", "WARNING"))
+    missing = [name for name in sorted(plants) if name not in hit]
+    if missing:
+        print("SELFTEST FAILED: undetected plants: %s" % ", ".join(missing))
+        return 1
+    print("SELFTEST OK: all %d planted payloads detected (proof above)" % len(plants))
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report-dir", default="artifacts/repo-sanity", help="Directory for report.txt and findings.json")
+    parser.add_argument("--strict", action="store_true", help="Treat WARNING findings as fatal")
+    parser.add_argument("--selftest", action="store_true", help="Plant known-bad samples and prove detection")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    report_dir = Path(args.report_dir)
+    if args.selftest:
+        return selftest(report_dir)
+    return run_audit(ROOT, report_dir, args.strict)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Focused Challenge #9 slice, stacked on the prerequisite realign PR
(#500): a GitLab-linkage pilot where every job is a thin wrapper
around a Makefile target, mirrored across GitHub Actions and GitLab CI so a
pegged GitLab repo runs the identical pipeline.

- **Nightly matrix**: 35 distro x python lanes (CPython 3.6 -> 3.15-rc,
  PyPy 3.9/3.10/3.11, across Debian/Ubuntu/AlmaLinux/Rocky/Fedora/
  openSUSE/Amazon Linux/Arch) through one shared lane script
  (`ci/scripts/matrix_lane.sh`) used verbatim by both forges. The first
  live run already produced three real findings (see Validation).
- **Security concern** (`ci/security.gitlab-ci.yml`): GitLab SAST
  (Semgrep-based analyzer for Python), SAST-IaC, Secret Detection and
  Dependency Scanning templates wired, plus free-tier `code-quality`
  (ruff's native GitLab format; the upstream CodeClimate template is
  deprecated), `license-report` (pip-licenses, pinned in-job) and
  `repo-sanity` jobs; tier gates documented honestly in the file header.
- **Trust audit** (`tools/repo_sanity.py`, `make repo-sanity`): full-tree
  scan for Trojan-Source bidi controls, zero-width/invisible characters,
  unicode line separators, C0/C1 controls, homoglyph-prone letters, BOMs,
  non-UTF-8; complements the diff-scoped `tools/fortifications.py`. Tree
  baseline: 0 critical, 0 warning. Detector proven by `--selftest` (5
  planted payload classes detected with caret-pointer proof).
- **Coverage publishing**: `make coverage-xml` (Cobertura) feeding the
  GitLab MR widget (`ci/coverage.gitlab-ci.yml`) and Codecov on GitHub
  (`.github/workflows/coverage.yml`). Baseline: 45% / 139 tests.
- **OpenSSF Scorecard**: weekly GitHub workflow (SARIF -> code scanning,
  publish to scorecard.dev), README badge, and a scheduled GitLab CLI twin.
  Public-API baseline: 7.1 (2026-06-08).
- **Docs**: `docs/gitlab-linkage-pilot.md` (GitHub-first + GitLab-pegged
  contributor model and out-of-the-box findings table),
  `docs/secure-coding-pyscg.md` (PySCG mapping of real scanner findings,
  prioritised next steps), `docs/supply-chain-sbom.md` (SBOM/provenance
  proposal, proposal-only).

## Related

Refs #488
Stacked on #500 (prerequisite); the first commit here is that PR.

## Challenge #9 checklist review scope (Requirement #3)

- [x] Prerequisite PR: CI structure realigned to the pvgis layout
  (separate stacked PR: #500).
- [ ] Increase coverage to at least 80%: NOT claimed. This slice publishes
  the honest 45% baseline via Cobertura/Codecov instead.
- [ ] Stanford SWEPR / Transcend lessons: NOT claimed in this slice.
- [ ] Pegged GitLab repo created: NOT claimed as completed; the full
  account-side setup path and what-works-OOTB exploration are documented
  in docs/gitlab-linkage-pilot.md.
- [x] Nightly CI runs via the Makefile in a matrix of >30 distro*python
  images: 35 lanes incl. 3.6/3.9/3.12/3.15-rc; PyPy bonus included (3
  lanes, all green on the live run). Live evidence:
  https://github.com/Vadik-x/qtop/actions/workflows/nightly-matrix.yml
- [x] Explore SAST, Semgrep analyzer, Secret Detection, Dependency
  Scanning/SCA, License Compliance, Code Quality out of the box: templates
  wired + per-feature tier notes + real local scanner baselines (semgrep,
  bandit, gitleaks, detect-secrets, pip-audit) in the evidence repo.
  GitLab Advanced SAST (Ultimate) stubbed; DAST/Container Scanning
  documented as gated on the unclaimed registry item.
- [x] Extra repo sanity/trustability checks with proof: `make repo-sanity`
  + selftest proof artifacts (evidence repo) + live findings: tree clean.
- [x] OpenSSF Scorecard: workflow + badge + GitLab twin + 7.1 baseline
  snapshot.
- [x] Align to Secure Coding Guide for Python or propose next steps:
  docs/secure-coding-pyscg.md maps every finding cluster to verified PySCG
  pages (incl. two PySCG coverage gaps proposed as upstream
  contributions) with P1-P3 next steps.
- [x] Codecov / Coveralls / GitLab cobertura style: both forges wired from
  one `make coverage-xml` target.
- [ ] pytest + allure-pytest + artifact publishing: NOT claimed (kept out
  to avoid a new CI-only dependency without maintainer agreement).
- [ ] GitLab registry container deployment + scanning + web UI: NOT
  claimed.
- [x] Propose how contributors benefit from GitLab without leaving
  GitHub: docs/gitlab-linkage-pilot.md (mirror model, status-back
  integration, limits stated honestly).
- [x] SBOM / verifiable supply-chain path, proposal only:
  docs/supply-chain-sbom.md.

## Validation

Local (all via the Makefile, Python 3.12 base per the issue hint):
- `make ci` -> 139 passed, 10/10 sample gates, fortifications ok, ruff
  lint+format clean, diff whitespace clean.
- `make coverage-xml` -> Cobertura written, TOTAL 45%.
- `make repo-sanity` -> 0 critical, 0 warning, 4 expected fixture INFO.
- `tools/repo_sanity.py --selftest` -> 5/5 planted payloads detected.
- `make compat-py36` on real Python 3.6.15 -> exit 0, 10/10 gates
  (transcript + SGE render SVG in the evidence repo).
- All yaml files parse; every added line is printable ASCII.

Live (fork, branch stack):
- pytest-qtop (project's own workflow): green.
- coverage-qtop: green.
- scorecard-qtop: green.
- nightly-matrix-qtop: first run 22/35 green and surfaced three real
  findings, fixed in the follow-up commit on this branch: (1) qtop's
  scheduler autodetection calls a hardcoded /usr/bin/which
  (qtop_py/qtop.py:357) absent on minimal RHEL-family/Arch images --
  follow-up `shutil.which()` proposal recorded in the PySCG doc; (2) the
  pinned CI set's true floor is Python 3.9 (importlib-metadata==8.7.1), so
  3.8 lanes run the dependency-light gate; (3) openSUSE images lack tar,
  needing a git bootstrap before checkout. Re-run results:
  34/35 green (sole failure was a transient openSUSE mirror refresh error, exit 4 from zypper; refresh made best-effort in the third commit, fresh run on the Actions page).

Evidence repo (per CONTRIBUTING.md, artifacts stay out of qtop):
https://github.com/Vadik-x/qtop-488-evidence

## DCO / AI / PoH

- DCO: every commit carries `Signed-off-by: Vadik-x <vadik.core@gmail.com>`
  matching the commit author.
- AI disclosure (mandatory, with version): Claude Opus 4.8 used.
- PoH: verified via the maintainer's checks (the (SDP) Student Developer Pack
  tag, a verified LinkedIn profile, and the emailed code-relay). No personal
  documents or private data were submitted.
- No force-pushing was used at any point; all commits are append-only
  (the push tooling rejects non-fast-forward updates by construction).
