### PR TITLE
20260801: fix: reject unsafe anonymized sample archives

### DIFF
--- a/qtop_py/qtop.py
+++ b/qtop_py/qtop.py
@@ -2431,6 +2431,9 @@ def main():
     if args.version:
         print("qtop current version: " + __version__)
         sys.exit(0)
+    if args.ANONYMIZE and args.SAMPLE:
+        sys.stderr.write("Cannot combine --anonymize with --sample: sample archives include raw scheduler output files that are not anonymized.\n")
+        return 1
     utils.init_logging(args)
     dynamic_config = dict()
     args, dynamic_config["force_names"] = process_args(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,3 +68,15 @@ def test_no_scheduler_message_is_not_duplicated(tmp_path, module):
     assert result.returncode == 1
     assert output.count("No suitable scheduler was found") == 1
     assert "Traceback" not in output
+
+
+@pytest.mark.parametrize("module", ("qtop_py.cli", "qtop_py.qtop"))
+def test_anonymized_sample_archive_is_rejected_before_collection(tmp_path, module):
+    result = run_cli(tmp_path, module, "--anonymize", "--experimental", "--sample")
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 1
+    assert "Cannot combine --anonymize with --sample" in output
+    assert "raw scheduler output files" in output
+    assert "Traceback" not in output
+    assert list(tmp_path.rglob("qtop_sample_*.tar")) == []


### PR DESCRIPTION
## Summary

- reject `--anonymize --sample` before qtop collects data
- explain that sample archives include raw scheduler output files
- add subprocess regression coverage for both supported module entry points

## Security / QA impact

`--anonymize --experimental` masks identifiers in rendered output, but sample archives later add the original scheduler files. Combining it with `--sample` could therefore disclose the user names, node names, queues, and other raw cluster data that the operator expected anonymization to protect. This patch fails before logging, scheduler collection, or tar creation rather than producing a misleading archive.

## Validation

- `.venv/bin/python -m pytest tests/test_cli.py -q` — 11 passed
- `.venv/bin/python -m pytest -q --ignore=tests/test_repo_sanity.py` — 203 passed
- full suite — 207 passed, 1 pre-existing platform failure: macOS rejects the deliberately non-UTF-8 filename in `test_tracked_files_preserves_non_utf8_filename_bytes`
- `make backend-validation` — 10/10 scheduler samples passed (PBS, SGE, Slurm, OAR, demo)
- `ruff check .` — passed
- `ruff format --check .` — passed
- `tools/fortifications.py --base-ref origin/develop` — passed
- `git diff --check origin/develop...HEAD` — passed

## Contribution requirements

- source and target: `develop`
- DCO-signed commit
- no force push used
- no runtime dependency added
- Python 3.6-compatible syntax retained

AI assistance disclosure: OpenAI Codex (GPT-5.6) assisted with issue triage, implementation, validation, and drafting this description. I reviewed the diff and test results and remain responsible for the contribution.

Refs #484

/claim #484