### PR TITLE
20260624 (human) fix: improve file utility error handling

### DIFF
--- a/qtop_py/fileutils.py
+++ b/qtop_py/fileutils.py
@@ -1,11 +1,12 @@
+import datetime
+import errno
+import glob
 import logging
 import os
-import errno
+import posixpath
+import sys
 import tempfile
 import tarfile
-import sys
-import glob
-import datetime
 
 
 def mkdir_p(path):
@@ -76,12 +77,13 @@ def add_to_sample(filepaths_to_add, sample_out, sample_method=tarfile, subdir=No
     """
     assert isinstance(filepaths_to_add, list)
     for filepath_to_add in filepaths_to_add:
-        path, fn = filepath_to_add.rsplit("/", 1)
+        filename = os.path.basename(filepath_to_add)
+        archive_name = filename if not subdir else posixpath.join(subdir, filename)
         try:
             logging.debug("Adding %s to sample..." % filepath_to_add)
-            sample_out.add(filepath_to_add, arcname=fn if not subdir else os.path.join(subdir, fn))
-        except tarfile.TarError:  # TODO: test what could go wrong here
-            logging.error("There seems to be something wrong with the tarfile. Skipping...")
+            sample_out.add(filepath_to_add, arcname=archive_name)
+        except (tarfile.TarError, OSError) as exc:
+            logging.error("Could not add %s to the sample archive: %s. Skipping...", filepath_to_add, exc)
     # else:
     # logging.debug('Closing sample...')
     # sample_out.close()
@@ -137,18 +139,18 @@ def get_timedelta(extra_kw_args):
 
 def parse_time_input(_time):
     """
-    the func accepts a _time str in either (h)ours, (m)inutes, or (s)econds, using the respective suffix,
+    The function accepts a _time str in either (h)ours, (m)inutes, or (s)econds, using the respective suffix,
     e.g. '5h', or '10m', or '30s'
-    A tuple is returned, e.g. (5, 'hours')
+    A dictionary is returned, e.g. {"hours": 5}.
     """
-    assert _time.endswith(("h", "m", "s"))
-    try:
-        int(_time[:-1])
-    except ValueError:
-        logging.critical("Time input given must be a number followed by the letter h/m/s. Exiting.")
-
-    quantity, user_unit_suffix = _time[:-1], _time[-1]
     units = {"m": "minutes", "s": "seconds", "h": "hours"}
-    user_unit = units[user_unit_suffix]
+    error_message = "Time input must be a number followed by h, m, or s."
+    if not isinstance(_time, str) or len(_time) < 2 or _time[-1] not in units:
+        raise ValueError(error_message)
 
-    return {user_unit: int(quantity)}
+    try:
+        quantity = int(_time[:-1])
+    except ValueError as exc:
+        raise ValueError(error_message) from exc
+
+    return {units[_time[-1]]: quantity}

--- a/tests/test_fileutils_error_handling.py
+++ b/tests/test_fileutils_error_handling.py
@@ -1,0 +1,48 @@
+import logging
+import tarfile
+from unittest.mock import Mock
+
+import pytest
+
+from qtop_py import fileutils
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("5h", {"hours": 5}),
+        ("10m", {"minutes": 10}),
+        ("30s", {"seconds": 30}),
+    ],
+)
+def test_parse_time_input(value, expected):
+    assert fileutils.parse_time_input(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "5d", "hours", "hm", None])
+def test_parse_time_input_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="number followed by h, m, or s"):
+        fileutils.parse_time_input(value)
+
+
+def test_add_to_sample_uses_a_portable_archive_path(tmp_path):
+    source = tmp_path / "qtop.log"
+    sample_out = Mock()
+
+    result = fileutils.add_to_sample([str(source)], sample_out, subdir="qtop_py")
+
+    sample_out.add.assert_called_once_with(str(source), arcname="qtop_py/qtop.log")
+    assert result is sample_out
+
+
+@pytest.mark.parametrize("error", [tarfile.TarError("invalid archive"), OSError("file disappeared")])
+def test_add_to_sample_reports_source_path_on_failure(tmp_path, caplog, error):
+    source = tmp_path / "qtop.log"
+    sample_out = Mock()
+    sample_out.add.side_effect = error
+
+    with caplog.at_level(logging.ERROR):
+        fileutils.add_to_sample([str(source)], sample_out)
+
+    assert str(source) in caplog.text
+    assert str(error) in caplog.text


### PR DESCRIPTION
## Implementation checklist

- [x] Make sample archive member names portable across operating-system path separators
- [x] Report the source path and underlying tar or filesystem error when sample collection skips a file
- [x] Replace assertion-based time input validation with clear `ValueError` messages
- [x] Add focused regression tests for valid and invalid inputs and archive failures

## Why

`add_to_sample` split paths using a literal `/`, which fails for Windows paths. It also reported a generic tar error without identifying the source file or underlying reason. `parse_time_input` relied on `assert`, which can be disabled with optimized Python and produced unclear failures for malformed values.

## Impact

Valid `h`, `m`, and `s` configuration values keep their existing behavior. Invalid values now fail consistently with an actionable message. Sample collection still skips unreadable inputs, but its log identifies the affected path and error. No runtime dependency is added.

## Validation

- `python -m pytest -q tests/test_fileutils_error_handling.py tests/test_validate_scheduler_samples.py tests/test_yaml_parser.py` — 36 passed
- `python -m ruff check qtop_py/fileutils.py tests/test_fileutils_error_handling.py` — passed
- `python -m ruff format --check qtop_py/fileutils.py tests/test_fileutils_error_handling.py` — passed

Full test collection on Windows remains blocked by the pre-existing unconditional `SIGPIPE` import in `qtop_py/qtop.py`; this change does not touch that area.

## AI disclosure

Prepared with OpenAI Codex (GPT-5). Rabin reviewed the described behavior and accepts responsibility for the submission.

Part of #484.
