### PR TITLE
20260611: (human) ci: split GitLab pipeline into ci includes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,51 +1,13 @@
+default:
+  image: python:3.12.3-bookworm
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 stages:
   - test
   - build
 
-modern-python:
-  image: python:3.12.3-bookworm
-  stage: test
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make git
-    - make ci-deps PYTHON=python
-    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
-    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
-    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
-  script:
-    - make gitlab-ci PYTHON=python
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate/
-
-almalinux-python36:
-  image: almalinux:8
-  stage: test
-  before_script:
-    - dnf -y install make findutils
-    - dnf -y install python36
-  script:
-    - |
-      PYTHON_BIN="$(command -v python3.6)"
-      "$PYTHON_BIN" --version
-      make compat-py36 PYTHON="$PYTHON_BIN"
-  artifacts:
-    when: always
-    paths:
-      - artifacts/sample-gate-py36/
-
-build:
-  image: python:3.12.3-bookworm
-  stage: build
-  needs:
-    - modern-python
-    - almalinux-python36
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends make
-  script:
-    - make gitlab-build PYTHON=python
-  artifacts:
-    paths:
-      - dist/
+include:
+  - local: ci/test.gitlab-ci.yml
+  - local: ci/build.gitlab-ci.yml

--- a/ci/build.gitlab-ci.yml
+++ b/ci/build.gitlab-ci.yml
@@ -1,0 +1,13 @@
+build:
+  stage: build
+  needs:
+    - modern-python
+    - almalinux-python36
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make
+  script:
+    - make gitlab-build PYTHON=python
+  artifacts:
+    paths:
+      - dist/

--- a/ci/test.gitlab-ci.yml
+++ b/ci/test.gitlab-ci.yml
@@ -1,0 +1,31 @@
+modern-python:
+  stage: test
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends make git
+    - make ci-deps PYTHON=python
+    - export TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-develop}"
+    - git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+    - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
+  script:
+    - make gitlab-ci PYTHON=python
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate/
+
+almalinux-python36:
+  image: almalinux:8
+  stage: test
+  before_script:
+    - dnf -y install make findutils
+    - dnf -y install python36
+  script:
+    - |
+      PYTHON_BIN="$(command -v python3.6)"
+      "$PYTHON_BIN" --version
+      make compat-py36 PYTHON="$PYTHON_BIN"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/sample-gate-py36/


### PR DESCRIPTION
Small prerequisite for #488.

This keeps the existing GitLab test/build jobs, but moves the job bodies under `ci/` so the root `.gitlab-ci.yml` stays focused on defaults, stages, and local includes, similar to the PVGIS layout linked from the challenge.

#488 review scope:
- [x] Prerequisite PR, before bounty PR: realign the qtop CI structure toward the PVGIS-style split.
- [ ] All other #488 checklist items are intentionally out of scope for this prerequisite PR. I am not claiming #488 completion here.

Validation:
- YAML parse for `.gitlab-ci.yml` and `ci/*.gitlab-ci.yml`
- `git diff HEAD~1..HEAD --check`
- `FORTIFY_BASE_REF=upstream/develop make gitlab-ci PYTHON=/tmp/qtop-488-prereq-ci/bin/python`
- `make gitlab-build PYTHON=/tmp/qtop-488-prereq-ci/bin/python`

PoH: using the `(human)` tag, and happy to satisfy a maintainer PoH check if needed. I will not force-push this PR without permission.

AI/version disclosure: Assisted with Codex 5.5; I reviewed the diff and validation output locally.