### PR TITLE
20260717: fix: derive PBS totals when summary is missing

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -5,6 +5,7 @@
 ## Copyright (c) 2016 Sotiris Fragkiskos
 ## Copyright (c) 2023 Hewlett Packard Enterprise Development LP
 ## Copyright (c) 2026 Jacob Hatchett
+## Copyright (c) 2026 Mateo Rojas
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -172,6 +173,8 @@ class PBSStatExtractor(StatExtractor):
         run_qd_search = r"^\s*(?P<tot_run>\d+)\s+(?P<tot_queued>\d+)"  # this picks up the last line contents
 
         all_qstatq_values = list()
+        total_running_jobs = None
+        total_queued_jobs = None
         with open(qstatq_file, "r") as fin:
             fin.readline()
             fin.readline()
@@ -196,6 +199,9 @@ class PBSStatExtractor(StatExtractor):
                     for key, value in [("queue_name", queue_name), ("run", run), ("queued", queued), ("lm", lm), ("state", state)]:
                         temp_dict[key] = value
                     all_qstatq_values.append(temp_dict)
+            if total_running_jobs is None or total_queued_jobs is None:
+                total_running_jobs = sum(int(queue["run"]) for queue in all_qstatq_values)
+                total_queued_jobs = sum(int(queue["queued"]) for queue in all_qstatq_values)
             all_qstatq_values.append({"Total_running": total_running_jobs, "Total_queued": total_queued_jobs})
 
         return all_qstatq_values

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -4,12 +4,14 @@
 ## Copyright (c) 2016 Fotis Georgatos
 ## Copyright (c) 2016 Sotiris Fragkiskos
 ## Copyright (c) 2023 Hewlett Packard Enterprise Development LP
+## Copyright (c) 2026 Mateo Rojas
 ##
 ## SPDX-License-Identifier: MIT
 ##
 
 from qtop_py.plugins import pbs
 import pytest
+from types import SimpleNamespace
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,31 @@ def test_get_jobs_cores(jobs, result):
     result = iter(result)
     for job, core in pbs.PBSBatchSystem._get_jobs_cores(jobs):
         assert (job, core) == next(result)
+
+
+def test_qstatq_regex_derives_totals_when_summary_line_is_missing(tmp_path):
+    qstatq_file = tmp_path / "qstat_q.txt"
+    qstatq_file.write_text(
+        "Server: cluster\n"
+        "\n"
+        "Queue            Memory CPU Time Walltime Node Run Que Lm  State\n"
+        "---------------- ------ -------- -------- ---- --- --- --- -----\n"
+        "\n"
+        "workq            --     --       --       --   3   2   --  E R\n"
+        "short            --     --       --       --   1   4   --  E R\n"
+    )
+    extractor = pbs.PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+
+    queues = extractor.extract_qstatq(str(qstatq_file))
+
+    assert queues[-1] == {"Total_running": 4, "Total_queued": 6}
+
+
+def test_qstatq_regex_returns_zero_totals_for_header_only_output(tmp_path):
+    qstatq_file = tmp_path / "qstat_q.txt"
+    qstatq_file.write_text(
+        "Server: cluster\n\nQueue            Memory CPU Time Walltime Node Run Que Lm  State\n---------------- ------ -------- -------- ---- --- --- --- -----\n\n"
+    )
+    extractor = pbs.PBSStatExtractor({}, SimpleNamespace(ANONYMIZE=False))
+
+    assert extractor.extract_qstatq(str(qstatq_file)) == [{"Total_running": 0, "Total_queued": 0}]


### PR DESCRIPTION
## Challenge #484 slice

This is a focused, non-overlapping PBS error-handling and QA contribution for #484.

- [x] Prevent truncated or header-only `qstat -Q` text output from crashing qtop.
- [x] Derive accurate running and queued totals from parsed queue rows when PBS omits its final summary line.
- [x] Preserve the reported summary totals when that line is present.
- [x] Add regressions for both missing-summary and header-only output.
- [x] Keep Python 3.6-compatible runtime syntax and add no dependency.
- [ ] The other Challenge #484 checklist items are intentionally outside this narrow PR.

## Root cause and impact

`PBSStatExtractor._extract_qstatq_regex()` assigned `total_running_jobs` and `total_queued_jobs` only while parsing the optional final totals row. Truncated command output, and otherwise valid output without that row, reached the return path with unbound local variables. qtop now falls back to summing the parsed queue rows, or zero for header-only output, instead of emitting a traceback.

## Validation

- `python -m pytest -q` — 141 passed; one pre-existing SGE `SyntaxWarning`.
- `python -m pytest tests/plugins/test_pbs.py -q` — 11 passed.
- Five-backend sample gate — PBS, SGE, Slurm, OAR, and demo: 10 passed, 0 failed.
- Five-backend ANSI-colour artifact render — 10 passed, 0 failed.
- `python -m ruff check qtop_py/plugins/pbs.py tests/plugins/test_pbs.py` — passed.
- `python -m ruff format --check qtop_py/plugins/pbs.py tests/plugins/test_pbs.py` — passed.
- `git diff --check` — passed.

The current execution host is macOS and did not provide an AlmaLinux 8/Python 3.6 runtime. The production change uses only syntax supported by Python 3.6; repository CI remains the direct compatibility check.

## Contribution alignment

- Base and target: `develop`.
- DCO: commit contains `Signed-off-by` using Mateo Rojas's configured GitHub identity.
- No force push was used.
- Mateo Rojas is the responsible contributor using his personal GitHub account and can respond to normal review requests. No personal documents will be uploaded.
- AI assistance disclosure: OpenAI Codex (GPT-5) assisted with locating the failure path, implementing the narrow fix, running validation, and drafting this description. Mateo remains responsible for the contribution.

/claim #484
