### PR TITLE
ci: improve shared validation workflow and coverage artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,10 @@ jobs:
         if: always()
         with:
           name: sample-gate-${{ matrix.python-version }}
-          path: artifacts/sample-gate/
+          path: |
+            artifacts/sample-gate/
+            coverage.xml
+            htmlcov/
 
   almalinux-python36:
     runs-on: ubuntu-24.04

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,17 @@ modern-python:
     - export FORTIFY_BASE_REF="origin/${TARGET_BRANCH}"
   script:
     - make gitlab-ci PYTHON=python
+  coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+%)/'
   artifacts:
     when: always
     paths:
       - artifacts/sample-gate/
+      - coverage.xml
+      - htmlcov/
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
 
 almalinux-python36:
   image: almalinux:8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,38 @@ Please follow common conventions for Open Source projects, f.i. align to Electro
 - For new features or fixes, either open a new issue or leave a comment on a relevant case that is already open
 - Let's avoid storing artifacts in the main `qtop` repo and keep it light; use the repo `qtop-artifacts` instead.
 
+## Testing & Validation Workflow
+
+Contributors should run local validation before submitting a pull request to ensure all changes pass the project's quality checks. The project uses a shared, local-first validation contract managed through the `Makefile`:
+
+- Run the full local/CI validation path (pytest unit tests, sample gates, linting, formatting checks, and fortifications):
+  ```bash
+  make ci
+  ```
+- Run the python test suite:
+  ```bash
+  make test
+  ```
+- Run tests with coverage and print terminal, HTML, and XML coverage reports:
+  ```bash
+  make coverage
+  ```
+- Run the fast committed scheduler validation sample gate:
+  ```bash
+  make sample-gate
+  ```
+- Run light source-health, formatting checks, and fortifications:
+  ```bash
+  make lint
+  make fortifications
+  ```
+- Clean up all local validation, coverage, build, and temporary artifacts:
+  ```bash
+  make clean
+  ```
+
+For more detailed information on validation gates and CI behavior, see the project documentation under `docs/`.
+
 ## Proof of humanity
 
 Due to many incoming PRs, it is needed to extend the effort to deal with the advent of bots; part of this is yours.

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: ci-deps test coverage backend-validation backend-colour-artifacts render-ba
 rerun: clean all ## Clean generated files, then rerun the complete local validation path
 
 clean: confirm ## Remove generated validation, build, and Python cache output
-	rm -rf artifacts build dist .coverage .pytest_cache .ruff_cache qtop.egg-info
+	rm -rf artifacts build dist .coverage .pytest_cache .ruff_cache qtop.egg-info coverage.xml htmlcov
 	find . -type d -name __pycache__ -prune -exec rm -rf {} +
 	find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
@@ -37,9 +37,11 @@ ci-deps: ## Install pinned CI Python dependencies
 test: ## Run the Python test suite
 	$(PYTHON) -m pytest
 
-coverage: ## Run tests with coverage.py and print a terminal report
+coverage: ## Run tests with coverage.py and print terminal/XML/HTML reports
 	$(PYTHON) -m coverage run -m pytest
 	$(PYTHON) -m coverage report
+	$(PYTHON) -m coverage xml
+	$(PYTHON) -m coverage html
 
 sample-gate: ## Run fast committed PBS/SGE/Slurm/OAR/demo qtop sample gates
 	$(PYTHON) tools/validate_scheduler_samples.py --schedulers $(SAMPLE_GATE_SCHEDULERS) --max-failures $(SAMPLE_GATE_MAX_FAILURES) --artifact-dir $(SAMPLE_GATE_ARTIFACT_DIR)
@@ -96,9 +98,9 @@ compat-py36: ## Run dependency-light Python 3.6 compatibility checks
 
 ci: test backend-validation lint ruff-check format-check ## Run the shared local/CI validation path
 
-github-ci: ci ## GitHub Actions entry point for test validation
+github-ci: coverage backend-validation lint ruff-check format-check ## GitHub Actions entry point for test validation
 
-gitlab-ci: ci ## GitLab CI entry point for test validation
+gitlab-ci: coverage backend-validation lint ruff-check format-check ## GitLab CI entry point for test validation
 
 build: ci-deps ## Build source and wheel distributions with pinned CI build deps
 	$(PYTHON) -m build --no-isolation

--- a/tools/validate_scheduler_samples.py
+++ b/tools/validate_scheduler_samples.py
@@ -286,7 +286,29 @@ def main():
     for case in cases:
         result = run_case(case, artifact_dir, args.timeout)
         results.append(result)
-        print("%s: %s" % (result["name"], "ok" if result["ok"] else "failed"))
+        if result["ok"]:
+            print("%s: ok" % result["name"])
+        else:
+            print("%s: failed" % result["name"])
+            print("  Error: %s" % result.get("error", "unknown validation error"))
+            if result.get("missing_markers"):
+                print("  Missing markers: %s" % ", ".join("'%s'" % m for m in result["missing_markers"]))
+            if result.get("returncode") is not None:
+                print("  Exit code: %s" % result["returncode"])
+            # Display recent stderr log entries for quicker CI diagnosis
+            artifact = result.get("artifact")
+            if artifact:
+                case_dir = ROOT / artifact
+                stderr_path = case_dir / "stderr.log"
+                if stderr_path.exists():
+                    try:
+                        stderr_content = stderr_path.read_text(encoding="utf-8").strip()
+                        if stderr_content:
+                            print("  Stderr output (last 10 lines):")
+                            for line in stderr_content.splitlines()[-10:]:
+                                print("    %s" % line)
+                    except Exception:
+                        pass
 
     failures = [result for result in results if not result["ok"]]
     summary = {


### PR DESCRIPTION
## Summary

This PR addresses a focused part of #433 by improving qtop's shared validation and coverage workflow.

It keeps validation Makefile-driven, improves coverage artifact generation for GitHub/GitLab CI, adds clearer scheduler sample validation logs, and documents the local testing workflow for contributors.

## Changes

- Updated `make coverage` to generate terminal, XML, and HTML coverage reports
- Updated `make clean` to remove generated coverage artifacts
- Updated GitHub Actions artifact upload to include coverage reports
- Updated GitLab CI to parse coverage and publish Cobertura/HTML coverage artifacts
- Improved scheduler sample validation failure output for easier CI debugging
- Added a Testing & Validation Workflow section to `CONTRIBUTING.md`

## Testing

Ran locally:

```bash
make ci
make coverage
echo "y" | make clean