### PR TITLE
docs: add original qtop.sh under ./contrib for reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Historical material under contrib/ is stored verbatim; do not flag the
+# trailing whitespace and tab layout of a 2012 file as a diff-health problem.
+contrib/qtop.sh -whitespace
+contrib/LICENSE -whitespace

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ Try `--help` for all available options.
 
 Documentation/tutorial [here](docs/documentation.rst).
 
+## Historical reference material
+
+The original bash qtop that this tool grew out of is kept, verbatim and for
+reading only, as [`contrib/qtop.sh`](contrib/qtop.sh). It carries its own
+GPL-2.0-or-later licence and is deliberately excluded from the package, so
+installed qtop and the published sdist and wheel stay MIT-only. Read
+[`contrib/README.md`](contrib/README.md) before redistributing a clone.
+
 ## Profile
 
     Description: the fast text mode way to monitor your cluster's utilization and status; the time has come to take back control of your cluster's scheduling business
-    License: MIT
+    License: MIT (contrib/qtop.sh is GPL-2.0-or-later; see contrib/README.md)
     Version: 0.9.20260610 / Date: 2026-06-10
     Homepage: https://github.com/qtop/qtop

--- a/contrib/LICENSE
+++ b/contrib/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,62 @@
+# contrib - historical reference material
+
+This directory holds material kept for **reference and provenance only**. It is
+not part of the qtop runtime, is not imported by `qtop_py`, is not exercised by
+the test suite, and is not shipped in the sdist or the wheel.
+
+## `qtop.sh` - the original shell qtop
+
+`qtop.sh` is the historic bash implementation of qtop that the current Python
+tool evolved from, added verbatim so the origin of the tool stays inspectable
+inside the repository (qtop/qtop#244). It is the last shell release: its own
+header already points readers at the Python rewrite.
+
+| | |
+| --- | --- |
+| Release | qtop-53 |
+| Revision | `$Id: qtop 3053 2012-09-14 13:42:46Z fotis $` |
+| Packaged | 2012-12-11 |
+| Author | Fotis Georgatos `<fotis@cern.ch>` |
+| Copyright | (C) 2008, 2009, 2010, ETH Zuerich / CSCS; (C) 2012, University of Luxembourg / LCSB |
+| Retrieved from | `qtop-53/qtop` inside <https://fotis.web.cern.ch/fotis/QTOP/qtop.tar.gz> |
+| sha256 | `fcffd7705bafb0d35f27ef1208e312974afc39d439fd195763230472b3ed8103` |
+
+The bytes are unchanged from that tarball; only the name gained a `.sh` suffix,
+as the issue asked for. `LICENSE` is likewise the tarball's own licence file,
+copied verbatim - it is the "LICENSE file" the script header refers to.
+
+The same tarball also carries `qtop.conf`, `qtop.colormap`, `qtop.man`,
+`ansi2html.sh`, `qtop4cron` and `qtop4oar`. Those are left out on purpose: the
+issue asked for the script itself, and the tarball remains one download away for
+anyone who wants the rest.
+
+### Licensing - please read before redistributing
+
+**qtop itself is MIT licensed. `qtop.sh` is not.** Its header places it under
+the *GNU General Public License version 2 or later*, and its copyright is held
+by ETH Zuerich / CSCS and the University of Luxembourg rather than by the qtop
+authors. The GPL-2.0 text ships next to it as `LICENSE`, as that licence
+requires of anyone distributing a verbatim copy.
+
+To keep this from surprising anyone downstream, the file is deliberately
+isolated:
+
+- it lives at the repository root under `contrib/`, **outside** the `qtop_py`
+  package, so it is unreachable from an installed qtop;
+- `pyproject.toml` (`packages = ["qtop_py"]`) and `setup.py` (`find_packages`)
+  never see it;
+- `MANIFEST.in` uses explicit includes, so it stays out of the sdist too.
+
+The practical consequence: `pip install qtop`, the built wheel and the built
+sdist all remain MIT-only, exactly as before. Only people who clone the git
+repository receive this file, and they receive it under GPL-2.0-or-later.
+Anyone redistributing a clone or a `git archive` of the repository is
+redistributing a GPL-2.0-or-later file and should honour that licence for it.
+
+### Do not run this on a live cluster
+
+The script is prototype-grade 2012 code, kept for reading rather than for use;
+its own header says *"THIS CODE IS WORK OF PROTOTYPING NATURE, THE REGULAR
+'AS-IS' CONDITIONS APPLY"*. It targets Torque/PBS only, shells out to `qstat`,
+`qstat -q` and `pbsnodes -a`, and offers to fetch a colormap over plain HTTP
+from a URL that no longer serves one. Use the Python `qtop` for anything real.

--- a/contrib/qtop.sh
+++ b/contrib/qtop.sh
@@ -1,0 +1,424 @@
+#!/bin/bash
+##
+## Copyright (C) 2008, 2009, 2010, ETH Zuerich / CSCS
+## Copyright (C) 2012, University of Luxembourg / LCSB
+##
+## This module is free software; you can redistribute it and/or modify it
+## under the terms of GNU general public license (GPL) version 2 or later.
+## See the LICENSE file for details or refer to http://www.gnu.org
+##
+## Homepage: http://cern.ch/fotis/QTOP
+##
+## Authors: Fotis Georgatos <fotis@cern.ch>
+## $Id: qtop 3053 2012-09-14 13:42:46Z fotis $
+## $Revision: 3053 $
+## $Date: 2012-09-14 15:42:46 +0200 (Fri, 14 Sep 2012) $
+##
+## IMPORTANT NOTE: THIS CODE IS WORK OF PROTOTYPING NATURE, THE REGULAR "AS-IS" CONDITIONS APPLY
+
+## ### ### ### ### ### ### ### ### WARNING ### ### ### ### ### ### ### ### ### ### 
+## qtop is currently being rewritten in Python; see https://github.com/sfranky/qtop
+
+## TODO items / wishlist
+## * Rewrite the whole thing in python; that will solve all these problems in a generic way:
+## ** allow for more complex visualization schemes, including per rack view and other geometries
+## ** support Rocks cluster format (relates to visualization item really)
+## ** support WNs w. complex names (relates to visualization item really)
+## ** support visualization of single user's jobs
+## ** add support for arc m/w (ie. more complex pool account mappings) and other front-ends
+## ** fix bug with SPACING=' ', whereby no WN header lines are reported aligned
+
+## People have proposed to consider also ideas from:
+## http://sourceforge.net/projects/pbswebmon
+## http://www-rcf.usc.edu/~garrick/perl-PBS/
+
+### CONTROL VARIABLES, YOU CAN USE ANY OF THESE INSIDE ~/.qtop/qtop.conf OR /etc/qtop.conf FILE
+# DEBUG=yes			# enforce debugging output
+# WNREMAP=yes			# enforce WN name remapping
+# DOWNLOADQTOPCOLORMAP=yes	# enforce automatic creation of ~/.qtop and downloading of colormap file
+## Better to choose only one of the following options
+COLORAUTO=yes			# enforce color mode automation depending on input tty (DEFAULT)
+# NOCOLOR			# enforce non-color mode in any case
+# FORCECOLOR			# enforce color mode despite not having interactive input tty
+## More environment variables that can be overriden using a qtop.conf file
+# PBSPATH="/usr/bin"					# Some systems may prefer PBSPATH="/usr/local/bin"
+# PBSNODES_A="$PBSPATH/pbsnodes -a"
+# QSTAT_Q="$PBSPATH/qstat -q"
+# QSTAT="$PBSPATH/qstat"
+# COLORMAPFILE="~/.qtop/qtop.colormap"			# Make sure this file exists and has correct contents if you want color
+# TMPDIR="/tmp"						# This is directly passed down to a mktemp call
+# PBS							# Notify of PBS (instead of torque) pbsnodes output format
+# SUSPEND_SECTION_SUMMARY
+# SUSPEND_SECTION_NODES
+# SUSPEND_SECTION_ACCOUNTS
+# SOURCEDIR="MyDirectoryWithQstatNpbsnodesOutput"	# Put the results of the previous 3 commands in such a dir, for offline testing
+# SBDII="bdii"
+# JOBSUFFIX_OVERRIDE="jobsuffix.subdomain.example.com"	# Use this if autodetection fails
+# LRMS_OVERRIDE="mylrms"				# Use this if autodetection fails
+# GETUSERS_COMMAND="/opt/edg/sbin/edg-mkgridpool --list"
+# WN_COLON="10"						# Put vertical bar every X nodes, experimental feature
+# REPLACE_CHARS="0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z" # Replace sequence
+# BS="*"
+# SPACING=" "						# Experimental option to provide spaces within the output matrix; helps readability in small clusters
+# DDEBUG=yes # put a hash in front of this line to enforce developer's breakpoints/output
+
+### Use getopt to change the default parameters
+##
+## as much as possible we follow conventions seen in:
+## * http://www.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_01
+## * http://www.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
+##
+cat <<EOF >/tmp/qtop.help.$$
+
+QTOP: PBS report tool. Kindly try also: watch -d $0 . All bugs added by fotis@cern.ch
+
+Usage: (simple vs extended options)
+
+$0 [-a] [-c OFF|ON|AUTO] [-f COLORMAPFILE ] [-h] [-o WN_COLON] [-p PBSPATH] [-s SOURCEDIR] [-x SUMMARY|NODES|ACCOUNTS]
+
+$0 [-a] [-b BDII] [-c OFF|ON|AUTO] [-d] [-f COLORMAPFILE ] [-h] [-i PBS] [-j JOBSUFFIX_OVERRIDE] [-l LRMS_OVERRIDE] [-s SOURCEDIR] [-o WN_COLON] \\
+		[-n PBSNODES_A] [-p PBSPATH] [-q QSTAT] [-r REPLACE_CHARS] [-s SOURCEDIR] [-u GETUSERS_COMMAND] [-x SUMMARY|NODES|ACCOUNTS] [-w]
+
+-a	Try WN name remapping	This is used in situations where node names are not a pure arithmetic sequence (eg. rocks clusters)
+-b 	Local BDII hostname	Useful on cluster with grid m/w, to compare values among LRMS and Information System
+-c 	OFF|ON|AUTO colormode	Select use of ANSI-colored output. AUTO is the default and should work in most cases (sensitive upon input tty)
+-d 	Debug information 	Use twice for extra output; mainly intended for usage by developer/debugging purposes
+-f	Set COLORMAPFILE	Describe location of file with the definitions of color output, used for generating ANSI sequences
+-i	Type of LRMS		One of TORQUE|PBS|OAR|SGE|GE|LL|LSF|SLURM|CONDOR (future-proof, currently only the first two are implemented)
+-j	Set JOBSUFFIX_OVERRIDE	Use this if autodetection fails. eg. "jobsuffix.subdomain.example.com"
+-l	Set LRMS_OVERRIDE	Use this if autodetection fails. eg. "mylrms"
+-n	Set PBSNODES_A command	eg. '\$PBSPATH/pbsnodes -a'
+-q	Set QSTAT command	eg. '\$PBSPATH/qstat'
+-p	Set PBSPATH		Default is "/usr/bin". Some systems may have the respective pbs commands in PBSPATH='/usr/local/bin'
+-s	Set SOURCEDIR		This is useful for offline testing of qtop. Directory should contain the stdout of pbsnodes -a , qstat -q , qstat
+-o	Set vertical separator	Put vertical bar every WN_COLON nodes. Experimental option, output may be garbled in certain cases
+-r 	Character sequence	Define a sequence of replacement symbols for the individual user accounts. Experimental option
+-t	Set alternative TMPDIR. qtop creates there a subdirectory and multiple temporary files underneath
+-u	Cmd to get DN mappings	Useful on grid CEs. By default, you should let 'getent passwd' to output the account mappings
+-x	Exclude section		Exclude in output one or more of SUMMARY|NODES|ACCOUNTS sections
+-w	Autotune, for first run	Create a ~/.qtop directory and wget a default colormap file (will overwrite the existing one, so use with care)
+
+EOF
+
+while getopts "adhb:c:f:i:j:l:n:o:p:q:r:s:t:u:x:w" options; do
+  case $options in
+    i ) exec $0'4'`echo $OPTARG|tr 'A-Z' 'a-z'` `echo $*|sed "s/-i $OPTARG//g"`;; # implement the escape mechanism for other LRMSs
+    a ) WNREMAP=yes;;
+    b ) SBDII=$OPTARG;;
+    c ) COLORSWITCH=$OPTARG;;
+    d ) [ $DEBUG ] && DDEBUG=yes
+	DEBUG=yes;;
+    f ) COLORMAPFILE=$OPTARG;;
+    j ) JOBSUFFIX_OVERRIDE=$OPTARG;;
+    l ) LRMS_OVERRIDE=$OPTARG;;
+    n ) PBSNODES_A=$OPTARG;;
+    o ) WN_COLON=$OPTARG;;
+    p ) PBSPATH=$OPTARG;;
+    q ) QSTAT=$OPTARG
+        QSTAT_Q=$OPTARG -q;;
+    r ) REPLACE_CHARS=$OPTARG;;
+    s ) SOURCEDIR=$OPTARG;;
+    t ) TMPDIR=$OPTARG;;
+    u ) GETUSERS_COMMAND=$OPTARG;;
+    x ) export SUSPEND_SECTION_$OPTARG=yes;;
+    w ) DOWNLOADQTOPCOLORMAP=yes;;
+    h ) cat /tmp/qtop.help.$$
+        exit 1;;
+    * ) cat /tmp/qtop.help.$$
+        exit 1;;
+  esac
+done
+rm /tmp/qtop.help.$$
+
+### BEGIN tuning environment variables
+
+LANG=C  # Not setting this can have consequences for sed, sort and join operations and some more (eg. date or sed or tr)
+LC_COLLATE= # This one fixes a nasty annoying bug with sed/sort/join, which has been tyranning some users
+
+## Pick any default parameters from /etc/qtop.conf and ~/.qtop/qtop.conf
+[ -f /etc/qtop.conf ] && source /etc/qtop.conf
+[ -f ~/.qtop/qtop.conf ] && source ~/.qtop/qtop.conf
+
+## Calculate dependent variables and other defaults
+TMPDIR=${TMPDIR:-"/tmp"}
+WORKDIR=`mktemp -p /tmp -d qtop.XXXXXXXXXX || exit 1`
+## This is useful for testing purposes with precalculated input files
+[ "$SOURCEDIR" ] && QSTAT_Q="cat $SOURCEDIR/qstat?q*" && QSTAT="cat $SOURCEDIR/qstat.???" && PBSNODES_A="cat $SOURCEDIR/pbsnodes*"
+PBSPATH=${PBSPATH:-"/usr/bin"}
+QSTAT_Q=${QSTAT_Q:-"$PBSPATH/qstat -q"}
+QSTAT=${QSTAT:-"$PBSPATH/qstat"}
+PBSNODES_A=${PBSNODES_A:-"$PBSPATH/pbsnodes -a"}
+SBDII=${SBDII:-$SITE_GIIS_URL}
+# WN_COLON=${WN_COLON:-20} # experimental visualization feature
+REPLACE_CHARS=${REPLACE_CHARS:-`(seq 48 57;seq 65 90;seq 97 250)|awk '{printf "%c ",$1}'`} # default string: 0-9, A-Z, a-z..\0xff
+BS=${BS:-"*"}                   # Blocked Queue Symbol
+## you may use the two next lines for debugging purposes
+[ $DEBUG ] && env >$WORKDIR/qtop.env
+[ $DEBUG ] && set >$WORKDIR/qtop.set
+
+[ -z "$SGE_CELL" ] || (echo Bailing out... Not yet ready for Sun Grid Engine clusters |(cat;false)) || exit 1
+
+## NOTE: Ideally, the following should be an atomic operation, alas it is not yet possible within shell code
+$QSTAT        >$WORKDIR/qstat.out     || (echo Bailing out... qstat failed            |(cat;false)) || exit 1
+$QSTAT_Q      >$WORKDIR/qstat.q       || (echo Bailing out... qstat -q failed         |(cat;false)) || exit 1
+$PBSNODES_A   >$WORKDIR/pbsnodes.raw  || (echo Bailing out... pbsnodes -a failed      |(cat;false)) || exit 1
+
+## Certain PBS instances provide a pbsnodes output that has to be truncated in this way
+sed 's/[[:digit:]]\/, //g' -i $WORKDIR/pbsnodes.raw
+
+## Now, run the magic heuristics module
+[ $DEBUG ] && echo -n '=== DEBUG:'
+NODELIST=$WORKDIR/pbsnodes.nodelist
+
+## Detect if under PBSPro
+grep pbs_version $WORKDIR/pbsnodes.raw|grep -q PBSPro && PBS=yes
+[ $PBS ] && sed -i 's/^     pcpus =/     np =/g' $WORKDIR/pbsnodes.raw # difference in the way of reporting number of cores per node
+
+CORES_PER_WN=`grep '^     np = ' $WORKDIR/pbsnodes.raw|sed 's/     np = //g'|sort -rnu|xargs`
+CORES_PER_WN=`echo $CORES_PER_WN|cut -d' ' -f1` # In effect, pick the maximum value for reporting
+[ $DEBUG ] && echo -n ' CORES_PER_WN='$CORES_PER_WN
+
+JOBSUFFIX=${JOBSUFFIX_OVERRIDE:-"`cat $WORKDIR/pbsnodes.raw|grep jobs.= |tr ',' '\n'|cut -d. -f3-|sed 's/\/[[:digit:]]*$//g;s/^[[:digit:]]*\///g'|uniq`"}
+[ $DEBUG ] && echo -n ' JOBSUFFIX='$JOBSUFFIX
+WNDOMAIN=`cat $WORKDIR/pbsnodes.raw|grep -v '^ '|grep -v ^$|tee $NODELIST|sed 's/^[-[:alnum:]]*//g'|uniq|cut -c2-`
+[ $DEBUG ] && echo -n ' WNDOMAIN='$WNDOMAIN
+echo $WNDOMAIN|xargs|grep ' ' && echo '--- Aborting heuristics... Bailing out because WNDOMAIN is not unique ---' && exit 1
+
+WNPREFIX=`cat $NODELIST|sed "s/\.$WNDOMAIN$//g"|sed 's/[[:digit:]]*$//g'|sort -u|xargs`
+WNPREFIXTMP=`cat $NODELIST|sed "s/^$WNPREFIX//g"|cut -c1|sort -u`
+[ `echo $WNPREFIXTMP|wc -w` = 1 ] && WNPREFIX=$WNPREFIX$WNPREFIXTMP
+## If WNPREFIX is not unique go for a remapping spin
+echo $WNPREFIX $WNREMAP|xargs|grep -q ' ' && \
+	(echo -ne '\n=== WARN: --- Remapping WN names and retrying heuristics... good luck with this ---' 
+	k=101 # fictitious first WN number
+	for i in `cat $WORKDIR/pbsnodes.raw|grep -v '^ '|grep -v '^$'`;do
+		echo "s/^$i$/wn$k/g;"|sort;k=`echo $k+1|bc`;done > $WORKDIR/pbsnodes.sed
+	sed -i -f $WORKDIR/pbsnodes.sed $WORKDIR/pbsnodes.raw )
+
+## Refresh values, just in case after possible remapping
+WNDOMAIN=`cat $WORKDIR/pbsnodes.raw|grep -v '^ '|grep -v ^$|tee $NODELIST|sed 's/^[-[:alnum:]]*//g'|uniq|cut -c2-`
+echo $WNDOMAIN|xargs|grep ' ' && echo '--- Aborting heuristics... Bailing out because WNDOMAIN is not unique ---' && exit 1
+WNPREFIX=`cat $NODELIST|sed "s/\.$WNDOMAIN$//g"|sed 's/[[:digit:]]*$//g'|sort -u|xargs`
+WNPREFIXTMP=`cat $NODELIST|sed "s/^$WNPREFIX//g"|cut -c1|sort -u`
+[ `echo $WNPREFIXTMP|wc -w` = 1 ] && WNPREFIX=$WNPREFIX$WNPREFIXTMP
+[ $DEBUG ] && echo -n ' WNPREFIX='$WNPREFIX || echo
+
+## Now do the WNPREFIX check
+echo $WNPREFIX|xargs|grep ' ' && echo '--- Aborting heuristics... Bailing out because WNPREFIX is not unique ---' && exit 1
+
+WN_LIST=`cat $NODELIST|sed "s/\.$WNDOMAIN$//g"|sed "s/^$WNPREFIX//g"|sort -n|xargs`
+#echo -n ' WN_LIST='$WN_LIST
+
+WN_FIRST=`echo $WN_LIST|cut -d' ' -f1`
+[ $DEBUG ] && echo -n ' WN_FIRST='$WN_FIRST
+
+WN_LAST=`echo $WN_LIST|sed 's/.* //g'`
+[ $DEBUG ] && echo -n ' WN_LAST='$WN_LAST
+
+[ $WN_LAST ] || (echo; echo --- Aborting heuristics... Bailing out... Not possible to detect WN_LAST |(cat;false)) || exit 1
+
+LRMS=${LRMS_OVERRIDE:-"`grep jobs.= $WORKDIR/pbsnodes.raw|tr ',' '\n'|cut -d. -f2|sed 's/\/[[:digit:]]*//g'|xargs -n1|uniq`"}
+[ $DEBUG ] && echo -n ' LRMS='$LRMS
+[ $DEBUG ] && echo ' ==='
+[ $DEBUG ] && [ "$SOURCEDIR" ] && echo '=== DEBUG: SOURCEDIR='$SOURCEDIR' ==='
+
+GETUSERS_COMMAND=${GETUSERS_COMMAND:-'/opt/edg/sbin/edg-mkgridpool --list'}
+#GETUSERS_COMMAND_PARSER="grep -v '^  date'|sed 's/.\[0m//;s/.\[1m//;s/^  subject =.//g;s/:$//g'|xargs -l2"
+
+## refresh with new WNPREFIX
+cat $WORKDIR/pbsnodes.raw |sed "s/^$WNPREFIX/wn/g" >$WORKDIR/pbsnodes
+
+## Show some color intelligence; can be forced with "COLOR=yes qtop" or "echo|qtop"; requires a colormap file
+case $COLORSWITCH in
+    OFF  ) NOCOLOR=yes ;;
+    ON   ) FORCECOLOR=yes ;;
+    AUTO ) COLORAUTO=yes ;;
+esac
+
+## here is a warning to fix your ~/.qtop/qtop.colormap file; you will need this to group scheduled jobs visually, by color
+[ ! -f ~/.qtop/qtop.colormap ]	&& DOWNLOADQTOPCOLORMAP=YES
+[ "$DOWNLOADQTOPCOLORMAP" ]	&& echo "WARN: It appears this is your first run of qtop... fix COLORMAPFILE or just fetch qtop.colormap with" \
+				&& echo "WARN: wget http://cern.ch/fotis/qtop.colormap -nv -O ~/.qtop/qtop.colormap" \
+				&& mkdir -p ~/.qtop
+
+[ -f ~/.qtop/qtop.colormap ] && COLORMAPFILE=${COLORMAPFILE:-~/.qtop/qtop.colormap} # safety check
+[ -f /etc/qtop.colormap ]    && COLORMAPFILE=${COLORMAPFILE:-/etc/qtop.colormap} # safety check
+## Now do the testing and decide for going with color or without
+[ -f $COLORMAPFILE ] && COLOR=yes
+## Some magic for terminal detection; actually checks input tty
+[ "$COLORAUTO" ] && [ -x /usr/bin/tty ] && NOCOLOR=$NOCOLOR`tty -s ||echo yes`
+[ "$NOCOLOR" ] && COLOR=''
+## FORCECOLOR available for user override, set this for enforcing color
+[ "$FORCECOLOR" ] && COLOR=yes && NOCOLOR=''				
+
+
+### END tuning environment variables
+
+
+
+
+echo -n "QTOP: PBS report tool. Please try: watch -d $0 . All bugs added by fotis@cern.ch. Cross fingers now"
+
+### BEGIN preprocessing section
+
+
+## The following is needed for getting the user-DN mapping; work here is incomplete, due to m/w diversity
+[ "$USER" = root ]	&& DOGETUSERS=yes
+[ "$DOGETUSERS"  ]	&& $GETUSERS_COMMAND \
+			| grep -v '^  date'|sed 's/.\[0m//;s/.\[1m//;s/^  subject =.//g;s/:$//g' |xargs -l2 |sort > $WORKDIR/pool_mappings \
+			|| cat $WORKDIR/qstat.out |sed '1,3d'|awk '{print $3}'|sort -u			> $WORKDIR/pool_mappings
+
+echo -n '.' # This is just to get a feeling of script progress
+[ $DDEBUG ] && echo -e '\n=== DEBUG: sleep 3 # point1' && sleep 3 # developer's soft breakpoint
+
+## the following annoying hack is the only shell way to get by, due to the fact that "join" requires string-sorted inputs.
+LAST_CPUID=`echo $CORES_PER_WN-1|bc` # yes, this can be done with eval, too
+seq 0 $LAST_CPUID|sort > $WORKDIR/CPUs2
+
+cat $WORKDIR/qstat.out |sed '1,2d'|grep -v '^\-\-'|awk '{print $3}'|sort|uniq -c|sort -rn >$WORKDIR/qtopusers
+echo $REPLACE_CHARS |xargs -n1|paste $WORKDIR/qtopusers - |cut -c9- |sort |tee $WORKDIR/qtopusers.processed \
+        |sed "`grep -v ^# $COLORMAPFILE|awk '{printf "s/^"$1"/"$3"/g;\n"}'|sort -r|tee $WORKDIR/qtop.colormap.processed`" \
+	|grep -v ^$|awk '{print "s/^"$2"/"$1$2"%0m/g;"}' |sort -r > $WORKDIR/qtopusers.colormap
+
+cat $WORKDIR/qstat.out|sed '1,2d'|awk '{print $1" "$3}'|sed -r "s/\.$QSTAT_LRMS / /g"|sed -r "s/\.$LRMS / /g"|sort >$WORKDIR/qstat.processed
+cat $WORKDIR/pbsnodes|egrep '(^wn|jobs.=)' \
+	|sed -r "s/\.$LRMS\././g;s/\.$WNDOMAIN$//g;s/\.$JOBSUFFIX//g;s/$LRMS\//\//g" \
+	|sed 's/\= job-sharing/= S/g;s/\= down,/= D/g;s/\= job-exclusive,/= J/g;s/\= offline,/= O/g' >$WORKDIR/pbsnodes.processed
+
+echo -n '.' # This is just to get a feeling of script progress
+[ $DDEBUG ] && echo -e '\n=== DEBUG: sleep 3 # point2' && sleep 3 # developer's soft breakpoint
+
+## Prepare WN vectorfiles. The awk parsing in between is needed to reverse a PBS vs torque effect
+## In PBS, core ID is job *suffix*, while in Torque it is *prefix*
+for i in `seq -w $WN_FIRST $WN_LAST`;do
+CORES=`cat $WORKDIR/pbsnodes|egrep "(^wn|np =)"|grep -A1 ^wn$i|xargs|cut -d= -f2` # This is needed to find max core id
+echo $CORES|sed 's/[0-9 ]//g'|grep -v ^$ >/dev/null && echo && echo '--- Aborting... Bailing out because something went wrong in Cores calculation...' && exit 1
+[ "$CORES" ] || CORES=099			# Fictional maximum number of cores, $CORES should not be empty
+CORES=`(echo $CORES'+1')|xargs|bc`	# Add 1, to get ready for the sed expression
+cat $WORKDIR/pbsnodes.processed \
+	|grep -A1 ^wn$i|grep -v ^wn|sed 's/.*jobs.=//g'|tr , \  |sed 's/\// /g'|xargs -n2|awk '{print $2" "$1}' \
+	|([ "$PBS" ] && sort -k2 || sort ) \
+	|([ "$PBS" ] && join -1 2 - $WORKDIR/qstat.processed || join - $WORKDIR/qstat.processed)|sort -k3 \
+	|join -1 3 - $WORKDIR/qtopusers.processed|sort -k3 \
+	|join -1 3 -a 2 - $WORKDIR/CPUs2|sort -nk1|cut -d' ' -f4 \
+	|sed 's/^$/_/g' \
+	|sed $CORES',$s/_/#/g' \
+	|([ "$NOCOLOR" ] && cat || sed -f $WORKDIR/qtopusers.colormap )>$WORKDIR/pbsnodes.wn$i;done
+
+## so, files $WORKDIR/pbsnodes.wn$i will contain the vectors that correspond to WN status
+
+### END preprocessing section
+
+
+### BEGIN presentation section
+
+echo -n '.' # This is just to get a feeling of script progress
+[ $DDEBUG ] && echo -e '\n=== DEBUG: sleep 3 # point3' && sleep 3 # developer's soft breakpoint
+echo
+
+[ $SUSPEND_SECTION_SUMMARY ] || (
+echo
+(echo "===> Job accounting summary <==="
+echo "(Rev$Revision: 3053 $)"
+[ $NOCOLOR ] || echo '%40m%1;37m'
+date
+[ $NOCOLOR ] || echo '%0m'
+echo "WORKDIR=$WORKDIR"
+)|sed 's/%/\\033\[/g' |xargs -0 echo -e|xargs
+## 1st line of Usage Totals was inspired by pbstop
+echo -en "Usage Totals:\t"
+(
+## Nodes
+[ $NOCOLOR ] || echo '%40m%1;37m'
+echo `cat $WORKDIR/pbsnodes |grep 'state ='|egrep -vc '(down|offline)'`/`cat $WORKDIR/pbsnodes |grep -c 'state ='`
+[ $NOCOLOR ] || echo '%0m'
+echo "Nodes |\t"
+## Cores
+[ $NOCOLOR ] || echo '%40m%1;37m'
+echo `cat $WORKDIR/pbsnodes.wn*|grep -vc _`/ # Shortest way to write this, more elegant too
+echo `cat $WORKDIR/pbsnodes |grep "np ="|sed 's/.*=//g'|xargs|tr ' ' '+'|bc`
+[ $NOCOLOR ] || echo '%0m'
+echo "Cores |\t"
+## Jobs
+[ $NOCOLOR ] || echo '%40m%1;37m'
+echo `cat $WORKDIR/qstat.q|tail -1|cut -c48-|sed 's/^ *//g;s/  */+/g'`
+[ $NOCOLOR ] || echo '%0m'
+echo "jobs (R+Q) reported by qstat -q\n"
+) |sed 's/%/\\033\[/g' |xargs -0 echo -e|xargs
+
+## Queue status
+echo -en 'Queues: |'
+[ $NOCOLOR ] && ((cat $WORKDIR/qstat.q|grep '  \-\- '|sort|awk '{ if ($9$10 != "ER") printf "'$BS'"; printf $1": "$6"+"$7"|\n"}'; echo "$BS implies blocked")|xargs)
+[ $NOCOLOR ] || ((cat $WORKDIR/qstat.q|grep '  \-\- '|sort|awk '{ if ($9$10 != "ER") printf "'$BS'"; else printf $1" ";printf $1": "$6"+"$7" %0m|\n"}' \
+	|sed -f $WORKDIR/qtop.colormap.processed;echo "$BS implies blocked")|sed 's/%/\\033\[/g'|xargs -0 echo -e|xargs|sed 's/| /|/g')
+
+## The following reports CE statistics from the site bdii. Note that information reported should be about the *current* CE
+## {Total,Free,Logical,Physical}CPUs:"
+[ "$SBDII" ] && ADMINTEAM=`ldapsearch -LLL -x -h $SBDII -p 2170 -b 'o=grid' '(ObjectClass=GlueSite)' GlueSiteEmailContact|grep ^GlueSiteEmailContact|sed 's/.*://g'|uniq`
+[ "$SBDII" ] && echo -en "Site BDII of <$ADMINTEAM> reports CPUs: |" && ldapsearch -x -LLL -h $SBDII -p 2170 -b 'o=grid'|grep CPUs \
+	|sed 's/^GlueCEState//g;s/^GlueSubCluster//g;s/GlueCEInfo//g;s/CPUs//g'|sort -ur|tr '\n' '|'|xargs|sed 's/ical: /:/g'|sed 's/ //g'
+)
+
+[ $SUSPEND_SECTION_NODES ] || (
+echo
+echo "===> Worker Nodes occupancy <=== (you can read in COLUMNS the node IDs; nodes in free state are denoted with - )"
+(
+## Node ID
+echo `seq -w $WN_FIRST $WN_LAST|cut -c1|xargs` = {_Worker_} |sed "s/ /$SPACING/g"
+[ $WN_LAST -ge 10 ] && \
+echo `seq -w $WN_FIRST $WN_LAST|cut -c2|xargs` = {__Node__} |sed "s/ /$SPACING/g"
+[ $WN_LAST -ge 100 ] && \
+echo `seq -w $WN_FIRST $WN_LAST|cut -c3|xargs` = {___ID___} |sed "s/ /$SPACING/g"
+## Node status
+seq -w $WN_FIRST $WN_LAST|sed "s/^/wn/g" >$WORKDIR/pbsnodes.listWN
+echo `egrep '(^wn|state.=)' $WORKDIR/pbsnodes|xargs -l2|sed "s/\.$WNDOMAIN//g"|sort \
+	|join -a 2 - $WORKDIR/pbsnodes.listWN |awk '{print $4}'|cut -c1|sed 's/^$/?/g' \
+	|xargs|tr f -|sed "s/$/ /g"|sed "s/ /%/g"`=Node state |sed "s/%/$SPACING/g"
+) | (
+	[ 0"$WN_COLON" -ge 4 ] && sed 's/'`head -c $WN_COLON /dev/zero|tr '\0' '.'`'/&|/g;s/^/|/g;s/|*$/|/g'
+	[ 0"$WN_COLON" -ge 4 ] || cat ) # These last two lines are just for placing a colon character in output
+
+## Prepare colon files in the pbsnodes.wn* format
+[ $WN_COLON ] && seq $CORES_PER_WN |xargs -n1 -i echo '|' | tee $WORKDIR/pbsnodes.wn000 >/dev/null # > $WORKDIR/pbsnodes.wn9999
+[ $WN_COLON ] && seq -w 0 $WN_COLON $WN_LAST|sed '1d'|xargs --replace -n1 cp $WORKDIR/pbsnodes.wn000 $WORKDIR/pbsnodes.wn{}.
+
+## ola ta lefta - matrix output kernel
+seq 0 $LAST_CPUID|xargs -n1 echo =Core |paste -d' ' $WORKDIR/pbsnodes.wn* - | sed "s/ /$SPACING/g" \
+	|sed 's/%/\\033\[/g' |echo -e `sed 's/[\x7f-\xff]/?/g'`|xargs -n1 echo -e # a method to interpret very long ANSI sequences.
+
+## Print last digit of number of cores... inserted for debugging purposes
+[ $DEBUG ] && (cat $WORKDIR/pbsnodes|egrep "(^wn|np =)"|xargs -l2 |sort \
+	|cut -d= -f2|sed 's/^ //g;s/^[[:digit:]]$/0&/g'|cut -c1|xargs|sed "s/ /$SPACING/g"; echo '#Cores')|xargs
+[ $DEBUG ] && (cat $WORKDIR/pbsnodes|egrep "(^wn|np =)"|xargs -l2 |sort \
+	|cut -d= -f2|sed 's/^ //g;s/^[[:digit:]]$/0&/g'|cut -c2|xargs|sed "s/ /$SPACING/g"; echo '#Cores')|xargs
+
+echo # empty line after matrix
+)
+
+[ $DDEBUG ] && echo -e '\n=== DEBUG: sleep 3 # point4' && sleep 3 # developer's soft breakpoint
+
+
+[ $SUSPEND_SECTION_ACCOUNTS ] || (
+echo "===> User accounts and pool mappings <=== ('all' includes those in C and W states, as reported by qstat)"
+echo -e 'id|  R + Q  / all |  unix account  | Userinfo / Grid certificate DN (info provided is according to current user privileges)'
+## No comments in terms of maintainability here, the following oneliner and formatter is a tricky piece of code but at least it works quite fine:
+## (an alternative for the awk-ward construct is "substr($0,length($1 $2 $3 $4) +5)")
+cat $WORKDIR/qstat.out |grep ' R '|awk '{printf $3"\n"}'|sort|uniq -c|awk '{printf $2" "$1"\n"}' > $WORKDIR/qstat.r
+cat $WORKDIR/qstat.out |grep ' Q '|awk '{printf $3"\n"}'|sort|uniq -c|awk '{printf $2" "$1"\n"}' > $WORKDIR/qstat.q
+cat $WORKDIR/qtopusers |sort -k2 \
+	|join -1 2 - $WORKDIR/qtopusers.processed \
+	|join -a 1 -e 0 - $WORKDIR/qstat.r|xargs -n1 --replace echo {} 0|cut -d' ' -f-4 \
+	|join -a 1 -e 0 - $WORKDIR/qstat.q|xargs -n1 --replace echo {} 0|cut -d' ' -f-5 \
+	|join -a 1 - $WORKDIR/pool_mappings|sort -rnk2 \
+	|awk '{printf "%1s |%3s +%3s /%4s |%15s |",$3,$4,$5,$2,$1; $1=""; $2=""; $3=""; $4=""; $5="";printf substr($0, 4)"\n"}' \
+	|([ "$NOCOLOR" ] \
+		&& cat \
+		|| sed "`sed 's/%0m//g' $WORKDIR/qtopusers.colormap |xargs`"|sed 's/$/%0m/g' |sed 's/%/\\033\[/g' |xargs -0 -l1 echo -e )
+		## if in trouble due to line legth try this one |xargs -s 100000 -0 -l1 echo -e
+) | tr '^' ' ' # This is added to allow an escape mechanism for situations where spaces are part of user GECOS field
+
+### END presentation section
+
+rm $WORKDIR/*
+rmdir $WORKDIR
+## EOF


### PR DESCRIPTION
## Description

Adds the last shell release of qtop (qtop-53, rev 3053, packaged 2012-12-11) verbatim as `contrib/qtop.sh`, taken from the author's own distribution at https://fotis.web.cern.ch/fotis/QTOP/qtop.tar.gz. `contrib/LICENSE` is that tarball's own GPL-2.0 text and `contrib/README.md` records the provenance, the sha256 and the licensing.

## Motivation

Closes #244.

The script is GPL-2.0-or-later and copyright ETH Zuerich / CSCS and the University of Luxembourg, while qtop is MIT — which is the downstream concern raised on the issue. `contrib/` sits at the repository root, outside the `qtop_py` package, so `find_packages`, the `pyproject.toml` packages list and the explicit `MANIFEST.in` includes all miss it. I built the sdist and the wheel and confirmed neither gains a single file, so `pip install qtop` and the published artifacts stay MIT-only. Only people who clone the repository receive the script, under GPL-2.0-or-later, and `contrib/README.md` plus a short README section say exactly that.

`make format-check` runs `git diff --check`, which would flag the trailing whitespace in the 2012 file; rather than alter the verbatim bytes, `.gitattributes` marks `contrib/qtop.sh` and `contrib/LICENSE` as `-whitespace`.

Verified locally: pytest 206 passed, `ruff check` and `ruff format --check` clean, `tools/fortifications.py` ok, `tools/repo_sanity.py` 0 critical / 0 warning, sample gate 10 passed / 0 failed.

## AI disclosure

Prepared with Claude Code (Claude Opus 5).
