### PR TITLE
20260704 Challenge #8: catch-all exception handler for invalid CLI args + #400

### DIFF
--- a/qtop_py/cli.py
+++ b/qtop_py/cli.py
@@ -28,6 +28,9 @@ def cli_main():
         if str(exc):
             sys.stderr.write("%s\n" % exc)
         return 1
+    except Exception as exc:
+        sys.stderr.write("Error: %s\n" % exc)
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses items from Challenge #8 checklist:

- [x] `./qtop -d` and other funny CLI invocations now show a friendly error message instead of raw stack trace (catch-all exception handler added to `cli_main`)
- [x] Includes #400 — scheduler detection portability (already in this branch)
- [ ] More items in progress

Hints followed:
- Aligned to CONTRIBUTING.md
- No force pushes

Scheduler runs shown:
- (local test: standard invocation passes)
