### PR TITLE
20260715: (human) chore: drop SimpleNamespace usage from tests and trace-export tool

### DIFF
--- a/tests/test_pbs_sample_regressions.py
+++ b/tests/test_pbs_sample_regressions.py
@@ -1,18 +1,19 @@
+from argparse import Namespace
 from collections import OrderedDict
-from types import SimpleNamespace
 
 from qtop_py import qtop
 from qtop_py.plugins.pbs import PBSStatExtractor
 
 
 def test_find_matrices_width_handles_empty_worker_nodes():
-    qtop.cluster = SimpleNamespace(highest_wn=0, workernode_list=[])
-    qtop.viewport = SimpleNamespace(h_term_size=80)
+    qtop.cluster = Namespace(highest_wn=0, workernode_list=[])
+    qtop.viewport = qtop.Viewport()
+    qtop.viewport.set_term_size(24, 80)
     qtop.config = {
         "workernodes_matrix": [{"wn id lines": {"min_masking_threshold": 30}}],
         "USER_CUT_MATRIX_WIDTH": None,
     }
-    qtop.args = SimpleNamespace(NOMASKING=False, REMAP=False)
+    qtop.args = Namespace(NOMASKING=False, REMAP=False)
 
     occupancy = qtop.WNOccupancy.__new__(qtop.WNOccupancy)
 
@@ -21,7 +22,7 @@ def test_find_matrices_width_handles_empty_worker_nodes():
 
 def test_general_attribute_lines_handle_empty_worker_node_dict():
     occupancy = qtop.WNOccupancy.__new__(qtop.WNOccupancy)
-    occupancy.cluster = SimpleNamespace(workernode_dict={})
+    occupancy.cluster = Namespace(workernode_dict={})
     config = {"scheduler": "pbs", "workernodes_matrix": [{"state": {"max_len": 1}}]}
 
     assert occupancy.calc_general_mult_attr_line("state", "state", config) == OrderedDict()
@@ -35,7 +36,7 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
         "this line does not match either supported qstat format\n"
         "1234.server      myjob            alice            00:01:00 R workq\n"
     )
-    extractor = PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+    extractor = PBSStatExtractor({}, Namespace(ANONYMIZE=False))
 
     assert extractor._extract_qstat_regex(str(qstat_file)) == [{"JobId": "1234", "UnixAccount": "alice", "S": "R", "Queue": "workq"}]
 
@@ -43,7 +44,7 @@ def test_pbs_qstat_regex_skips_unmatched_lines(tmp_path):
 def test_decide_remapping_handles_mixed_numeric_and_named_nodes():
     cluster = qtop.Cluster.__new__(qtop.Cluster)
     cluster.total_wn = 2
-    cluster.args = SimpleNamespace(BLINDREMAP=False)
+    cluster.args = Namespace(BLINDREMAP=False)
     cluster.node_subclusters = {"wn"}
     cluster.workernode_list = [1, "trueno_ita"]
     cluster.offdown_nodes = 0

--- a/tests/test_qtop.py
+++ b/tests/test_qtop.py
@@ -13,8 +13,8 @@ import pytest
 import re
 import datetime
 import sys
+from argparse import Namespace
 from pathlib import Path
-from types import SimpleNamespace
 from qtop_py import qtop as qtop_module
 from qtop_py import utils as qtop_utils
 from qtop_py.constants import SYMBOL_LONG_TAIL_USER, SYMBOL_UNKNOWN_NODE_STATE
@@ -244,7 +244,7 @@ def test_load_yaml_config_keeps_user_symbol_pool_bounded(monkeypatch, tmp_path):
     monkeypatch.setattr(qtop_module, "SYSTEMCONFDIR", str(tmp_path / "etc"))
     monkeypatch.setattr(qtop_module, "USERPATH", str(tmp_path / "user"))
     monkeypatch.setattr(qtop_module, "CURPATH", str(tmp_path), raising=False)
-    monkeypatch.setattr(qtop_module, "args", SimpleNamespace(CONFFILE=None), raising=False)
+    monkeypatch.setattr(qtop_module, "args", Namespace(CONFFILE=None), raising=False)
     monkeypatch.setattr(qtop_module.fileutils, "mkdir_p", lambda path: None)
 
     config, _, _ = qtop_module.load_yaml_config()

--- a/tools/validate_trace_export.py
+++ b/tools/validate_trace_export.py
@@ -22,7 +22,6 @@ import tempfile
 from collections import OrderedDict, namedtuple
 from contextlib import redirect_stdout
 from pathlib import Path
-from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -56,7 +55,7 @@ def load_exported_document(path):
 
 
 def qtop_args(show_account_totals=False, color="OFF"):
-    return SimpleNamespace(
+    return argparse.Namespace(
         COLOR=color,
         CLASSIC=False,
         WATCH=False,
@@ -105,7 +104,7 @@ def render_document(document, show_account_totals=False, color="OFF", term_heigh
     config["extract_info"] = None
     qtop.config = config
     qtop.user_to_color = user_to_color
-    qtop.web = SimpleNamespace(stop=lambda: None)
+    qtop.web = argparse.Namespace(stop=lambda: None)
     qtop.viewport = qtop.Viewport()
     qtop.viewport.set_term_size(term_height, term_columns)
     qtop.transposed_matrices = []


### PR DESCRIPTION
/claim #484

Takes the SimpleNamespace slice from the Challenge #8 checklist (staked in my /try comment on #484).

qtop's own CLI produces an `argparse.Namespace` (utils.py `parse_args`), so the test doubles and the trace-export tool now fake `args` with the same type the code sees at runtime, instead of `types.SimpleNamespace`. Namespace is also mutable, which matters — Cluster assigns `self.args.REMAP` during processing, so an immutable stand-in would break the trace-export path. The PBS regression test's viewport fake is now a real `Viewport` rather than an attribute bag.

Net effect: zero SimpleNamespace references left in the repo, one import dropped in tools/validate_trace_export.py (argparse was already imported there), LOC flat (+12/−12).

Validation:
- `make test` → 139 passed (same count as develop)
- `ruff check` on the three files → clean
- `make backend-colour-artifacts` → 10/10 gates pass; coloured runs per scheduler posted in the comments

AI-assisted: Claude Code (Fable 5); all changes reviewed and tested by me.

Signed-off via DCO in the commit.