### PR TITLE
20260711 (human) fix: normalize nested YAML list containers

### DIFF
--- a/qtop_py/yaml_parser.py
+++ b/qtop_py/yaml_parser.py
@@ -103,25 +103,28 @@ def get_line(fin, verbatim=False, SEPARATOR=None, DEF_INDENT=2):
 
 def convert_dash_key_in_dict(d):
     """
-    takes a dict of the form {'-': [...]} and converts it to [...]
-    """
-    try:
-        assert isinstance(d, dict)
-    except AssertionError:
-        return d  # TODO: Maybe this should fail, not be muted
+    Convert parser-internal ``{"-": [...]}`` values to regular lists.
 
-    for key_out in d:
-        if not (isinstance(d[key_out], dict) or len(d[key_out]) == 1):
-            continue
-        try:
-            for key_in in d[key_out]:
-                if key_in == "-" and key_out != "state":
-                    d[key_out] = d[key_out][key_in]
-        except TypeError:
-            return d
-        except IndexError:
-            continue
-    return d
+    Dash containers can appear below lists and nested dictionaries, so walk the
+    complete value tree.  Only unwrap dictionaries whose sole key is ``-``;
+    otherwise a valid sibling key would be discarded.  ``state`` keeps its
+    historical literal-dash behavior.
+    """
+    if not isinstance(d, dict):
+        return d
+
+    def convert(value, parent_key=None):
+        if isinstance(value, list):
+            return [convert(item) for item in value]
+        if not isinstance(value, dict):
+            return value
+
+        converted = {key: convert(child, key) for key, child in value.items()}
+        if parent_key != "state" and set(converted) == {"-"}:
+            return converted["-"]
+        return converted
+
+    return {key: convert(value, key) for key, value in d.items()}
 
 
 def parse(fn, DEF_INDENT=2):

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -287,24 +287,23 @@ def test_process_line_expands_literal_tuple_list():
             {"testkey22": {"-": [{"testkey23": "testvalue23"}, {"testkey24": "testvalue24"}, {"testkey25": "testvalue25"}]}},
             {"testkey22": [{"testkey23": "testvalue23"}, {"testkey24": "testvalue24"}, {"testkey25": "testvalue25"}]},
         ),
-        # (
-        #     {'filt':
-        #          {'-':
-        #               [
-        #                   {'list_name': [1, 2, 3]},
-        #                   {'list_pattern': {'-': ['p5', 'moonshot']}}
-        #               ]
-        #          }
-        #     },
-        #     {'filt':
-        #          [
-        #              {'list_name': [1, 2, 3]},
-        #              {'list_pattern': ['p5', 'moonshot']}
-        #          ]
-        #     }
-        # ),
+        (
+            {"filt": {"-": [{"list_name": [1, 2, 3]}, {"list_pattern": {"-": ["p5", "moonshot"]}}]}},
+            {"filt": [{"list_name": [1, 2, 3]}, {"list_pattern": ["p5", "moonshot"]}]},
+        ),
+        (
+            {"count": 3, "enabled": True, "name": None},
+            {"count": 3, "enabled": True, "name": None},
+        ),
+        (
+            {"state": {"-": ["Q", "R"]}},
+            {"state": {"-": ["Q", "R"]}},
+        ),
+        (
+            {"mixed": {"-": ["value"], "description": "keep me"}},
+            {"mixed": {"-": ["value"], "description": "keep me"}},
+        ),
     ),
 )
 def test_convert_dash_key_in_dict(dict_a, dict_b):
-    # pass
     assert convert_dash_key_in_dict(dict_a) == dict_b


### PR DESCRIPTION
## Summary

- recursively normalize parser-internal `{"-": [...]}` containers at every nested dictionary/list level
- preserve the historical literal-dash behavior under `state`
- avoid calling `len()` on scalar YAML values
- retain sibling keys instead of discarding them when a dictionary contains both `-` and named entries

## Why

`convert_dash_key_in_dict()` only converted one nesting level. A nested list such as `list_pattern` therefore leaked the parser's internal `{"-": ...}` representation into the loaded configuration. The old implementation also called `len()` on arbitrary values, which raised `TypeError` for integer, boolean, or null scalars, and it could replace a mixed dictionary with only its `-` value.

The conversion now walks the value tree and unwraps only exact, single-key dash containers. This keeps the public parsed shape consistent without adding a dependency or changing the `state` exception.

## Validation

- `.venv/bin/python -m pytest tests/test_yaml_parser.py -q` — 27 passed
- `.venv/bin/python -m pytest -q` — 143 passed
- `.venv/bin/python tools/validate_scheduler_samples.py --schedulers pbs,sge,slurm,oar,demo --max-failures 0 --artifact-dir /tmp/qtop-atlas-sample-gate` — 10/10 passed
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m ruff format --check .` — passed
- `git diff --check` — passed

## Contribution notes

- Targets `develop` and is based on `upstream/develop`.
- The commit includes a DCO `Signed-off-by` line.
- No force-push was used.
- PoH: `(human)` — the contributor accepts a reasonable maintainer proof-of-humanity challenge, including a live video call or multiple public proof channels. No identity documents or other sensitive personal data will be submitted.
- AI assistance disclosure: OpenAI Codex with GPT-5 assisted with issue triage, implementation drafting, and validation selection. I reviewed the diff and test results and remain responsible for the submitted change.

Refs #484

/claim #484
