### PR TITLE
20260624 fix: improve Windows CLI fallbacks

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -25,10 +25,19 @@ import os
 import re
 import json
 import datetime
+import shutil
 from collections import namedtuple, OrderedDict, Counter
 from os.path import realpath
-from signal import signal, SIGPIPE, SIG_DFL
-import termios
+from signal import SIG_DFL, signal
+
+try:
+    from signal import SIGPIPE
+except ImportError:
+    SIGPIPE = None
+try:
+    import termios
+except ImportError:
+    termios = None
 import contextlib
 import glob
 import tempfile
@@ -61,6 +70,11 @@ import time
 
 here = sys.path[0]
 PLUGIN_BATCH_SYSTEMS = (DemoBatchSystem, OARBatchSystem, PBSBatchSystem, SGEBatchSystem, SlurmBatchSystem)
+
+
+def reset_sigpipe():
+    if SIGPIPE is not None:
+        signal(SIGPIPE, SIG_DFL)
 
 
 def _configured_separator(config):
@@ -187,6 +201,8 @@ def raw_mode(file):
     """
     if args.ONLYSAVETOFILE:
         yield
+    elif termios is None:
+        yield
     else:
         if args.WATCH:
             try:
@@ -302,8 +318,12 @@ def calculate_term_size(config, FALLBACK_TERM_SIZE):
     """
     fallback_term_size = config.get("term_size", FALLBACK_TERM_SIZE)
 
-    _command = subprocess.Popen(["/bin/stty", "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    tty_size, error = _command.communicate()
+    stty = shutil.which("stty")
+    if stty:
+        _command = subprocess.Popen([stty, "size"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tty_size, error = _command.communicate()
+    else:
+        tty_size, error = b"", b"stty not found"
     if not error:
         term_height, term_columns = [int(x) for x in tty_size.strip().split()]
         logging.debug('terminal size v, h from "stty size": %s, %s' % (term_height, term_columns))
@@ -354,11 +374,11 @@ def auto_get_avail_batch_system(config):
     """
     # TODO pbsnodes etc should not be hardcoded!
     for system, batch_command in config["signature_commands"].items():
-        NOT_FOUND = subprocess.call(["/usr/bin/which", batch_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not NOT_FOUND:
-            if system != "demo":
-                logging.debug("Auto-detected scheduler: %s" % system)
-                return system
+        if not shutil.which(batch_command):
+            continue
+        if system != "demo":
+            logging.debug("Auto-detected scheduler: %s" % system)
+            return system
 
     raise SchedulerNotSpecified
 
@@ -1753,7 +1773,7 @@ class TextDisplay(object):
         return joined_list
 
     def print_core_lines(self, core_user_map, print_char_start, print_char_stop, transposed_matrices, userid_to_userid_re_pat, mapping, attrs, options1, options2):
-        signal(SIGPIPE, SIG_DFL)
+        reset_sigpipe()
         remove_corelines = dynamic_config.get("rem_empty_corelines", config["rem_empty_corelines"]) + 1
 
         # if corelines vertical (transposed matrix)
@@ -1776,7 +1796,7 @@ class TextDisplay(object):
                     print(core_line_zipped)
                 except IOError:
                     try:
-                        signal(SIGPIPE, SIG_DFL)
+                        reset_sigpipe()
                         print(core_line_zipped)
                         sys.stdout.close()
                     except IOError:
@@ -2392,11 +2412,15 @@ def main():
         print("Anonymize should be ran with --experimental switch!! Exiting...")
         sys.exit(1)
     if args.WATCH or args.REPLAY:  # this is needed for the filtering/sorting options
-        try:
-            old_attrs = termios.tcgetattr(0)
-        except termios.error:
+        if termios is None:
             old_attrs = ""
-        new_attrs = old_attrs[:]
+            new_attrs = ""
+        else:
+            try:
+                old_attrs = termios.tcgetattr(0)
+            except termios.error:
+                old_attrs = ""
+            new_attrs = old_attrs[:]
 
     available_batch_systems = discover_qtop_batch_systems()
 

--- a/qtop_py/utils.py
+++ b/qtop_py/utils.py
@@ -12,7 +12,6 @@ import logging
 import sys
 from argparse import ArgumentParser
 from qtop_py import fileutils
-from qtop_py.colormap import *  # noqa: F403  ## FIXME: this is a code-smell, because it can be tightened
 from qtop_py.constants import QTOP_LOGFILE
 
 

--- a/tests/test_fortifications.py
+++ b/tests/test_fortifications.py
@@ -1,0 +1,45 @@
+from tools import fortifications
+
+
+def test_find_star_imports_reports_wildcard_imports(monkeypatch, tmp_path):
+    source = tmp_path / "qtop_py" / "bad_import.py"
+    source.parent.mkdir()
+    source.write_text("from qtop_py.colormap import *\n", encoding="utf-8")
+
+    monkeypatch.setattr(fortifications, "ROOT", tmp_path)
+    monkeypatch.setattr(fortifications, "iter_python_files", lambda: [source])
+
+    assert fortifications.find_star_imports() == ["qtop_py/bad_import.py:1 wildcard import is not allowed"]
+
+
+def test_find_star_imports_accepts_explicit_imports(monkeypatch, tmp_path):
+    source = tmp_path / "qtop_py" / "good_import.py"
+    source.parent.mkdir()
+    source.write_text("from qtop_py.colormap import color_to_code\n", encoding="utf-8")
+
+    monkeypatch.setattr(fortifications, "ROOT", tmp_path)
+    monkeypatch.setattr(fortifications, "iter_python_files", lambda: [source])
+
+    assert fortifications.find_star_imports() == []
+
+
+def test_find_star_imports_ignores_tests(monkeypatch, tmp_path):
+    source = tmp_path / "tests" / "helper.py"
+    source.parent.mkdir()
+    source.write_text("from qtop_py.colormap import *\n", encoding="utf-8")
+
+    monkeypatch.setattr(fortifications, "ROOT", tmp_path)
+    monkeypatch.setattr(fortifications, "iter_python_files", lambda: [source])
+
+    assert fortifications.find_star_imports() == []
+
+
+def test_find_star_imports_reports_syntax_errors(monkeypatch, tmp_path):
+    source = tmp_path / "tools" / "broken.py"
+    source.parent.mkdir()
+    source.write_text("def broken(:\n", encoding="utf-8")
+
+    monkeypatch.setattr(fortifications, "ROOT", tmp_path)
+    monkeypatch.setattr(fortifications, "iter_python_files", lambda: [source])
+
+    assert fortifications.find_star_imports() == ["tools/broken.py:1 syntax error while scanning imports: invalid syntax"]

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -85,6 +85,37 @@ def test_sort_worker_nodes_rejects_custom_python_sorting(monkeypatch):
         cluster._sort_worker_nodes()
 
 
+def test_reset_sigpipe_is_noop_when_platform_has_no_sigpipe(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(qtop_module, "SIGPIPE", None)
+    monkeypatch.setattr(qtop_module, "signal", lambda *args: calls.append(args))
+
+    qtop_module.reset_sigpipe()
+
+    assert calls == []
+
+
+def test_reset_sigpipe_restores_default_when_available(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(qtop_module, "SIGPIPE", 13)
+    monkeypatch.setattr(qtop_module, "SIG_DFL", "default")
+    monkeypatch.setattr(qtop_module, "signal", lambda *args: calls.append(args))
+
+    qtop_module.reset_sigpipe()
+
+    assert calls == [(13, "default")]
+
+
+def test_raw_mode_is_noop_when_platform_has_no_termios(monkeypatch):
+    monkeypatch.setattr(qtop_module, "termios", None)
+    monkeypatch.setattr(qtop_module, "args", SimpleNamespace(ONLYSAVETOFILE=False, WATCH=True), raising=False)
+
+    with qtop_module.raw_mode(sys.stdin):
+        pass
+
+
 @pytest.mark.parametrize(
     "domain_name, match",
     (

--- a/tools/fortifications.py
+++ b/tools/fortifications.py
@@ -52,7 +52,7 @@ def iter_python_files():
 def find_eval_calls():
     problems = []
     for path in iter_python_files():
-        relative = str(path.relative_to(ROOT))
+        relative = path.relative_to(ROOT).as_posix()
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
         except SyntaxError as exc:
@@ -61,6 +61,24 @@ def find_eval_calls():
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "eval":
                 problems.append("%s:%s eval() call is not allowed" % (relative, getattr(node, "lineno", "?")))
+    return problems
+
+
+def find_star_imports():
+    problems = []
+    checked_roots = ("qtop_py", "tools")
+    for path in iter_python_files():
+        relative = path.relative_to(ROOT).as_posix()
+        if not relative.startswith(checked_roots):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        except SyntaxError as exc:
+            problems.append("%s:%s syntax error while scanning imports: %s" % (relative, exc.lineno, exc.msg))
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names):
+                problems.append("%s:%s wildcard import is not allowed" % (relative, getattr(node, "lineno", "?")))
     return problems
 
 
@@ -94,6 +112,7 @@ def main():
             break
 
     problems.extend(find_eval_calls())
+    problems.extend(find_star_imports())
 
     if problems:
         for problem in problems:


### PR DESCRIPTION
Addresses part of #484
/claim #484

## Summary
- make qtop import and CLI fallback paths safe on Windows/non-POSIX systems by guarding SIGPIPE/termios and replacing hard-coded /bin/stty and /usr/bin/which calls with portable fallbacks
- remove the wildcard colormap import from qtop_py.utils
- extend tools/fortifications.py to reject new wildcard imports in runtime/tooling code

## Validation
- .\venv\Scripts\python -m pytest -q (146 passed)
- .\venv\Scripts\python -m ruff check .
- .\venv\Scripts\python -m ruff format --check .
- .\venv\Scripts\python tools\fortifications.py --base-ref origin/develop

## Notes
- PR targets develop, per CONTRIBUTING.md.
- AI assistance disclosure: Codex assisted with implementation and validation; I reviewed the diff and test output before submission.
- PoH: human-reviewed submission from EDDYWEI92; no force-pushes planned.
