### PR TITLE
20260717 fix: keep CLI source and sample errors concise

### DIFF
--- a/qtop_py/cli.py
+++ b/qtop_py/cli.py
@@ -10,7 +10,7 @@
 
 import re
 import sys
-from qtop_py.qtop import InvalidScheduler, NoSchedulerFound, SchedulerNotSpecified, main
+from qtop_py.qtop import InvalidScheduler, InvalidSourceDirectory, NoSchedulerFound, SchedulerNotSpecified, main
 
 
 def cli_main():
@@ -27,6 +27,9 @@ def cli_main():
     except (InvalidScheduler, NoSchedulerFound) as exc:
         if str(exc):
             sys.stderr.write("%s\n" % exc)
+        return 1
+    except InvalidSourceDirectory as exc:
+        sys.stderr.write("%s\n" % exc)
         return 1
 
 

--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -841,7 +841,10 @@ def init_dirs(args, _savepath):
     logging.debug("User-defined source directory: %s" % args.SOURCEDIR)
     args.workdir = args.SOURCEDIR or _savepath
     logging.debug("Working directory is now: %s" % args.workdir)
-    os.chdir(args.workdir)
+    try:
+        os.chdir(args.workdir)
+    except OSError as exc:
+        raise InvalidSourceDirectory("Cannot use source directory %s: %s" % (args.workdir, exc.strerror))
     return args
 
 
@@ -2360,6 +2363,10 @@ class InvalidScheduler(Exception):
     pass
 
 
+class InvalidSourceDirectory(Exception):
+    pass
+
+
 def main():
     # define global vars which are used out of scope
     global \
@@ -2406,6 +2413,8 @@ def main():
 
     viewport = Viewport()  # controls the part of the qtop matrix shown on screen
     max_line_len = 0
+    sample_out = None
+    scheduler_output_filenames = {}
 
     check_python_version()
     initial_cwd = os.getcwd()
@@ -2452,7 +2461,7 @@ def main():
                 scheduler_output_filenames = fetch_scheduler_files(args, config)
                 SAMPLE_FILENAME = fileutils.get_sample_filename(SAMPLE_FILENAME, config)
                 if args.SAMPLE:
-                    fileutils.tar_out = fileutils.init_sample_file(args, savepath, SAMPLE_FILENAME, scheduler_output_filenames, QTOPCONF_YAML, QTOPPATH)
+                    sample_out = fileutils.init_sample_file(args, savepath, SAMPLE_FILENAME, scheduler_output_filenames, QTOPCONF_YAML, QTOPPATH)
 
                 ###### Gather data ###############
                 #
@@ -2529,19 +2538,19 @@ def main():
                 fileutils.deprecate_old_output_files(config)
 
             if args.SAMPLE:
-                fileutils.tar_out = fileutils.add_to_sample([output_fp], fileutils.tar_out)
+                sample_out = fileutils.add_to_sample([output_fp], sample_out)
 
         except (KeyboardInterrupt, EOFError) as e:
             repr(e)
             fileutils.safe_exit_with_file_close(handle, output_fp, stdout, args, savepath, QTOP_LOGFILE, SAMPLE_FILENAME)
         finally:
-            if args.SAMPLE >= 1:
-                fileutils.tar_out = fileutils.add_to_sample([QTOP_LOGFILE], fileutils.tar_out)
+            if sample_out is not None:
+                sample_out = fileutils.add_to_sample([QTOP_LOGFILE], sample_out)
                 # add all scheduler output files to sample
                 for fn in scheduler_output_filenames:
                     if os.path.isfile(scheduler_output_filenames[fn]):
-                        fileutils.tar_out = fileutils.add_to_sample([scheduler_output_filenames[fn]], fileutils.tar_out)
-                fileutils.tar_out.close()
+                        sample_out = fileutils.add_to_sample([scheduler_output_filenames[fn]], sample_out)
+                sample_out.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,8 @@ def run_cli(tmp_path, *args):
         (("-d",), "No scheduler could be auto-detected"),
         (("-bb",), "Selected scheduler system not supported"),
         (("-b", "not-a-scheduler"), "Selected scheduler system not supported"),
+        (("-s", "missing-source"), "Cannot use source directory"),
+        (("-L",), "No scheduler could be auto-detected"),
     ),
 )
 def test_expected_cli_scheduler_errors_are_concise(tmp_path, args, expected):


### PR DESCRIPTION
/claim #484

## Selected Challenge #8 checklist

Requested for review in this PR:

- [x] Improve funny CLI invocations that currently end in stack traces.
- [x] Improve QA/error reporting with focused subprocess regressions.
- [x] Fix two concrete error paths without adding runtime dependencies.
- [ ] All other Challenge #8 checklist items are intentionally out of scope for this focused slice.

## What changed

- `-s/--SetSourceDir` now reports an unusable directory as one concise error instead of exposing `FileNotFoundError`.
- `-L/--sample` no longer masks a scheduler-selection failure with an uninitialized archive `AttributeError`.
- Sample archive state is local to `main()` and cleanup only runs after an archive was actually opened.
- The CLI subprocess regression table covers both failures and rejects traceback output.

## Validation

- `python -m pytest -q` — **141 passed**
- `ruff check qtop_py/qtop.py qtop_py/cli.py tests/test_cli.py` — **passed**
- Manual `-s /missing` and `-L` invocations both exit 1 with concise messages and no traceback.
- `git diff --check` — **passed**

The commit is DCO signed-off. The branch was created from `develop`; no force push was used.

AI disclosure: OpenAI Codex (GPT-5) materially assisted with reproducing the two failures, implementing the patch, and running tests. Mateo reviewed and takes responsibility for the contribution.

Addresses #484.