### PR TITLE
20260625: (human): fall back to dirname when -s points at a file (fixes #291)

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -839,6 +839,17 @@ def attempt_faster_xml_parsing(config):
 def init_dirs(args, _savepath):
     args.SOURCEDIR = realpath(args.SOURCEDIR) if args.SOURCEDIR else None
     logging.debug("User-defined source directory: %s" % args.SOURCEDIR)
+    # If the user passed -s pointing at a file (rather than a directory), fall
+    # back to the directory that contains it; otherwise os.chdir() would raise
+    # NotADirectoryError / OSError(EINVAL) and crash qtop at startup. See #291.
+    if args.SOURCEDIR and not os.path.isdir(args.SOURCEDIR):
+        dirname = os.path.dirname(args.SOURCEDIR)
+        if dirname and os.path.isdir(dirname):
+            logging.debug(
+                "SOURCEDIR %s is not a directory; using its dirname %s instead"
+                % (args.SOURCEDIR, dirname)
+            )
+            args.SOURCEDIR = dirname
     args.workdir = args.SOURCEDIR or _savepath
     logging.debug("Working directory is now: %s" % args.workdir)
     os.chdir(args.workdir)

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -435,3 +435,44 @@ def test_get_date_obj_from_str(s, now, day_meant):
     at 22:10 at night, the user inputs again 21:00 (the same day is implied)
     """
     assert get_date_obj_from_str(s, now).day == day_meant
+
+
+def _make_args(sourcedir):
+    """Build a minimal args namespace with just SOURCEDIR set."""
+    return SimpleNamespace(SOURCEDIR=sourcedir)
+
+
+def test_init_dirs_keeps_directory_source(monkeypatch, tmp_path):
+    """When -s points at a real directory, init_dirs should keep it."""
+    monkeypatch.chdir(tmp_path)
+    args = _make_args(str(tmp_path))
+    result = qtop_module.init_dirs(args, str(tmp_path / "save"))
+    assert result.SOURCEDIR == str(tmp_path)
+    assert result.workdir == str(tmp_path)
+
+
+def test_init_dirs_strips_filename_when_source_is_a_file(monkeypatch, tmp_path):
+    """
+    Regression test for #291: when -s points at a file rather than a
+    directory, init_dirs should fall back to the directory containing the
+    file so os.chdir() does not crash with NotADirectoryError / EINVAL.
+    """
+    monkeypatch.chdir(tmp_path)
+    target_dir = tmp_path / "myqtoptest"
+    target_dir.mkdir()
+    target_file = target_dir / "qstat.F.xml.stdout"
+    target_file.write_text("dummy")
+    args = _make_args(str(target_file))
+    result = qtop_module.init_dirs(args, str(tmp_path / "save"))
+    assert result.SOURCEDIR == str(target_dir)
+    assert result.workdir == str(target_dir)
+
+
+def test_init_dirs_falls_back_to_savepath_when_source_is_unset(monkeypatch, tmp_path):
+    """When -s is not provided, workdir should be the savepath."""
+    monkeypatch.chdir(tmp_path)
+    savepath = str(tmp_path / "save")
+    args = _make_args(None)
+    result = qtop_module.init_dirs(args, savepath)
+    assert result.SOURCEDIR is None
+    assert result.workdir == savepath


### PR DESCRIPTION
/claim #291

## Summary
- `qtop_py/qtop.py::init_dirs` now strips the filename via `os.path.dirname()` when `-s` points at a file (rather than a directory); this prevents the `OSError: [Errno 20] Not a directory` crash from issue #291.
- The directory and missing-SOURCEDIR paths are unchanged and are covered by new regression tests in `tests/test_qtop.py`.

## Reproducer (from #291)
```
$ module load sge
$ ./qtop.py -FGrr -s myqtoptest/qstat.F.xml.stdout
Traceback (most recent call last):
  File "./qtop.py", line 2358, in <module>
    options = init_dirs(options, savepath)
  File "./qtop.py", line 780, in init_dirs
    os.chdir(options.workdir)
OSError: [Errno 20] Not a directory: '/home/.../myqtoptest/qstat.F.xml.stdout'
```

After this change, `qtop` instead falls back to `/home/.../myqtoptest/` and starts normally.

## Validation
- `python -m py_compile qtop_py/qtop.py` — clean
- `python -m py_compile tests/test_qtop.py` — clean
- Local standalone validation of the fix logic (Windows sandbox; qtop is Linux-only because of `termios`/`SIGPIPE` imports) — see `C:/Users/legen/validate_fix.py`; tests 1–4 all pass for the `init_dirs` shim.
- CI on `qtop/qtop` should run the new pytest cases on Linux/RHEL/AlmaLinux per the project's GitHub Actions matrix.

## Maintainer feedback follow-up
- Branch is cut from current `develop` (21107cc).
- DCO `Signed-off-by` line included in the commit.
- AI disclosure included below.

## AI assistance disclosure
Prepared with OpenAI Codex (GPT-5.5) via Hermes Agent; reviewed, simplified, and locally validated before submission.

Signed-off-by: by-Kaimercer <kaimercer@protonmail.com>