### PR TITLE
20260617 (LI) (PRO) (human): tighten CLI entrypoint scheduler errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3"
 "Homepage" = "https://github.com/qtop/qtop"
 
 [project.scripts]
-qtop = "qtop_py.qtop:main"
+qtop = "qtop_py.qtop:cli_main"
 
 [tool.setuptools.dynamic]
 version = {attr = "qtop_py.__version__"}

--- a/qtop_py/cli.py
+++ b/qtop_py/cli.py
@@ -10,24 +10,7 @@
 
 import re
 import sys
-from qtop_py.qtop import InvalidScheduler, NoSchedulerFound, SchedulerNotSpecified, main
-
-
-def cli_main():
-    try:
-        return main() or 0
-    except SchedulerNotSpecified:
-        # fmt: off
-        sys.stderr.write(
-            "No scheduler could be auto-detected. "
-            "Select one with -b/--batchSystem, QTOP_SCHEDULER, or qtopconf.yaml.\n"
-        )
-        # fmt: on
-        return 1
-    except (InvalidScheduler, NoSchedulerFound) as exc:
-        if str(exc):
-            sys.stderr.write("%s\n" % exc)
-        return 1
+from qtop_py.qtop import cli_main
 
 
 if __name__ == "__main__":

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -2360,6 +2360,22 @@ class InvalidScheduler(Exception):
     pass
 
 
+def cli_error_message(error):
+    if isinstance(error, SchedulerNotSpecified):
+        return "No scheduler could be auto-detected. Select one with -b/--batchSystem, QTOP_SCHEDULER, or qtopconf.yaml."
+    return str(error)
+
+
+def cli_main():
+    try:
+        return main() or 0
+    except (InvalidScheduler, NoSchedulerFound, SchedulerNotSpecified) as error:
+        message = cli_error_message(error)
+        if message:
+            sys.stderr.write("%s\n" % message)
+        return 1
+
+
 def main():
     # define global vars which are used out of scope
     global \
@@ -2545,4 +2561,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(cli_main())

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     packages=find_packages(include=["qtop_py", "qtop_py.*"]),
     include_package_data=True,
     python_requires=">=3",
-    entry_points={"console_scripts": ["qtop=qtop_py.qtop:main"]},
+    entry_points={"console_scripts": ["qtop=qtop_py.qtop:cli_main"]},
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import subprocess
 import sys
@@ -9,14 +10,14 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_cli(tmp_path, *args):
+def run_cli(tmp_path, module, *args):
     env = os.environ.copy()
     env["HOME"] = str(tmp_path)
     env.pop("QTOP_SCHEDULER", None)
     env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
 
     return subprocess.run(
-        [sys.executable, "-m", "qtop_py.cli", *args],
+        [sys.executable, "-m", module, *args],
         cwd=str(ROOT),
         env=env,
         text=True,
@@ -34,10 +35,24 @@ def run_cli(tmp_path, *args):
         (("-b", "not-a-scheduler"), "Selected scheduler system not supported"),
     ),
 )
-def test_expected_cli_scheduler_errors_are_concise(tmp_path, args, expected):
-    result = run_cli(tmp_path, *args)
+@pytest.mark.parametrize("module", ("qtop_py.cli", "qtop_py.qtop"))
+def test_expected_cli_scheduler_errors_are_concise(tmp_path, module, args, expected):
+    result = run_cli(tmp_path, module, *args)
     output = result.stdout + result.stderr
 
     assert result.returncode != 0
     assert expected in output
     assert "Traceback" not in output
+    assert "SchedulerNotSpecified" not in output
+    assert "InvalidScheduler" not in output
+
+
+def test_packaging_entry_points_use_cli_wrapper():
+    assert 'qtop = "qtop_py.qtop:cli_main"' in (ROOT / "pyproject.toml").read_text()
+
+    setup_tree = ast.parse((ROOT / "setup.py").read_text())
+    setup_call = next(node for node in ast.walk(setup_tree) if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup")
+    entry_points_keyword = next(keyword for keyword in setup_call.keywords if keyword.arg == "entry_points")
+    entry_points = ast.literal_eval(entry_points_keyword.value)
+
+    assert entry_points["console_scripts"] == ["qtop=qtop_py.qtop:cli_main"]


### PR DESCRIPTION
## Summary
# PR Request: 20260617 (human): tighten CLI entrypoint scheduler errors

Open this PR from:

`Utkarsh-Sinha0:challenge-8-cli-entrypoint-dco`

to:

`qtop/qtop:develop`

Compare link:

https://github.com/qtop/qtop/compare/develop...Utkarsh-Sinha0:qtop:challenge-8-cli-entrypoint-dco?expand=1

---

## PR title

```text
20260617 (human): tighten CLI entrypoint scheduler errors
```

## PR body

```markdown
## Summary

- Route installed `qtop` console entry points through the concise CLI wrapper instead of calling `main()` directly.
- Reuse one scheduler-error formatter for both `qtop_py.cli` and direct `python -m qtop_py.qtop` execution.
- Extend CLI regression coverage so `-d`, `-bb`, and invalid scheduler invocations do not expose tracebacks or exception class names from either module path.

## Why this is narrow for Challenge #8

This targets the funny CLI invocation traceback class of #484 without touching the broader SGE, raw-mode, unused-variable, or FIXME cleanup areas already covered by other open Challenge #8 PRs.

The installed package path mattered here because both `pyproject.toml` and `setup.py` previously pointed the `qtop` console script at `qtop_py.qtop:main`, while the traceback-safe wrapper lived in `qtop_py.cli`. This PR makes the production entry point use the same concise error path and keeps `qtop_py.cli` as a thin compatibility wrapper.

## Before / after behavior

Measured locally against upstream `develop` (`0ebb45103be30eea939f86fa396e474cca974d7c`) and this branch (`63c2278572d5854d658ba0e46c4a56b819323d71`).

| Invocation path | Args | Before traceback? | After traceback? | Before lines | After lines | Before chars | After chars |
|---|---:|---:|---:|---:|---:|---:|---:|
| `python -m qtop_py.cli` | `-d` | No | No | 1 | 1 | 105 | 105 |
| `python -m qtop_py.cli` | `-bb` | No | No | 3 | 3 | 310 | 307 |
| `python -m qtop_py.cli` | `-b not-a-scheduler` | No | No | 3 | 3 | 310 | 307 |
| `python -m qtop_py.qtop` | `-d` | Yes | No | 16 | 3 | 1196 | 347 |
| `python -m qtop_py.qtop` | `-bb` | Yes | No | 17 | 5 | 1333 | 549 |
| `python -m qtop_py.qtop` | `-b not-a-scheduler` | Yes | No | 17 | 5 | 1333 | 549 |

Notes:

- The main improvement is for the `qtop_py.qtop` / installed-entry-point path, which previously called `main()` directly.
- The existing `qtop_py.cli` path already handled these scheduler exceptions concisely; this PR preserves that behavior while centralizing it.
- The remaining warning lines in direct module execution are pre-existing `logging.warn` deprecation output and are intentionally not changed here to keep this PR narrow.

## Behavior examples

### Before: direct qtop module with `-d`

```text
DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
Traceback (most recent call last):
  ...
__main__.SchedulerNotSpecified
```

### After: direct qtop module with `-d`

```text
DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
No scheduler could be auto-detected. Select one with -b/--batchSystem, QTOP_SCHEDULER, or qtopconf.yaml.
```

### Before: direct qtop module with `-bb`

```text
CRITICAL - Selected scheduler system not supported. Available choices are demo, oar, pbs, sge, slurm, auto.
CRITICAL - For help, try ./qtop.py --help
CRITICAL - Log file created in .../.local/qtop/logs/qtop.log
Traceback (most recent call last):
  ...
__main__.InvalidScheduler
```

### After: direct qtop module with `-bb`

```text
CRITICAL - Selected scheduler system not supported. Available choices are demo, oar, pbs, sge, slurm, auto.
CRITICAL - For help, try ./qtop.py --help
CRITICAL - Log file created in .../.local/qtop/logs/qtop.log
```

## Logic diagram

```mermaid
flowchart TD
    A[User invokes qtop] --> B{Entry path}
    B -->|python -m qtop_py.cli| C[qtop_py.cli]
    B -->|python -m qtop_py.qtop| D[qtop_py.qtop __main__]
    B -->|installed console script| E[packaging entry point]

    C --> F[shared cli_main]
    D --> F
    E --> F

    F --> G[main]
    G --> H{Known scheduler exception?}
    H -->|SchedulerNotSpecified| I[print concise no scheduler guidance]
    H -->|InvalidScheduler or NoSchedulerFound| J[print existing scheduler error text]
    H -->|No exception| K[return normal exit code]
    H -->|Unexpected exception| L[not swallowed; normal debugging behavior remains]

    I --> M[return 1]
    J --> M
```

## Diff shape

```text
5 files changed, 39 insertions(+), 25 deletions(-)
```

Files:

- `qtop_py/qtop.py`
  - Adds `cli_error_message()` and `cli_main()`.
  - Makes direct module execution call `sys.exit(cli_main())`.
- `qtop_py/cli.py`
  - Keeps the existing module as a compatibility wrapper by importing shared `cli_main`.
- `pyproject.toml`
  - Points the production console script at `qtop_py.qtop:cli_main`.
- `setup.py`
  - Keeps legacy packaging entry point aligned with `pyproject.toml`.
- `tests/test_cli.py`
  - Verifies both module invocation paths.
  - Verifies packaging entry points use `cli_main`.
  - Rejects tracebacks and raw scheduler exception class names in expected scheduler-error paths.

## Validation

- `python3 -m pytest tests/test_cli.py -q` — 7 passed
- `python3 -m pytest tests/test_qtop.py -q` — 45 passed
- `python3 -m pytest -q` — 143 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — passed
- `python3 -m py_compile qtop_py/qtop.py qtop_py/cli.py tests/test_cli.py` — passed

## Risk assessment

Low risk:

- Does not change scheduler detection logic.
- Does not change scheduler plugin parsing.
- Does not swallow unexpected exceptions.
- Only handles the same known scheduler exceptions that `qtop_py.cli` already handled.
- Aligns installed console scripts with the existing CLI wrapper behavior.

## Challenge / contribution notes

DCO: commit includes `Signed-off-by: Utkarsh Sinha <159023661+Utkarsh-Sinha0@users.noreply.github.com>`.

PoH: (human) I accept reasonable proof-of-humanity follow-up from maintainers.

AI disclosure:  Claude Sonnet 4.6 assisted with implementation and validation; I reviewed and am responsible for the submitted changes.

Refs #484
```
