### PR TITLE
20260717: fix: normalize ranged PBS array job IDs

### DIFF
--- a/qtop_py/plugins/pbs.py
+++ b/qtop_py/plugins/pbs.py
@@ -5,6 +5,7 @@
 ## Copyright (c) 2016 Sotiris Fragkiskos
 ## Copyright (c) 2023 Hewlett Packard Enterprise Development LP
 ## Copyright (c) 2026 Jacob Hatchett
+## Copyright (c) 2026 Mateo Rojas Vargas
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -336,13 +337,13 @@ class PBSBatchSystem(GenericBatchSystem):
             elif re.match(r"[\w.-]+", part1):  # PBS Pro job id
                 job, core = part1, part2
 
+            job = job.strip().split("/", 1)[0].split(".", 1)[0]
+            job = re.sub(r"\[\d*\]$", "", job)
+
             if ("," in core) or ("-" in core):  # job id with subjobs
-                for subcore, subjob in PBSBatchSystem.get_corejob_from_range(core, job):
-                    subjob = subjob.strip().split("/")[0].split(".")[0]
-                    yield subjob, subcore  # TODO: int or no int?
+                for subcore, _job in PBSBatchSystem.get_corejob_from_range(core, job):
+                    yield job, subcore
             else:  # job id without subjobs
-                job = job.strip().split("/")[0].split(".")[0]
-                job = re.sub(r"\[\d*\]$", "", job)
                 yield job, core
 
     def _read_all_blocks(self, orig_file):

--- a/tests/plugins/test_pbs.py
+++ b/tests/plugins/test_pbs.py
@@ -4,6 +4,7 @@
 ## Copyright (c) 2016 Fotis Georgatos
 ## Copyright (c) 2016 Sotiris Fragkiskos
 ## Copyright (c) 2023 Hewlett Packard Enterprise Development LP
+## Copyright (c) 2026 Mateo Rojas Vargas
 ##
 ## SPDX-License-Identifier: MIT
 ##
@@ -33,8 +34,10 @@ def test_get_corejob_from_range(core_selections, result, job=None):
         (["0/10102182.f-batch01.grid.sinica.edu.tw", "1/10102106.f-batch01.grid.sinica.edu.tw"], [("10102182", "0"), ("10102106", "1")]),
         (["2/10102339.f-batch01.grid.sinica.edu.tw", "3/10104007.f-batch01.grid.sinica.edu.tw"], [("10102339", "2"), ("10104007", "3")]),
         (["3-5/10102339.f-batch01.grid.sinica.edu.tw"], [("10102339", "3"), ("10102339", "4"), ("10102339", "5")]),
+        (["0-2/10102339[7].f-batch01.grid.sinica.edu.tw"], [("10102339", "0"), ("10102339", "1"), ("10102339", "2")]),
         (["2257887.cluster-pbs5/0", "2257887.cluster-pbs5/1"], [("2257887", "0"), ("2257887", "1")]),
         (["2257887.cluster-pbs5/2", "2257887.cluster-pbs5/3"], [("2257887", "2"), ("2257887", "3")]),
+        (["2257887[7].cluster-pbs5/0-2"], [("2257887", "0"), ("2257887", "1"), ("2257887", "2")]),
     ),
 )
 def test_get_jobs_cores(jobs, result):


### PR DESCRIPTION
## Summary

- normalize PBS array job IDs before handling either ranged or single-core mappings
- ensure ranged forms such as `0-2/10102339[7].host` and `2257887[7].host/0-2` map to the normalized qstat ID
- add regression coverage for both Torque-style and PBS Pro-style array-job ranges

## Root cause and impact

The PBS parser removed the array suffix only in the single-core branch. Ranged mappings retained IDs such as `10102339[7]`, while qstat job IDs were normalized to `10102339`; this mismatch prevented qtop from associating those occupied cores with the job.

## Validation

- `pytest`: 141 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- `python tools/fortifications.py --base-ref upstream/develop`: passed
- backend color artifact gate: 10 samples passed, 0 failed, covering PBS, SGE, Slurm, OAR, and demo output
- `git diff --check upstream/develop...HEAD`: passed

Five-scheduler colored output evidence will be attached in a follow-up comment so generated artifacts stay out of the repository.

## Contribution requirements

- Source and target branch: `develop`
- DCO sign-off is present on the commit
- No force push was used
- No Proof-of-Humanity marker is claimed

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted with issue triage, implementation, and validation selection. I reviewed the diff and test results and remain responsible for this contribution.

Refs #484

/claim #484
